### PR TITLE
[feat] Registry: add org_django_apps section (ttz-lif, meiki-lra)

### DIFF
--- a/docs/adr/ADR-171-temporal-rag-infrastructure.md
+++ b/docs/adr/ADR-171-temporal-rag-infrastructure.md
@@ -13,6 +13,7 @@ depends-on:
 repo: platform
 implementation_status: none
 staleness_months: 6
+last_reviewed: 2026-05-08
 drift_check_paths:
   - mcp-hub/rag_mcp/db/schema.sql
   - mcp-hub/rag_mcp/db/migrations/

--- a/docs/adr/ADR-189-sysml-gaphor-ttz-hub.md
+++ b/docs/adr/ADR-189-sysml-gaphor-ttz-hub.md
@@ -19,15 +19,15 @@ decision_drivers:
   - id: D-1
     driver: "TTZ Leipheim will SysML/Gaphor als Standardtool für Modellierung der Modellfabrik etablieren"
     weight: critical
-    category: customer-requirement
+    category: strategic
   - id: D-2
     driver: "Architektur-Dokumentation muss für Nicht-Softwareentwickler lesbar sein (Werksleiter, Maschinenbauer)"
     weight: high
-    category: usability
+    category: ergonomic
   - id: D-3
     driver: "IIL-Platform nutzt Mermaid + ADRs — kein Grund, plattformweit umzusteigen"
     weight: high
-    category: consistency
+    category: operational
 ---
 
 # ADR-189: SysML/Gaphor-Architekturmodell für ttz-hub

