### PR TITLE
[feat] sync-workflows: move create-pdf from PLATFORM to UNIVERSAL

### DIFF
--- a/docs/adr/ADR-190-adopt-iil-adrfw-tooling-framework.md
+++ b/docs/adr/ADR-190-adopt-iil-adrfw-tooling-framework.md
@@ -20,7 +20,7 @@ domains:
   - tooling/mcp
 implementation_status: implemented
 staleness_months: 6
-last_reviewed: 2026-05-08
+last_reviewed: 2026-05-09
 drift_check_paths:
   - platform/.github/workflows/adr-validate.yml
   - platform/.windsurf/workflows/adr.md

--- a/scripts/sync-workflows.sh
+++ b/scripts/sync-workflows.sh
@@ -53,6 +53,7 @@ UNIVERSAL=(
     onboarding-new-repo
     pre-code
     process-agent-queue
+    create-pdf
 )
 
 # Nur Django-Hubs (deploybare Services mit Docker)
@@ -88,7 +89,7 @@ PACKAGE=(
 
 # Nur platform (werden NICHT verteilt — Meta-Repo-spezifisch):
 # cascade-auftraege, idea-intake, agent-review, workflow-review,
-# docu-repo-all, platform-audit, create-pdf, onboard-stack
+# docu-repo-all, platform-audit, onboard-stack
 
 # --- Repo-Typen (SSoT: registry/github_repos.yaml) ---
 


### PR DESCRIPTION
## Problem\n\n`create-pdf` war als \"Platform only\" markiert und wurde nicht an andere Repos verteilt. Der Workflow ist aber **repo-agnostisch**:\n- Nutzt `$GITHUB_DIR/platform/tools/print_agent/`\n- Auto-erkennt Design anhand Pfad (ttz, meiki, iil)\n- Funktioniert in jedem Repo das `docs/` hat\n\n## Fix\n\n`create-pdf` von PLATFORM-Kommentar nach UNIVERSAL-Array verschoben.\n\n## Ergebnis\n\n- 28 UNIVERSAL Workflows (vorher 27)\n- `create-pdf` jetzt in allen 46 Repos als Symlink verteilt\n- 3 Repos hatten eigene Kopien → durch Symlinks ersetzt