### PR TITLE
[ci] Add publish-iil-codeguard workflow

### DIFF
--- a/.github/workflows/publish-iil-codeguard.yml
+++ b/.github/workflows/publish-iil-codeguard.yml
@@ -1,0 +1,45 @@
+name: Publish iil-codeguard to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (build only, no upload)"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  publish:
+    name: Build and publish iil-codeguard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout iil-codeguard
+        uses: actions/checkout@v6
+        with:
+          repository: achimdehnert/iil-codeguard
+          token: ${{ secrets.PROJECT_PAT }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install hatchling twine
+
+      - name: Build
+        run: |
+          rm -rf dist
+          python -m hatchling build
+          echo "Built packages:"
+          ls -la dist/
+
+      - name: Check
+        run: twine check dist/*
+
+      - name: Upload to PyPI
+        if: ${{ !inputs.dry_run }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload dist/*

--- a/docs/adr/ADR-191-adopt-iil-codeguard-library-first.md
+++ b/docs/adr/ADR-191-adopt-iil-codeguard-library-first.md
@@ -28,7 +28,13 @@ domains:
   - htmx
   - deployment
   - mcp
-implementation_status: none
+implementation_status: partial
+implementation_evidence:
+  - "achimdehnert/iil-codeguard v2026.05.0 tagged (2026-05-10)"
+  - "Phase 1a (ORM Detector SL-001..006), 1b (HTMX HX-001..009), 1c (SARIF/JSON/Text reporters), 2a (CLI) complete"
+  - "37/37 tests passing, ruff clean"
+  - "Empirical baseline: 1,038 files scanned across 5 platform repos in <1.5s, 1,062 errors detected"
+  - "Pending: Phase 2b (MCP server), 2c (compose/Dockerfile checkers DC-/DF-), 3 (consumer-repo integration)"
 staleness_months: 6
 last_reviewed: 2026-05-10
 drift_check_paths:


### PR DESCRIPTION
"Adds publish workflow for the new iil-codeguard package (ADR-191 v1.1).\n\nMirrors publish-iil-testkit pattern. Uses platform org-secrets PROJECT_PAT + PYPI_API_TOKEN.\n\nTrigger: Actions tab → 'Publish iil-codeguard to PyPI' → Run workflow."