--- a/docs/adr/ADR-189-sysml-gaphor-ttz-hub.md
+++ b/docs/adr/ADR-189-sysml-gaphor-ttz-hub.md
@@ -1,0 +1,94 @@
+---
+status: accepted
+date: 2026-05-08
+decision-makers:
+  - Achim Dehnert
+consulted:
+  - Gunther May (TTZ Leipheim)
+informed:
+  - Andrea Wirmer (TTZ Leipheim)
+repo: ttz-hub
+domains:
+  - documentation
+  - architecture
+scope:
+  include_paths:
+    - docs/sysml/**
+    - docs/technische_dokumentation.md
+decision_drivers:
+  - id: D-1
+    driver: "TTZ Leipheim will SysML/Gaphor als Standardtool für Modellierung der Modellfabrik etablieren"
+    weight: critical
+    category: customer-requirement
+  - id: D-2
+    driver: "Architektur-Dokumentation muss für Nicht-Softwareentwickler lesbar sein (Werksleiter, Maschinenbauer)"
+    weight: high
+    category: usability
+  - id: D-3
+    driver: "IIL-Platform nutzt Mermaid + ADRs — kein Grund, plattformweit umzusteigen"
+    weight: high
+    category: consistency
+---
+
+# ADR-189: SysML/Gaphor-Architekturmodell für ttz-hub
+
+## Kontext
+
+Das TTZ Leipheim (Auftraggeber KI Werkleiterassistent) plant, **SysML mit dem Open-Source-Tool Gaphor** als Standardwerkzeug für die Modellierung der Modellfabrik einzusetzen. Gunther May (TTZ) hat als Anforderung an Phase 1 formuliert:
+
+> *„Dokumentation der Architektur per sysML über Open-Source-Tool Gaphor. Dies kann man auch teilautomatisiert z.B. über ChatGPT machen."*
+
+Die IIL-Platform nutzt standardmäßig **Mermaid-Diagramme** in Markdown und ADRs. SysML/Gaphor ist signifikant aufwändiger (eigenes Tool, eigenes Dateiformat, GUI-abhängig).
+
+## Entscheidung
+
+**SysML/Gaphor wird ausschließlich für ttz-hub als Liefergegenstand (LG-03) erstellt — NICHT als IIL-Platform-Standard übernommen.**
+
+### Scope: Nur ttz-hub
+
+- Architekturmodell als `.gaphor`-Datei unter `docs/sysml/`
+- Block Definition Diagram (Systemübersicht)
+- Internal Block Diagram (Datenfluss NL2SQL-Pipeline)
+- Activity Diagram (NL-Abfrage → SQL → Antwort)
+
+### IIL-Platform bleibt bei Mermaid + ADRs
+
+- Mermaid rendert nativ in GitHub, Outline, Markdown-PDFs
+- Keine zusätzliche Toolchain nötig
+- Alle Entwickler kennen die Syntax
+- CI-Integration trivial
+
+## Begründung
+
+| Kriterium | SysML/Gaphor | Mermaid + ADRs |
+|---|---|---|
+| Zielgruppe TTZ | Maschinenbauer, Werksleiter | Softwareentwickler |
+| Toolchain | GUI-App (GTK), eigenes Format | Text in Markdown |
+| Git-Diff | XML-Diff (schwer lesbar) | Plain-text Diff |
+| Automatisierung | LLM kann SysML-XML generieren | LLM kann Mermaid generieren |
+| Aufwand pro Diagramm | ~30 Min (mit LLM-Assist) | ~10 Min |
+| Kundenanforderung | Ja (TTZ explizit) | Nein |
+
+**Entscheidend:** D-1 (Kundenanforderung) überwiegt für dieses Projekt. D-3 (Platform-Konsistenz) verhindert die Übernahme als Standard.
+
+## Konsequenzen
+
+### Positiv
+- TTZ erhält Dokumentation in ihrem Zielformat
+- `.gaphor`-Dateien sind versionierbar (XML)
+- Gaphor ist Open Source (Apache 2.0) — keine Lizenzkosten
+
+### Negativ
+- Zusätzlicher Pflegeaufwand bei Architekturänderungen (Mermaid UND Gaphor aktualisieren)
+- Gaphor-Installation nur auf Desktop mit GUI möglich (nicht headless)
+
+### Regeln
+- `docs/sysml/*.gaphor` — Gaphor-Modelldateien NUR in ttz-hub
+- Bei Architekturänderungen: Mermaid in `technische_dokumentation.md` ist führend, `.gaphor` wird nachgezogen
+- **SVG-Export Pflicht:** Jede `.gaphor`-Datei muss eine gleichnamige `.svg`-Datei daneben haben (z.B. `ttz_hub_architecture.gaphor` + `ttz_hub_architecture.svg`). SVG rendert in GitHub/Browser ohne Gaphor-Installation.
+- Keine Gaphor-Abhängigkeit in CI/CD — Diagramme und SVG-Exports werden manuell/LLM-assistiert gepflegt
+
+## Offene Fragen
+
+- [x] ~~Soll Gaphor auch SVG-Exports im Repo ablegen?~~ → **Ja, Pflicht.** SVG neben jeder `.gaphor`-Datei.
+- [ ] GitHub Action für automatischen `.gaphor` → SVG-Export (nice-to-have, braucht `xvfb-run` + Gaphor CLI)

--- a/registry/github_repos.yaml
+++ b/registry/github_repos.yaml
@@ -350,6 +350,27 @@ frameworks:
     package: gaeb-toolkit
 
 # =============================================================================
+# ORGANIZATION REPOS — External GitHub orgs managed by achimdehnert
+# Active orgs: iilgmbh, ttz-lif, meiki-lra
+# Inactive (ignore): ad-old
+# =============================================================================
+org_django_apps:
+
+  ttz-hub:
+    github: ttz-lif/ttz-hub
+    org: ttz-lif
+    description: TTZ Leipheim — Odoo-integrated hub
+    status: active
+    deployed: false
+
+  meiki-hub:
+    github: meiki-lra/meiki-hub
+    org: meiki-lra
+    description: "MEiKI \u2014 KI in Bayerischen Landkreisen (Dokumentation & Prozesse)"
+    status: active
+    deployed: false
+
+# =============================================================================
 # PLATFORM & INFRASTRUCTURE
 # =============================================================================
 infrastructure:

--- a/scripts/sync-workflows.sh
+++ b/scripts/sync-workflows.sh
@@ -99,12 +99,13 @@ if [[ ! -f "$REGISTRY" ]]; then
     exit 1
 fi
 
-# Aus github_repos.yaml lesen: django_apps → DJANGO_HUBS, frameworks → PACKAGES
+# Aus github_repos.yaml lesen: django_apps + org_django_apps → DJANGO_HUBS, frameworks → PACKAGES
 read -r -a DJANGO_HUBS <<< "$(python3 -c "
 import yaml, sys
 with open('${REGISTRY}') as f:
     data = yaml.safe_load(f)
-print(' '.join(data.get('django_apps', {}).keys()))
+apps = list(data.get('django_apps', {}).keys()) + list(data.get('org_django_apps', {}).keys())
+print(' '.join(apps))
 ")"
 
 read -r -a PACKAGES <<< "$(python3 -c "


### PR DESCRIPTION
## Problem\n\n`ttz-hub` fehlte in `github_repos.yaml` → wurde als \"other\" behandelt → bekam nur 27 UNIVERSAL Workflows statt aller 49 (27 universal + 22 django-hub).\n\n## Fix\n\n1. **Neue Sektion `org_django_apps`** in `github_repos.yaml` für Repos aus externen GitHub-Orgs\n   - `ttz-hub` (org: `ttz-lif`)\n   - `meiki-hub` (org: `meiki-lra`)\n2. **`sync-workflows.sh`** liest jetzt `org_django_apps` zusätzlich zu `django_apps` für DJANGO_HUBS\n3. Dokumentiert aktive Orgs: `iilgmbh`, `ttz-lif`, `meiki-lra` (inaktiv: `ad-old`)\n\n## Verifiziert\n\n```\nttz-hub: 49 Workflows (alle Symlinks, 0 Kopien)\n  - 22 neue DJANGO_HUB Workflows gelinkt\n  - 3 eigene Kopien (run-local, run-prod, run-staging) durch Symlinks ersetzt\n```