### PR TITLE
fix(ci): staging deploy cancel-in-progress: true — prevent lock accumulation

### DIFF
--- a/.github/workflows/_deploy-unified.yml
+++ b/.github/workflows/_deploy-unified.yml
@@ -184,7 +184,7 @@ jobs:
       (needs.build.result == 'success' || needs.build.result == 'skipped')
     concurrency:
       group: deploy-${{ inputs.app_name }}-staging
-      cancel-in-progress: false
+      cancel-in-progress: true
     environment:
       name: staging
       url: https://staging.${{ inputs.app_name }}.iil.pet

--- a/.github/workflows/adr-sync.yml
+++ b/.github/workflows/adr-sync.yml
@@ -1,0 +1,20 @@
+name: ADR Sync to pgvector
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/adr/**'
+
+jobs:
+  trigger-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger ADR Sync
+        run: |
+          echo "ADR changes detected, triggering sync on production server"
+          # POST to mcp-hub internal endpoint to trigger sync
+          # This requires the server to expose an /internal/adr-sync endpoint
+          # For now, this is a placeholder - the systemd timer will handle hourly syncs
+          echo "TODO: Add curl call to production server /internal/adr-sync"

--- a/.windsurf/workflows/deploy.md
+++ b/.windsurf/workflows/deploy.md
@@ -118,6 +118,80 @@ Verwende `deployment-mcp` → `compose_ps` Tool.
 
 ---
 
+## Stuck Deploy — Diagnose & Fix
+
+### Symptom
+Deploy-Runs bleiben permanent in `queued` — `deploy / 🔍 Resolve` zeigt leere Runner-Spalte.
+CI-Jobs des gleichen Commits liefen durch. Mehrere Runs pilen sich auf.
+
+### Root Cause
+Zwei Ursachen kombinieren sich — **Root Cause ist #3**:
+1. **Kein `concurrency` auf Workflow-Ebene** → mehrere Deploy-Runs starten gleichzeitig
+2. **Job-Level `concurrency: cancel-in-progress: false`** in `_deploy-unified.yml` → steckengebliebene `deploy-staging` Jobs halten einen Concurrency-Lock
+3. ⭐ **`prod-server` Custom-Label fehlt auf dem Runner** → `runs-on: prod-server` findet keinen Runner! CI-Jobs laufen auf `self-hosted` (random dispatch), Deploy braucht explizit `prod-server`-Label.
+
+**Runner-Label prüfen** (sofort):
+```bash
+TOKEN=$(cat ~/.secrets/github_token)
+curl -s -H "Authorization: token ${TOKEN}" \
+  "https://api.github.com/repos/achimdehnert/{REPO}/actions/runners" \
+  | python3 -c "import json,sys; [print(r['id'], r['name'], [l['name'] for l in r.get('labels',[])]) for r in json.load(sys.stdin).get('runners',[])]"
+# prod-server runner muss 'prod-server' in labels haben!
+```
+**Label hinzufügen** (Fix):
+```bash
+curl -X POST -H "Authorization: token ${TOKEN}" \
+  "https://api.github.com/repos/achimdehnert/{REPO}/actions/runners/{RUNNER_ID}/labels" \
+  -d '{"labels":["prod-server"]}'
+```
+
+### Fix — permanent (schon integriert)
+`deploy.yml` (jedes Repo) bekommt Workflow-level concurrency:
+```yaml
+concurrency:
+  group: deploy-{app_name}-${{ github.ref_name }}
+  cancel-in-progress: true   # neuer Push cancelt hängenden alten Run sofort
+```
+`_deploy-unified.yml` (Platform): Staging-Job `cancel-in-progress: true`.
+
+### Notfall-Prozedur wenn Deploy feststeckt
+
+// turbo
+1. Hängende Runs canceln:
+```bash
+TOKEN=$(cat ~/.secrets/github_token)
+REPO="achimdehnert/dev-hub"   # Repo anpassen
+curl -s -H "Authorization: token ${TOKEN}" \
+  "https://api.github.com/repos/${REPO}/actions/runs?status=queued&per_page=10" \
+  | python3 -c "import json,sys; [print(r['id']) for r in json.load(sys.stdin)['workflow_runs']]"
+# Für jeden Run-ID:
+curl -X POST -H "Authorization: token ${TOKEN}" \
+  "https://api.github.com/repos/${REPO}/actions/runs/{RUN_ID}/cancel"
+```
+
+2. Runner neustarten (falls nötig):
+```bash
+ssh root@88.198.191.108 \
+  "systemctl restart actions.runner.achimdehnert-{repo}.prod-server.service"
+```
+
+3. Templates-Hotfix (template-only Änderungen, ohne GHA):
+```bash
+# Lokales Repo → direkt in Container kopieren
+scp templates/controlling/dashboard.html root@88.198.191.108:/tmp/
+ssh root@88.198.191.108 "docker cp /tmp/dashboard.html devhub_web:/app/templates/controlling/dashboard.html"
+```
+
+4. Frischen Deploy via workflow_dispatch triggern:
+```bash
+curl -X POST -H "Authorization: token ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  "https://api.github.com/repos/${REPO}/actions/workflows/deploy.yml/dispatches" \
+  -d '{"ref":"main"}'
+```
+
+---
+
 ## Lessons Learned (Feb 2026)
 
 ### Private Repo Dependencies im Docker-Build

--- a/.windsurf/workflows/onboard-repo.md
+++ b/.windsurf/workflows/onboard-repo.md
@@ -814,9 +814,13 @@ ssh root@88.198.191.108 "certbot certonly --webroot -w /var/www/html -d <DOMAIN>
 
 ## Step 6: Platform-Integration
 
-### 6.1 registry/repos.yaml aktualisieren (PFLICHT — Single Source of Truth)
+### 6.1 Registry aktualisieren (PFLICHT — beide Dateien, keine Ausnahme)
 
-Füge das neue Repo in `platform/registry/repos.yaml` ein:
+> **Warum beide?** `github_repos.yaml` ist SSoT für alle Plattform-Automationen:
+> runner-health (täglicher Label-Check), sync-workflows.sh, concurrency-batch-fixes.
+> Fehlt ein Repo hier → runner-health ignoriert es → stuck deploys nicht erkannt.
+
+#### 6.1a `platform/registry/repos.yaml` (Catalog-Sync)
 
 ```yaml
 - name: <REPO_NAME>
@@ -833,6 +837,29 @@ Füge das neue Repo in `platform/registry/repos.yaml` ein:
 ```
 
 **Danach:** GitHub Action `sync-registry-to-devhub.yml` triggert automatisch → devhub.iil.pet/repos zeigt das neue Repo.
+
+#### 6.1b `platform/registry/github_repos.yaml` (Automation SSoT — PFLICHT)
+
+```yaml
+# In django_apps: section eintragen:
+django_apps:
+  <REPO_NAME>:
+    github: achimdehnert/<REPO_NAME>
+    description: <DESCRIPTION>
+    deployed: true
+    domain: <DOMAIN>
+    port: <PORT>
+    lifecycle: experimental
+```
+
+```bash
+# Konsistenz prüfen nach dem Eintrag:
+python ${GITHUB_DIR:-$HOME/github}/platform/infra/scripts/validate_repos.py
+```
+
+> **Ohne diesen Eintrag:** `runner-health.yml` ignoriert das Repo täglich.
+> Das nächste `runner-health`-Run meldet dann `⚠️ UNREGISTERED RUNNER` als Drift-Warning —
+> aber dann ist der Schaden schon eingetreten. **Besser: sofort beim Onboarding eintragen.**
 
 ### 6.2 MCP-Orchestrator registrieren
 

--- a/docs/adr/ADR-194-universal-llm-call-logging-via-gateway.md
+++ b/docs/adr/ADR-194-universal-llm-call-logging-via-gateway.md
@@ -1,0 +1,231 @@
+---
+status: superseded
+superseded-by: ADR-195 (LiteLLM-Proxy as Logging Engine + Anthropic Admin API as Truth Anchor)
+date: 2026-05-11
+decision-makers:
+  - Achim Dehnert
+reviewed-by:
+  - Claude Opus 4.7 (Sparring Review, 2026-05-11) — REVISIONS REQUIRED, see reviews/ADR-194-review.md
+  - Claude Opus 4.7 (Out-of-the-Box Critique, 2026-05-11) — fundamental concerns: SPoF, bootstrap paradox, Admin API + OSS proxy not considered
+depends-on:
+  - ADR-115 (Grafana Agent Controlling Dashboard — llm_calls table)
+  - ADR-116 (Dynamic Model Router — budget-aware routing)
+  - ADR-178 (LLM Gateway Consolidation — V2 as canonical)
+supersedes: []
+repo: platform
+consumers:
+  - mcp-hub (llm_gateway service)
+  - aifw
+  - dev-hub
+  - travel-beat
+  - bfagent
+  - risk-hub
+  - coach-hub
+  - weltenhub
+  - wedding-hub
+domains:
+  - llm
+  - observability
+  - cost-control
+  - security
+implementation_status: none
+staleness_months: 12
+last_reviewed: 2026-05-11
+drift_check_paths:
+  - "mcp-hub/llm_gateway/main.py"
+  - "aifw/src/aifw/service.py"
+  - "~/.claude/hooks/log_llm_call.py"
+  - "~/.codeium/windsurf/memories/global_rules.md"
+---
+
+# ADR-194: Universal LLM Call Logging via Gateway Choke-Point
+
+> **⚠ SUPERSEDED by [ADR-195](./ADR-195-litellm-proxy-engine-plus-admin-api-truth.md) on 2026-05-11.**
+> Adversarial review + out-of-the-box critique surfaced fundamental issues (SPoF on prod, bootstrap paradox, missing evaluation of Anthropic Admin API and OSS proxies). ADR-195 chooses LiteLLM-Proxy as engine + Anthropic Admin API as truth anchor + local sidecar deployment. The pain analysis in this document (658 invisible calls = $125 / 4 days) remains valid and motivates ADR-195. Kept for historical context.
+
+| Metadata | |
+|----------|---|
+| **Status** | Superseded (by ADR-195) |
+| **Date** | 2026-05-11 |
+| **Author** | Achim Dehnert |
+| **Reviewer** | — |
+| **Depends On** | ADR-115, ADR-116, ADR-178 |
+| **Consumers** | mcp-hub, aifw, all 19 platform repos |
+
+---
+
+## Context
+
+Per ADR-115 lives our cost/quality visibility on the `llm_calls` PostgreSQL table. As of 2026-05-11 four independent ingestion paths feed it:
+
+| Source | Path | Coverage |
+|--------|------|----------|
+| `aifw.sync_completion()` | Django code → `aifw.service` → INSERT | Deterministic when used |
+| `agent_team` | `mcp-hub/orchestrator_mcp/agent_team/llm_adapter.py` direct INSERT | Deterministic |
+| Headless CLI runs | `mcp-hub/orchestrator_mcp/headless/services/bridge.py` | Deterministic |
+| Cascade (Windsurf chat) | MCP tool `cascade_log_response` called by the agent | **Best-effort, ~80% compliance** |
+| Claude Code (interactive) | `~/.claude/hooks/log_llm_call.py` Stop hook (added 2026-05-11) | Deterministic on workstation only |
+| Direct `anthropic`/`openai` SDK calls in scripts | — | **Invisible** |
+
+This creates three structural problems:
+
+1. **Coverage gaps.** Any LLM call that bypasses `aifw` and is not made from a deployment we own (Windsurf desktop chat, ad-hoc Python scripts, future agent integrations) is invisible to controlling. As of 2026-05-11 the backfill of 4 days of Claude Code transcripts recovered **658 previously-invisible API calls = $125 USD** that had never appeared in any dashboard.
+2. **Five logging code paths.** `aifw`, `agent_team`, `bridge.py`, `cascade_logger.py`, and the new Claude Code hook each re-implement the same INSERT plus per-source pricing math. ADR-115 specified one table, not five writers.
+3. **Best-effort instrumentation does not scale.** `cascade_log_response` relies on the model remembering a Windsurf rule. Adding a similar hook to every new agent integration (Devin chat, Aider interactive, future tools) is a maintenance treadmill.
+
+ADR-178 already established `llm_gateway` (V2, `mcp-hub/llm_gateway/`) as the canonical HTTP gateway with built-in `usage_logger.py` that writes to `llm_calls`. Today it is consumed only by `agent_team/llm_adapter.py` — the other four code paths bypass it.
+
+## Decision Drivers
+
+- **Single source of truth for cost data.** ADR-115's controlling dashboard is only as honest as the underlying ingestion.
+- **Provider-agnostic.** Anthropic, OpenAI, OpenRouter, and Cerebras must all funnel through the same logging surface.
+- **No agent cooperation required.** Coverage must not depend on the model "remembering to log."
+- **Defense in depth.** When the gateway is unreachable, the system should degrade to direct provider calls plus best-effort local logging — never block work.
+- **Compliance/auditing.** Sec/legal need a reliable record of every prompt and token spend, including those routed through third-party agents (Cascade BYOK mode, future SaaS integrations).
+
+## Considered Options
+
+### Option A: Status quo + iterate per-source
+
+Keep `aifw`, `agent_team`, `bridge.py`, `cascade_logger.py`, the Claude Code hook, plus add a Python `sitecustomize.py` monkey-patch for SDK bypass calls.
+
+- **Pro**: Incremental, no infrastructure changes.
+- **Pro**: Each path can use its own pricing table (already true).
+- **Con**: Five+ writers, divergent pricing, divergent schemas. Recently `cache_creation_input_tokens` field varied in shape between the cascade logger (legacy flat) and the Claude Code hook (nested `cache_creation.ephemeral_5m_input_tokens`).
+- **Con**: Cascade desktop chat stays best-effort.
+- **Con**: Monkey-patching fragile under SDK upgrades (Anthropic SDK v0.40 changed `messages.create` signature; OpenAI v2 changed client factory).
+
+### Option B: Promote `llm_gateway` to single choke-point (chosen)
+
+All LLM consumers — `aifw`, Claude Code, Cascade BYOK, ad-hoc scripts, headless CLI — route their API calls through `llm_gateway`, which logs and forwards. Provider-format passthrough endpoints (`/v1/messages` for Anthropic, `/v1/chat/completions` for OpenAI) keep client SDKs unmodified.
+
+- **Pro**: Single writer. Pricing, schema evolution, retries, budget enforcement (ADR-116) all in one place.
+- **Pro**: `ANTHROPIC_BASE_URL` and `OPENAI_BASE_URL` env vars are honored by every official SDK and by Claude Code — zero client code changes.
+- **Pro**: Adding a new agent (Devin, Aider, custom) auto-inherits logging.
+- **Con**: Single point of failure unless made HA. Mitigation: gateway returns provider response unmodified, has 99.x SLO target, plus fallback (see Decision below).
+- **Con**: Windsurf Pro-plan (non-BYOK) Cascade calls still untraceable — that traffic is billed by Anthropic-to-Windsurf, not to us, so it is outside our control regardless.
+- **Con**: One-time migration effort across ~19 repos.
+
+### Option C: Network-level capture
+
+eBPF or Envoy sidecar intercepts all outbound HTTPS to `api.anthropic.com` and `api.openai.com`.
+
+- **Pro**: Truly transparent; works even for code we did not write.
+- **Con**: Requires TLS termination (MITM cert installed on every workstation) or relies on SDK base-URL override anyway — at which point Option B is simpler.
+- **Con**: Operationally hostile; surprising for new contributors; security review burden.
+
+## Decision Outcome
+
+**Chosen: Option B — `llm_gateway` as universal choke-point.**
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Clients                                                         │
+│  ┌───────────┐  ┌──────────┐  ┌────────┐  ┌──────────────────┐  │
+│  │Claude Code│  │ Cascade  │  │ aifw   │  │ Ad-hoc scripts   │  │
+│  │           │  │  (BYOK)  │  │        │  │ (anthropic SDK)  │  │
+│  └─────┬─────┘  └────┬─────┘  └───┬────┘  └────────┬─────────┘  │
+│        │             │            │                 │            │
+│        │ ANTHROPIC_BASE_URL set to llm-gateway.iil.pet           │
+│        ▼             ▼            ▼                 ▼            │
+│  ┌─────────────────────────────────────────────────────────────┐│
+│  │  llm_gateway (V2, FastAPI, mcp-hub)                          ││
+│  │  ─ /v1/messages           ← Anthropic passthrough  [NEW]     ││
+│  │  ─ /v1/chat/completions   ← OpenAI passthrough     [EXISTS]  ││
+│  │  ─ /v1/agent              ← agent_team             [EXISTS]  ││
+│  │  ─ usage_logger.py        → INSERT INTO llm_calls            ││
+│  │  ─ budget_tracker         → ADR-116 budget enforcement       ││
+│  │  ─ rate_limit + retries                                      ││
+│  └────────────────────────┬─────────────────────────────────────┘│
+│                           │                                       │
+│                           ▼                                       │
+│  ┌──────────────────────────────────────────┐                    │
+│  │  Upstream providers: api.anthropic.com,  │                    │
+│  │  api.openai.com, openrouter.ai, ...      │                    │
+│  └──────────────────────────────────────────┘                    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Required changes by client
+
+| Client | Today | After ADR-194 |
+|--------|-------|---------------|
+| `aifw` | Calls Anthropic/OpenAI directly, INSERTs from its service layer | `ANTHROPIC_BASE_URL` env points to gateway; `aifw.service` removes its INSERT path |
+| Claude Code | Stop hook reads transcripts, INSERTs | `ANTHROPIC_BASE_URL` env in shell profile points to gateway; hook deleted after stabilisation |
+| Cascade in BYOK mode | MCP `cascade_log_response` called by agent | BYOK URL set to gateway; rule deleted |
+| Cascade in Pro mode | (unchanged) | Out of scope — Anthropic-Windsurf billing |
+| Headless CLI (Claude, Devin) | `bridge.py` writes INSERT post-hoc from CLI stdout | Same — these wrap CLIs we do not control. Logging via gateway is preferred when CLI honors `ANTHROPIC_BASE_URL`; fallback remains `bridge.py` |
+| `agent_team` | Already via gateway | Unchanged |
+| Ad-hoc scripts | Direct SDK + invisible | `ANTHROPIC_BASE_URL` inherited from venv-level config |
+
+### Gateway extensions required
+
+1. **Anthropic `/v1/messages` passthrough endpoint** — accept the exact Anthropic request shape, forward to `api.anthropic.com`, parse the response's `usage` block (input/output/cache_creation/cache_read), INSERT one row, return upstream response byte-for-byte.
+2. **Streaming support** — Anthropic and Claude Code use SSE streams. Gateway must proxy stream chunks while accumulating usage from the final `message_delta` event.
+3. **Auth model** — gateway accepts the user's `x-api-key` header, validates it locally if we issue our own keys, or forwards verbatim for BYOK. Keys are not stored beyond a salted hash for attribution.
+4. **Cache-tier pricing** — extend `pricing.py` with the 1.25x/2x/0.1x multipliers for `cache_creation_5m`, `cache_creation_1h`, `cache_read` (the Claude Code hook proves these are the correct billing rates per Anthropic 2026-05).
+5. **Degraded mode** — if upstream is unreachable, return 503 (do not silently drop). If the INSERT fails, log the call and continue (logging must never block a working LLM request).
+
+### Migration plan
+
+| Phase | Scope | Effort | Risk |
+|-------|-------|--------|------|
+| **P1** | Gateway: add `/v1/messages` passthrough + streaming + cache pricing. Deploy alongside existing `/v1/agent` route. | 3 d | Low — additive |
+| **P2** | Claude Code: set `ANTHROPIC_BASE_URL` in workstation `~/.bashrc`. Stop hook stays as defense-in-depth for 4 weeks; logs duplicate calls become a comparison check. | 0.5 d | Low — env var override, instant rollback |
+| **P3** | `aifw`: switch base URL to gateway; remove `aifw.service` INSERT path; keep cost-computation utility for compatibility. Add a `aifw.service` flag `bypass_gateway=True` for offline testing. | 2 d | Medium — touches 19 consumer repos via the same dependency, but call signature unchanged |
+| **P4** | Cascade BYOK setup documented in onboarding; `cascade_log_response` MCP tool kept available but deprecated. | 0.5 d | Low |
+| **P5** | Retire dual writers: delete Claude Code Stop hook, delete `cascade_logger.py` after one billing cycle with zero discrepancy. | 0.5 d | Low |
+
+Total estimated effort: **6.5 person-days**, spread over 2–3 weeks (P1 → P5 are mostly sequential).
+
+### Non-goals
+
+- **Replacing `aifw`'s prompt/quality-level abstraction.** `aifw` still owns prompt templates, model-selection logic (ADR-116), and the `action_code` taxonomy. ADR-194 only redirects the actual HTTP call.
+- **Windsurf Pro-plan visibility.** Out of scope — that traffic is Anthropic-billed-to-Windsurf, not visible to us by design.
+- **Token-level prompt inspection / DLP.** A future ADR may add prompt-content auditing in the gateway; this ADR limits scope to usage/cost.
+
+## Consequences
+
+### Positive
+
+- **100% logging coverage** for every LLM API call originating from our infrastructure (workstation, dev server, prod, headless runs, agent_team).
+- **Single pricing table.** Cache-tier pricing math lives in one place. Cost discrepancies between sources become impossible.
+- **ADR-116 budget enforcement** automatically covers Claude Code and Cascade BYOK — currently they can blow the budget invisibly.
+- **Vendor portability.** Switching from Anthropic direct to AWS Bedrock or Vertex needs a config change in the gateway, not in 19 repos.
+- **Audit trail.** Sec/legal can inspect prompts + responses centrally (with retention/redaction policies set in one place).
+
+### Negative
+
+- **Gateway availability becomes critical.** If `llm-gateway.iil.pet` is down, all Claude Code / Cascade interactive work halts. Mitigation: documented escape hatch — `unset ANTHROPIC_BASE_URL` to bypass gateway in degraded mode.
+- **Latency tax.** Adding one HTTP hop. Measure during P1; budget +30–50 ms p95.
+- **Migration touches 19 repos** indirectly via `aifw`. Risk surface is real even if each change is small.
+
+### Risks and mitigations
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Streaming proxy loses last `message_delta` event → wrong cost | Medium | P1 includes streaming-correctness tests against `anthropic-sdk` test fixtures |
+| Anthropic API breaks (e.g. new auth header) | Low | Gateway passthrough is byte-faithful; new headers flow through; pricing tables versioned |
+| Gateway becomes single point of failure | Medium | HA: deploy 2 replicas behind nginx; degraded mode bypasses gateway via env unset |
+| Migration P3 breaks an unknown aifw caller | Medium | Phase P3 ships behind `AIFW_USE_GATEWAY` feature flag, off by default for 1 week |
+| Cost double-counting during P2 transition | Low | Use `request_id` for global dedupe; add UNIQUE INDEX `(source, request_id)` to `llm_calls` as part of P1 |
+
+## Compliance / Drift Checks
+
+Add to `iil-codeguard` (per ADR-191):
+
+- `LLM-001` (error): Direct `import anthropic` or `from openai import` outside `aifw/`, `llm_gateway/`, and `tests/` — must use `aifw` or set `ANTHROPIC_BASE_URL`.
+- `LLM-002` (warning): Workstation shell profile missing `ANTHROPIC_BASE_URL` once P2 ships.
+- `LLM-003` (info): `llm_calls` row missing `request_id` — indicates a writer that bypassed the gateway.
+
+## Open Questions
+
+1. **Authentication**: do we issue our own per-user API keys at the gateway, or pass through the user's Anthropic key? Per-user keys enable attribution beyond `source` but require a key-management surface.
+2. **PII redaction**: Should the gateway redact prompts before INSERT, or store full prompt content (with retention policy)? Defer to a follow-up ADR.
+3. **Multi-tenancy**: Today `tenant_id=0` everywhere. If we onboard external tenants (e.g. weltenhub customers), gateway must propagate tenant attribution.
+
+## Implementation Status
+
+**None.** This ADR is the proposal; implementation begins after acceptance.

--- a/docs/adr/ADR-195-litellm-proxy-engine-plus-admin-api-truth.md
+++ b/docs/adr/ADR-195-litellm-proxy-engine-plus-admin-api-truth.md
@@ -1,0 +1,266 @@
+---
+status: proposed
+date: 2026-05-11
+decision-makers:
+  - Achim Dehnert
+reviewed-by:
+  - Claude Opus 4.7 (Sparring Review, 2026-05-11) — REVISIONS REQUIRED, see reviews/ADR-195-review.md
+depends-on:
+  - ADR-115 (Grafana Agent Controlling Dashboard — llm_calls table)
+  - ADR-116 (Dynamic Model Router — budget-aware routing)
+  - ADR-178 (LLM Gateway Consolidation — V2 as canonical)
+supersedes:
+  - ADR-194 (Universal LLM Call Logging via Gateway Choke-Point)
+repo: platform
+consumers:
+  - mcp-hub (llm_gateway, callback module)
+  - aifw
+  - dev-hub
+  - travel-beat
+  - bfagent
+  - risk-hub
+  - coach-hub
+  - weltenhub
+  - wedding-hub
+domains:
+  - llm
+  - observability
+  - cost-control
+  - security
+implementation_status: none
+staleness_months: 12
+last_reviewed: 2026-05-11
+drift_check_paths:
+  - "mcp-hub/llm_gateway/callbacks/litellm_callback.py"
+  - "mcp-hub/llm_gateway/admin_api/reconcile.py"
+  - "mcp-hub/llm_gateway/pricing.py"
+  - "~/.claude/hooks/log_llm_call.py"
+---
+
+# ADR-195: LiteLLM-Proxy as Logging Engine + Anthropic Admin API as Truth Anchor
+
+| Metadata | |
+|----------|---|
+| **Status** | Proposed (v1.0) |
+| **Date** | 2026-05-11 |
+| **Author** | Achim Dehnert |
+| **Supersedes** | ADR-194 v1.0 (Universal LLM Call Logging via Gateway Choke-Point) |
+| **Depends On** | ADR-115, ADR-116, ADR-178 |
+
+---
+
+## Context
+
+ADR-194 v1.0 proposed building a custom `llm_gateway` as universal HTTP choke-point for all LLM calls. The adversarial review (`reviews/ADR-194-review.md`) flagged a Blocker plus two Critical issues. A subsequent out-of-the-box critique surfaced three deeper concerns the v1 ADR did not address:
+
+1. **Bootstrap paradox** — gateway runs on prod-server `88.198.191.108`. When prod is down, Claude Code is unusable (BASE_URL points nowhere), which is exactly when developers need it to fix prod.
+2. **Threat model regression** — gateway TLS-terminates all prompts in-memory. Adds a compromise surface (our Hetzner container) on top of Anthropic's.
+3. **Build-vs-buy gap** — Anthropic now exposes an Admin API (`/v1/organizations/usage_report/messages` + `/v1/organizations/cost_report`) that delivers 100 % cost coverage at aggregate level without any code changes. OSS proxies (LiteLLM, Helicone) deliver per-call logging with 1 PT of setup vs. the 6.5 PT custom build.
+
+The original pain remains valid: as of 2026-05-11, 658 LLM calls = $125 over 4 days were invisible to controlling.
+
+Confirmed via live test against the Anthropic API (2026-05-11):
+
+| Probe | Result |
+|---|---|
+| Anthropic Admin API endpoint structure | Aggregate-only (minute/hour/day buckets), all token fields incl. `cache_creation.ephemeral_5m/1h_input_tokens`, group-by `api_key_id`/`workspace_id`/`model`/`speed` |
+| Existing `~/shared/secrets-inbox/anthropic_api_key` against admin endpoint | HTTP 401 — regular workspace key, **separate admin key required** |
+| Existing key against `/v1/messages` | HTTP 200 — confirms baseline auth path works |
+
+## Decision Drivers
+
+Inherited from ADR-194 (still valid):
+
+- Single source of truth for cost data
+- Provider-agnostic
+- No agent cooperation required for coverage
+- Compliance/auditing record of cost (prompt-content auditing remains a separate future ADR)
+
+New drivers exposed by the review process:
+
+- **No SPoF for interactive developer tools.** Claude Code must keep working when prod-server is down.
+- **Minimum new compromise surface.** Adding a TLS-terminating service we operate is a security cost; only justified if the value is real and irreplaceable.
+- **Optionality.** A speculative 6.5 PT build is more expensive than a 1.5 PT incremental step that converts the C-build decision from speculative to data-driven.
+
+## Considered Options
+
+### Option A — ADR-194 v1.0: custom `llm_gateway` as central choke-point
+
+Rejected. Detailed critique in `reviews/ADR-194-review.md` and out-of-the-box analysis (this session). Headline issues: SPoF on prod, bootstrap paradox, ignores Admin API + OSS proxies, 6.5 PT speculative build.
+
+### Option B — Anthropic Admin API only
+
+Daily polling of Admin API + per-source API keys (one each for `aifw`, Claude Code, Cascade BYOK, agent_team, ad-hoc scripts). 100 % cost coverage by Anthropic as truth-source. Existing self-loggers (aifw, agent_team, Stop hook) provide `action_code` attribution.
+
+- **Pro**: ~1.5 PT, zero new components, zero SPoF, zero migration across 19 repos, Anthropic-side spend limits replace most of ADR-116 budget enforcement.
+- **Pro**: Cascade BYOK becomes 100 % observable (today: ~80 % best-effort).
+- **Con**: No per-request granularity. "Which conversation was expensive?" cannot be answered without a self-logger on that path.
+- **Con**: Cost-data lags ~1 minute (Admin API minute-bucket polling cadence).
+
+### Option C — Custom gateway (ADR-194)
+
+See Option A.
+
+### Option D — Adopt OSS proxy (LiteLLM, Helicone, Langfuse)
+
+Adopt a battle-tested proxy as the per-call logging engine.
+
+- **Pro**: Streaming, retries, multi-provider passthrough all already correct.
+- **Pro**: ~1 PT setup, much less than 6.5 PT.
+- **Con (avoidable)**: schema lock-in, UI lock-in, pricing-update lag — only if naively adopted.
+- **Con (unavoidable)**: external roadmap dependency; possible supply-chain risk.
+
+### Option E (chosen) — D + B with explicit C-preparation
+
+LiteLLM-Proxy as **engine** (HTTP, streaming, retries) + Anthropic Admin API as **truth anchor** (settled cost reconciliation) + existing self-loggers (`aifw`, `agent_team`, Stop hook) as **attribution layer** (`action_code`). Architected explicitly so a later switch to a custom gateway (C) is a process swap, not a re-build.
+
+## Decision Outcome
+
+**Chosen: Option E.**
+
+### Architecture
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│  Clients (Workstation + Servers)                                    │
+│  ┌───────────┐  ┌──────────┐  ┌────────┐  ┌──────────────────┐    │
+│  │Claude Code│  │ Cascade  │  │ aifw   │  │ Ad-hoc scripts   │    │
+│  │           │  │  (BYOK)  │  │        │  │ (anthropic SDK)  │    │
+│  └─────┬─────┘  └────┬─────┘  └───┬────┘  └────────┬─────────┘    │
+│        │             │            │                 │              │
+│        │ ANTHROPIC_BASE_URL=http://127.0.0.1:4000   │              │
+│        ▼             ▼            ▼                 ▼              │
+│  ┌───────────────────────────────────────────────────────────────┐│
+│  │  Local LiteLLM-Proxy sidecar (per host, 127.0.0.1:4000)        ││
+│  │  - HTTP passthrough + streaming + retries                      ││
+│  │  - success_callback → our custom callback module               ││
+│  └────────────────────────┬───────────────────────────────────────┘│
+│                           │                                         │
+│  ┌────────────────────────▼───────────────────────────────────────┐│
+│  │  Our callback module (mcp-hub/llm_gateway/callbacks/)          ││
+│  │  - INSERT into llm_calls (OUR schema, ADR-115)                 ││
+│  │  - Pricing via mcp-hub/llm_gateway/pricing.py (OURS)           ││
+│  │  - Reads action_code from x-litellm-metadata header            ││
+│  └────────────────────────┬───────────────────────────────────────┘│
+│                           │                                         │
+│                           ▼                                         │
+│        api.anthropic.com / api.openai.com / openrouter.ai          │
+└────────────────────────────────────────────────────────────────────┘
+
+Parallel: daily reconcile job
+  Anthropic Admin API → llm_calls_reconcile → diff vs llm_calls → alert if drift > 1%
+```
+
+### Why local sidecar, not central
+
+- Prod-server down → workstation LiteLLM still reachable on `127.0.0.1` → Claude Code keeps working.
+- Compromise surface = local process on developer machine, not shared internet-facing service.
+- Trivial config (one Docker container or one binary per host); no HA/Load-Balancer needed.
+
+### Layer ownership (the key anti-lock-in commitment)
+
+| Layer | Owner |
+|---|---|
+| HTTP / streaming / retries | LiteLLM |
+| `llm_calls` schema (ADR-115) | **us** |
+| `pricing.py` (cache-tier multipliers, model prices) | **us** |
+| `action_code` taxonomy | **us** (via metadata header) |
+| Dashboard | **us** (Grafana on `llm_calls`) |
+| Truth-of-spend | Anthropic (Admin API) |
+
+LiteLLM owns nothing of value. If we replace it with a custom `/v1/messages` passthrough later, clients see no change (BASE_URL stays the same), schema/pricing/dashboard are untouched.
+
+### Per-source API keys
+
+Create one Anthropic API key per source via Anthropic Console (manual, ~5 min total):
+
+- `key_aifw` — used by aifw service
+- `key_cc` — used by Claude Code (workstation + headless)
+- `key_cascade` — used by Cascade BYOK
+- `key_agent_team` — used by orchestrator agent_team
+- `key_scripts` — used by ad-hoc Python scripts
+
+Each key gets an Anthropic-side spend limit (Console feature, free). Per-key spend visible via Admin API `group_by=api_key_id` — solves the 658-invisible-calls problem.
+
+### Migration plan
+
+| Phase | Scope | Effort | Risk |
+|-------|-------|--------|------|
+| **P1** | Create Admin API key (Anthropic Console — manual, requires browser). Store as `~/shared/secrets-inbox/anthropic_admin_api_key`. | 0.1 d | None |
+| **P2** | Smoke test: poll Admin API for last 24h; verify all expected token fields present. Document Admin API client in `mcp-hub/llm_gateway/admin_api/`. | 0.3 d | None |
+| **P3** | Create per-source Anthropic keys + set Anthropic-side spend limits. Inventory which keys land where. | 0.2 d | Low |
+| **P4** | Deploy LiteLLM-Proxy as sidecar on workstation + dev + prod (Docker compose). Set `ANTHROPIC_BASE_URL=http://127.0.0.1:4000`. Stop hook stays active as DEFENSE-IN-DEPTH but **self-disables** when `ANTHROPIC_BASE_URL` is set (resolves K-01 from ADR-194 review). | 0.5 d | Medium — first-time proxy setup |
+| **P5** | Write callback module (`callbacks/litellm_callback.py`): reads LiteLLM `success_callback` payload → applies `pricing.py` → INSERT into `llm_calls` with `source='litellm'` + `action_code` from header. | 1 d | Low |
+| **P6** | Daily reconcile cron: Admin API → `llm_calls_reconcile` table. Grafana panel "Cost Reconcile" with drift alarm at >1 % deviation over 7 days (resolves M-06 from ADR-194 review). | 0.4 d | Low |
+| **P7** | Observe 4 weeks: stop hook + LiteLLM callback both write (different `source`), reconcile shows whether LiteLLM coverage is complete. Then retire Stop hook. | 0.0 d (observation) | Low |
+
+**Total: ~2.5 PT** (vs ADR-194's 6.5 PT).
+
+### Phase-D-to-C migration path (preparation, no work in this ADR)
+
+Codified so we don't get stuck:
+
+1. Use Anthropic-format passthrough only (`/v1/messages`), not LiteLLM's OpenAI translator
+2. Callback module talks to **our** schema, never LiteLLM's DB
+3. No LiteLLM Web-UI in operational workflows (Grafana only)
+4. No LiteLLM forks/patches — workarounds via external code only
+5. Pricing math in `mcp-hub/llm_gateway/pricing.py`, not LiteLLM's pricing tables
+
+If after 3 months observation a custom gateway becomes warranted (concrete pain, not speculation), the C-build is then estimated ~5 PT (engine-swap behind unchanged BASE_URL).
+
+### Non-goals
+
+- **Per-prompt content storage / DLP** — separate ADR with Legal review. (Resolves K-02 from ADR-194 review by removing the "audit trail" claim.)
+- **Windsurf Pro-mode visibility** — billed Windsurf↔Anthropic, structurally invisible to us. Same as ADR-194.
+- **HA gateway** — sidecar architecture removes the need.
+
+## Consequences
+
+### Positive
+
+- **100 % cost coverage** via Admin API regardless of which client or host
+- **100 % per-call coverage** via LiteLLM sidecar for instrumented hosts
+- **No central SPoF** — local sidecar means workstation works even with prod-server down
+- **Datadriven decision** for a later custom gateway: 3 months of LiteLLM data tells us if/what to build
+- **Anthropic-side spend limits** replace most of ADR-116 enforcement complexity
+- **Cascade BYOK becomes 100 % observable** without agent cooperation (today: ~80 %)
+- **Reconcile against Anthropic invoice** — drift detection is mathematically possible (Admin API = settled truth)
+
+### Negative
+
+- **External dependency on LiteLLM-Proxy** — supply-chain and roadmap risk. Mitigation: layer ownership above.
+- **Latency tax** — sidecar adds local hop (~1–3 ms, not network hop). To be measured in P4.
+- **Two writers during P7 transition** — Stop hook + LiteLLM callback both INSERT. Mitigation: hook self-disables when `ANTHROPIC_BASE_URL` is set; reconcile detects any drift.
+- **Per-source key management** — 5 keys to rotate. Mitigation: Anthropic Console + secrets-inbox process is unchanged.
+
+### Risks and mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| LiteLLM streaming bug loses usage data | Medium | Reconcile against Admin API catches this within 24 h |
+| Stop hook + LiteLLM double-write same call | Medium | Hook self-disables when `ANTHROPIC_BASE_URL` is set (no overlap) |
+| Admin API rate-limit on large workloads | Low | Bucket-width=1h, 24 calls/day per workspace; well under limits |
+| LiteLLM pivots / drops self-hosted | Low | Layer ownership = engine swap, not system swap; ~5 PT to replace |
+| Admin key leak | Medium | Admin keys are highest privilege — store with same care as production secrets; rotation procedure documented |
+
+## Compliance / Drift Checks
+
+Replaces ADR-194's LLM-001/002/003:
+
+- `LLM-001` (error): Direct `import anthropic` outside `aifw/`, `llm_gateway/`, `tests/` without `ANTHROPIC_BASE_URL` set in the calling context.
+- `LLM-002` (info, runtime): `llm-doctor` CLI in `mcp-hub/llm_gateway/` checks at session start that `ANTHROPIC_BASE_URL` points to a reachable proxy. (Replaces ADR-194's unenforceable `~/.bashrc` check from review-H-04.)
+- `LLM-003` (warning): `llm_calls_reconcile` drift > 1 % over 7 days → alert. Indicates a writer bypassed the proxy or a callback dropped events.
+
+## Open Questions
+
+1. **LiteLLM-Proxy vs Helicone** — final choice deferred to P4 spike (½ day). Both fit the engine role; LiteLLM is already in our Python deps (orchestrator MCP), which weighs toward LiteLLM.
+2. **Workspace mapping** — should each source have its own Anthropic Workspace, or just its own API key? Workspaces enable group-by; keys alone are simpler. Decide in P3.
+3. **Reconcile threshold** — 1 % drift for alert is initial; tune after first month of observation data.
+
+## Implementation Status
+
+**None.** This ADR is the proposal; implementation begins at P1 after acceptance.
+
+## Changelog
+
+- 2026-05-11: v1.0 proposed. Supersedes ADR-194 v1.0. Driven by adversarial review (`reviews/ADR-194-review.md`) + out-of-the-box critique surfacing Admin API + OSS-proxy options. Decision: LiteLLM-as-engine + Admin-API-as-truth + sidecar deployment, with explicit anti-lock-in commitments enabling a later custom-gateway build at ~5 PT if needed.

--- a/docs/adr/ARCHITECT-OVERVIEW.md
+++ b/docs/adr/ARCHITECT-OVERVIEW.md
@@ -1,0 +1,281 @@
+# Plattform-ADR — Architekten-Übersicht
+
+> **Stand:** 2026-05-11
+> **Scope:** 144 aktive ADRs (Status `Accepted` / `Proposed` / Draft). Deprecated/Superseded/Archived nicht enthalten — Historie siehe `INDEX.md` und `_archive/`.
+> **Quelle:** Filesystem `docs/adr/*.md` (SSOT, siehe ADR-065).
+> **Lesehilfe:** Jede ADR mit 1–2 Sätzen — **Konzept** (was es ist) + **Fokus** (warum es da ist / was es liefert).
+
+---
+
+## 0. Wie diese Plattform gedacht ist (Big Picture)
+
+Die Plattform ist ein **Hub-Landschaft auf gemeinsamer Foundation**: ~20 Django/Reflex-Hubs (UI-Produkte) teilen sich eine wiederverwendbare Foundation aus Shared-Packages (`iil-*`, `weltenfw`, `aifw`, `authoringfw`, `promptfw`, …), eine zentrale Deployment-Pipeline auf Hetzner und einen AI/Agent-Layer (Multi-Agent Coding Team + LLM-Gateway + MCP-Tools). Multi-Tenancy (PostgreSQL Schema Isolation + RLS), zentrales Billing und ein einheitliches Identity Provider (authentik) sind plattformweit verpflichtend. **Single-Engineer-Team mit AI-Agents** — daher Optimierung auf Reuse, Konvention statt Konfiguration, automatisierte Gates statt manueller Reviews.
+
+Die ADRs gliedern sich in **13 Architektur-Cluster**:
+
+| # | Cluster | ADRs |
+|---|---------|------|
+| 1 | Foundation & Platform Governance | 14 |
+| 2 | Multi-Tenancy & Identity | 10 |
+| 3 | Frontend, UI, HTMX & REFLEX | 8 |
+| 4 | Deployment, CI/CD & Infrastructure | 21 |
+| 5 | MCP & Tool-Plattform | 8 |
+| 6 | AI / LLM Routing & Frameworks | 11 |
+| 7 | Agent-Plattform & Autonomous Coding | 19 |
+| 8 | Search, RAG & Document-Pipeline | 9 |
+| 9 | Shared Packages & Libraries | 13 |
+| 10 | Testing & Quality Gates | 7 |
+| 11 | Hubs, Domains & Produkte | 18 |
+| 12 | Work Management & Operationen | 4 |
+| 13 | Dokumentation | 2 |
+
+---
+
+## 1. Foundation & Platform Governance
+
+**Konzept-Strang:** Wie ADRs entstehen, wie sie konsistent bleiben, und welche plattformweiten Konventionen alle Repos einhalten. Optimiert auf **AI-Agent-Lesbarkeit** und **Drift-Vermeidung**.
+
+- **[ADR-015](ADR-015-platform-governance-system.md) — Platform Governance System.** Verbindliches Rahmenwerk für plattformweite Entscheidungen. *Fokus: definiert Rollen, Entscheidungs-Flow und Eskalationspfade.*
+- **[ADR-022](ADR-022-platform-consistency-standard.md) — Platform Consistency Standard (v3).** Pflicht-Tech-Stack & Coding-Konventionen für alle Django-Hubs. *Fokus: Voraussetzung für Shared-Packages und Multi-Agent-Coding — Konsistenz vor Innovation pro Repo.*
+- **[ADR-028](ADR-028-platform-context.md) — Platform Context.** Konsolidierung der Foundation-Schichten in einer SSOT. *Fokus: ein Ort, wo "wie funktioniert die Plattform" beantwortet wird (für Menschen und Agents).*
+- **[ADR-050](ADR-050-platform-decomposition-hub-landscape.md) — Hub Landscape & Developer Portal.** Plattform zerfällt in unabhängige Hubs + Entwicklerportal. *Fokus: Domain-Schnitt + dev-hub als Navigationszentrale.*
+- **[ADR-051](ADR-051-concept-to-adr-pipeline.md) — Concept-to-ADR Pipeline.** Idee → Concept-Note → ADR über AI-assistierte Promotion. *Fokus: niedrigere Friction für architektonische Entscheidungen.*
+- **[ADR-059](ADR-059-adr-drift-detector.md) — ADR Drift Detection.** Automatische Erkennung von ADRs, die nicht mehr zur Realität passen. *Fokus: ADRs als lebendige Artefakte, nicht historische Notizen.*
+- **[ADR-065](ADR-065-adr-numbering-filesystem-first.md) — Filesystem-first ADR Numbering.** Nummer = `max(existing) + 1`, niemals Wiederverwendung. *Fokus: keine Kollisionen bei parallelen Agent-Branches.*
+- **[ADR-071](ADR-071-amendment-code-quality-tooling.md) — Code Quality Tooling (Amendment zu 022).** Ruff/Black/etc. verbindlich. *Fokus: einheitliches Lint/Format-Setup als Vorbedingung für AI-Codegen.*
+- **[ADR-073](ADR-073-repo-scope.md) — Repo Scope & Migration Status.** Inventory aller in-scope Repos (mittlerweile 30). *Fokus: SSOT was zur Plattform gehört.*
+- **[ADR-083](ADR-083-hybrid-adr-governance.md) — Hybrid ADR Governance.** Plattform-ADRs + Repo-lokale ADRs. *Fokus: nicht alles muss in `platform/` landen — lokale Entscheidungen bleiben lokal.*
+- **[ADR-138](ADR-138-implementation-tracking-standard.md) — Implementation Tracking Standard.** Frontmatter-Feld `implementation_status` + verifizierbare Evidence. *Fokus: ADR sagt nicht nur "soll", sondern auch "ist umgesetzt".*
+- **[ADR-174](ADR-174-workflow-enforcement-ci-gate.md) — Workflow Enforcement: CI Gate.** PR-Checklist + Symlink-Policy + CI-Pflichtchecks. *Fokus: Konventionen werden vom CI durchgesetzt, nicht von Code-Review.*
+- **[ADR-175](ADR-175-workflow-modularization-pattern.md) — Workflow Modularization.** `.windsurf/workflows/` selektiv modularisieren. *Fokus: wiederverwendbare Agent-Workflows.*
+- **[ADR-190](ADR-190-adopt-iil-adrfw-tooling-framework.md) — iil-adrfw Tooling Framework.** Shared Python-Package für ADR-Tooling (Lint, Drift, Index). *Fokus: ADR-Toolchain ist selbst ein versionierbares Asset.*
+
+---
+
+## 2. Multi-Tenancy & Identity
+
+**Konzept-Strang:** Die Plattform ist von Anfang an **multi-tenant**. PostgreSQL-Schema pro Tenant, Self-Service-Onboarding, plattformweites SSO via authentik.
+
+- **[ADR-007](ADR-007-FINAL-PRODUCTION.md) — Tenant- & RBAC-Architektur.** Ur-ADR für Tenancy: Schema-Isolation + RBAC. *Fokus: Produktions-Baseline, auf der alles spätere aufsetzt.*
+- **[ADR-035](ADR-035-shared-django-tenancy.md) — Shared Django Tenancy Package.** Tenancy als wiederverwendbare Lib. *Fokus: Tenancy einmal richtig bauen, in jedem Hub nutzen.*
+- **[ADR-072](ADR-072-multi-tenancy-schema-isolation.md) — PostgreSQL Schema Isolation.** Ein Schema je Tenant statt Discriminator-Column. *Fokus: harte Isolation, geringere Mandanten-Leak-Wahrscheinlichkeit.*
+- **[ADR-074](ADR-074-multi-tenancy-testing-strategy.md) — Multi-Tenancy Testing Strategy.** Tenant-Propagation und Isolation als CI-Gate. *Fokus: Tenancy-Bugs sind silent — Tests müssen sie aktiv suchen.*
+- **[ADR-092](ADR-092-tenant-aware-seed-commands.md) — Tenant-Aware Seed Commands.** `manage.py seed_*` müssen Tenant explizit machen. *Fokus: kein versehentliches "Seed läuft in public-Schema".*
+- **[ADR-109](ADR-109-multi-tenancy-platform-standard.md) — Multi-Tenancy Plattform-Standard.** Multi-Tenancy ist für **alle UI-Hubs** verpflichtend. *Fokus: keine Single-Tenant-Hub-Ausreißer mehr.*
+- **[ADR-110](ADR-110-i18n-platform-standard.md) — i18n Plattform-Standard.** DE/EN ab Tag 1 in jedem Hub. *Fokus: i18n nicht nachträglich nachrüsten.*
+- **[ADR-137](ADR-137-tenant-lifecycle-module-selfservice-rls.md) — Tenant-Lifecycle + RLS.** Self-Service-Tenant-Anlage, Modul-Buchung, PostgreSQL RLS als zweite Schutzschicht. *Fokus: Plattform-Store macht neue Mandanten produktiv ohne Engineer.*
+- **[ADR-142](ADR-142-unified-identity-authentik-platform-idp.md) — authentik als Platform IdP.** Ein SSO über alle Hubs. *Fokus: Identity weg aus jedem Hub — eine zentrale Wahrheit.*
+- **[ADR-161](ADR-161-shared-sds-library.md) — Two-Layer-Schema + Hybrid-RLS.** Plattform-weite (tenant-übergreifende) SDS-Daten ohne Tenancy-Bruch. *Fokus: kontrollierter Ausweg für genuinely geteilte Daten.*
+
+---
+
+## 3. Frontend, UI, HTMX & REFLEX
+
+**Konzept-Strang:** Server-rendered Django-Templates + HTMX, Tailwind via Design-Tokens, plus **REFLEX** als evidenzbasierte UI-Test/Quality-Methodologie.
+
+- **[ADR-040](ADR-040-frontend-completeness-gate.md) — Frontend Completeness Gate.** Feature gilt erst als fertig, wenn UI sichtbar funktioniert. *Fokus: kein "API ist da, UI kommt später".*
+- **[ADR-041](ADR-041-django-component-pattern.md) — Django Component Pattern.** Wiederverwendbare UI-Blöcke (`{% include %}`-Komponenten). *Fokus: gemeinsames Design-System ohne SPA-Komplexität.*
+- **[ADR-048](ADR-048-htmx-playbook.md) — HTMX Playbook.** Kanonische Patterns für Django+HTMX. *Fokus: ein Pattern pro Problem (Form, List, Modal, Polling), nicht "jeder Hub erfindet neu".*
+- **[ADR-049](ADR-049-design-token-system.md) — Design Token System.** CSS-Custom-Properties + Tailwind-Bridge. *Fokus: ein Theme über alle Hubs, Brand-Anpassung via Tokens.*
+- **[ADR-162](ADR-162-reflex-ui-testing-and-scraping.md) — REFLEX als Standard-Methodologie.** Evidenz-basierte UI-Entwicklung (Scraping + Pixel-Tests). *Fokus: UI-Behauptungen werden empirisch verifiziert, nicht behauptet.*
+- **[ADR-163](ADR-163-reflex-tiering-platform-quality-standard.md) — Three-Tier REFLEX Quality Standard.** Hub bekommt Tier 1/2/3 je nach UI-Qualitäts-Anspruch. *Fokus: nicht jeder Hub braucht Pixel-Perfekt — aber jeder Hub kennt sein Tier.*
+- **[ADR-165](ADR-165-reflex-review-engine-with-grafana-controlling.md) — Plugin-based REFLEX Review Engine.** Pluggable Reviewers + Grafana-Controlling. *Fokus: UI-Reviews auf Dashboards sichtbar, nicht in Issue-Kommentaren versteckt.*
+- **[ADR-192](ADR-192-django-service-layer-htmx-compliance-scanner.md) — Django Service-Layer + HTMX Compliance Scanner.** Statische Prüfung auf Service-Layer-Pattern + HTMX-Konventionen. *Fokus: Konvention statt Code-Review.*
+
+---
+
+## 4. Deployment, CI/CD & Infrastructure
+
+**Konzept-Strang:** Ein einheitlicher Deployment-Weg für alle Hubs auf **Hetzner-VMs**, 3-Server-Setup (Dev/Staging/Prod), `.ship.conf` als SSOT, Cloudflare davor.
+
+- **[ADR-021](ADR-021-unified-deployment-pattern.md) — Unified Single-Service Deployment Pipeline.** Eine Pipeline-Definition für alle Hubs. *Fokus: Deploy-Bugs einmal fixen, alle Repos profitieren.*
+- **[ADR-031](ADR-031-static-asset-versioning.md) — Static Asset Versioning & Landing Page Registry.** Statische Sites unter Git-Kontrolle. *Fokus: nie wieder "live-Page versehentlich überschrieben".*
+- **[ADR-042](ADR-042-dev-environment-deploy-workflow.md) — Dev-Environment & Deploy Workflow.** Wie Engineer/Agent lokal → Staging → Prod gelangt. *Fokus: ein dokumentierter Flow für alle Hubs.*
+- **[ADR-045](ADR-045-secrets-management.md) — Secrets & Environment Management.** `.env`-Konvention + Secret-Source pro Umgebung. *Fokus: keine Secrets im Git, kein Drift zwischen Hubs.*
+- **[ADR-056](ADR-056-deployment-preflight-and-pipeline-hardening.md) — Deployment Pre-Flight Validation.** Pre-Deploy Checks (Migrations, Health, Konfig). *Fokus: kaputte Deploys werden vor SSH-Push gestoppt.*
+- **[ADR-060](ADR-060-developer-workstation-ssh-configuration.md) — SSH Key Configuration Standard.** Einheitliche `~/.ssh/config`-Strategie. *Fokus: jeder Engineer/Agent erreicht jeden Server gleich.*
+- **[ADR-075](ADR-075-deployment-execution-strategy.md) — Split Deployment Execution.** Read-only MCP-Tools lokal + GH-Actions schreiben. *Fokus: Agents können nichts kaputtmachen, GH Actions hat Audit-Trail.*
+- **[ADR-077](ADR-077-infrastructure-context-system.md) — Infrastructure Context System.** `catalog-info.yaml` → dev-hub API → `context.md`. *Fokus: Plattform-Metadaten zentral abfragbar (Backstage-Pattern, schlank).*
+- **[ADR-078](ADR-078-amendment-docker-healthcheck-convention.md) — Docker HEALTHCHECK Convention.** HEALTHCHECK nur in `docker-compose.prod.yml`. *Fokus: keine Healthcheck-Drift zwischen Dockerfile und Compose.*
+- **[ADR-090](ADR-090-cicd-pipeline-python-postgres.md) — Hybrid Matrix CI/CD Pipeline.** Standard-Pipeline für Python+Postgres+Docker. *Fokus: Template, das jeder Hub übernimmt.*
+- **[ADR-098](ADR-098-production-infrastructure-tuning-standard.md) — 3-Layer Tuning Standard (Hetzner).** Redis maxmemory, Postgres `random_page_cost`, Docker `shm_size`/`logging` plattformweit. *Fokus: gleiche Tuning-Defaults, kein Production-Surprise.*
+- **[ADR-102](ADR-102-cloudflare-dns-cdn-migration.md) — Cloudflare DNS/CDN/DDoS.** Cloudflare als Edge für alle Hubs. *Fokus: DDoS-Schutz + zentrales DNS-Management.*
+- **[ADR-120](ADR-120-unified-deployment-pipeline.md) — Unified Multi-Repo Deployment Pipeline mit Staging.** Erweiterung von 021 um Staging-Stufe. *Fokus: keine direkten Prod-Deploys mehr.*
+- **[ADR-156](ADR-156-reliable-deployment-pipeline.md) — Server-Side Deploy Scripts + Short-Trigger.** Deploy-Logik auf dem Server, GH Actions triggert nur. *Fokus: weniger fragile GH-Actions-YAML, mehr lokaler Server-Code.*
+- **[ADR-157](ADR-157-staging-production-split-and-port-governance.md) — 3-Server-Architektur (Dev/Staging/Prod).** Drei Hetzner-Server + automatisierte Port-Governance. *Fokus: harte physische Trennung statt Logik-Trennung.*
+- **[ADR-159](ADR-159-shared-secrets-management.md) — Shared Secrets Management.** SSOT für API-Keys über alle Repos. *Fokus: API-Key existiert genau einmal, wird referenziert, nicht kopiert.*
+- **[ADR-164](ADR-164-port-strategy-conflict-free-dev-staging-prod.md) — Unified Port Strategy.** Konfliktfreie Port-Zuweisung dev/staging/prod. *Fokus: kein "Hub X läuft auf Port 8000, Hub Y auch".*
+- **[ADR-166](ADR-166-deployment-configuration-standard.md) — `.ship.conf` SSOT + `/livez/`.** Eine Datei pro Repo beschreibt Deploy + Healthcheck. *Fokus: SSOT für Deployment-Konfiguration, maschinen-lesbar für Agents.*
+- **[ADR-167](ADR-167-three-tier-middleware-architecture.md) — 3-Tier Middleware Standard.** Health Probes + Tenant Resolution in einer definierten Reihenfolge. *Fokus: Middleware-Reihenfolge ist Architektur, nicht Detail.*
+- **[ADR-185](ADR-185-deploy-agent-pattern.md) — Gate-controlled Deploy-Agent.** Automatisierte Staging→Prod-Deploys mit Quality-Gates. *Fokus: Deploys ohne Engineer, aber mit Safety-Net.*
+- **[ADR-193](ADR-193-deployment-configuration-compliance-audit.md) — Deployment Configuration Compliance Audit.** Automatische Prüfung, dass alle Repos den Deployment-Standard einhalten. *Fokus: Drift-Detection auf Infra-Ebene.*
+
+---
+
+## 5. MCP & Tool-Plattform
+
+**Konzept-Strang:** **MCP (Model Context Protocol)** ist die Schnittstelle, über die Agents/Claude/Cascade Plattform-Tools nutzen. 3-Tier-Architektur: Servers (capability) → Hub (consolidation) → Tools (skill).
+
+- **[ADR-010](ADR-010-mcp-tool-governance.md) — MCP Tool Governance.** Spec-Standard, Service-Discovery, Tool-Composition. *Fokus: Tools haben ein vorhersagbares Schema, Agents können sie blind nutzen.*
+- **[ADR-012](ADR-012-mcp-quality-standards.md) — MCP Server Quality Standards.** Mindestanforderungen für MCP-Server (Logging, Auth, Tests). *Fokus: kein "schnell hingerotzter" MCP-Server in Produktion.*
+- **[ADR-044](ADR-044-mcp-hub-architecture-consolidation.md) — MCP-Hub Architecture Consolidation.** Konsolidierung der MCP-Server in einem Hub-Repo. *Fokus: ein Ort statt 12 verteilte MCP-Repos.*
+- **[ADR-069](ADR-069-web-intelligence-mcp.md) — Web Intelligence MCP.** Plattformweiter Web-Zugriff (Scrape, Fetch, Cache). *Fokus: keiner muss mehr selbst HTTP-Clients bauen.*
+- **[ADR-091](ADR-091-platform-operations-hub-consolidation.md) — Platform Operations Hub Consolidation.** Ops-Tooling als ein MCP-Hub. *Fokus: Deploy/Logs/Restart über eine Tool-Surface.*
+- **[ADR-101](ADR-101-mcp-plattform-konzept.md) — 3-Tier MCP Architecture.** Tier 1 = Capability, Tier 2 = Hub, Tier 3 = Skill. *Fokus: klare Abstraktions-Ebenen statt Tool-Wildwuchs.*
+- **[ADR-172](ADR-172-rag-mcp-server.md) — rag-mcp Server.** Plattform-weite RAG-API als MCP-Tool. *Fokus: jeder Hub spricht denselben RAG-Endpoint an.*
+- **[ADR-176](ADR-176-mcp-server-ssot.md) — MCP-Server SSoT: platform = Config, mcp-hub = Code.** Config zentral, Implementierung im mcp-hub. *Fokus: keine Drift zwischen Server-Definition und tatsächlicher Implementierung.*
+
+---
+
+## 6. AI / LLM Routing & Frameworks
+
+**Konzept-Strang:** Plattform routet LLM-Calls über eine **eigene Abstraktionsschicht** (aifw + bfagent-llm/LiteLLM + Model-Registry), nicht direkt zu Anbietern. Routing entscheidet Tier/Budget/Quality dynamisch.
+
+- **[ADR-068](ADR-068-adaptive-model-routing.md) — Adaptive Model Routing.** Quality-Feedback-Loop steuert Modell-Auswahl. *Fokus: Modelle werden auf Basis empirischer Qualität gewählt, nicht Anbieter-Marketing.*
+- **[ADR-084](ADR-084-model-registry-dynamic-llm-routing.md) — Model Registry.** DB-gestützte Tier-Verwaltung der verfügbaren LLMs. *Fokus: Modell-Wechsel = DB-Update, kein Code-Deploy.*
+- **[ADR-089](ADR-089-bfagent-llm-litellm-db-driven-architecture.md) — bfagent-llm + LiteLLM.** LiteLLM als Provider-Adapter + DB-Routing. *Fokus: ein Endpoint für alle Anbieter (Anthropic/OpenAI/local).*
+- **[ADR-093](ADR-093-ai-config-app.md) — AI Config App in dev-hub.** UI zur Konfiguration der AI-Plattform. *Fokus: AI-Konfig ist editierbar ohne Deploy.*
+- **[ADR-095](ADR-095-aifw-quality-level-routing.md) — aifw Quality-Level Routing.** Multi-dimensionales Routing mit Prompt-Template-Koordination. *Fokus: "diese Task braucht Quality=high, Budget=low" → System wählt.*
+- **[ADR-097](ADR-097-aifw-060-implementation-contract.md) — aifw 0.6.0 Implementation Contract.** Models, Migrations, Service-Layer, Public API für aifw. *Fokus: stabiler API-Vertrag für aifw-Consumer.*
+- **[ADR-116](ADR-116-dynamic-model-router.md) — Dynamic Model Router.** Budget-aware regelbasierter Fallback-Router. *Fokus: wenn Premium-Modell aus, ziehe auf günstigeres um, ohne Code-Änderung.*
+- **[ADR-132](ADR-132-ai-context-defense-in-depth.md) — AI Context Defense-in-Depth.** Mehrere Schichten gegen Prompt-Injection und Context-Drift. *Fokus: Agents arbeiten mit getrustetem Kontext.*
+- **[ADR-133](ADR-133-shared-ai-services-package.md) — Shared AI Services Package.** Wiederverwendbare AI-Services als pip-Paket. *Fokus: Embedding/Summarize/Classify einmal bauen, überall nutzen.*
+- **[ADR-146](ADR-146-hub-prompt-management.md) — promptfw als SSoT für DB-Prompts.** Prompts in DB, editierbar via UI. *Fokus: Prompt-Engineering ohne Deploy.*
+- **[ADR-178](ADR-178-llm-gateway-consolidation.md) — LLM Gateway Consolidation.** Konsolidierung mehrerer Gateway-Komponenten. *Fokus: weniger Hops zwischen Hub und Anbieter.*
+
+---
+
+## 7. Agent-Plattform & Autonomous Coding
+
+**Konzept-Strang:** **Multi-Agent Coding Team** mit spezialisierten Rollen (DocBot/TestBot/FeatureBot/…), Progressive Autonomy, Guardrails, QA-Cycle. Discord/Telegram als IDE-ähnliche Gateways.
+
+- **[ADR-036](ADR-036-chat-agent-ecosystem.md) — Chat-Agent Ecosystem.** DomainToolkits + Research-Integration + Shared Chat-Widget. *Fokus: ein Chat-Agent-Pattern, das jeder Hub einbettet.*
+- **[ADR-037](ADR-037-chat-conversation-logging.md) — Chat Conversation Logging.** Conversation-Persistence + Quality-Management. *Fokus: Chats sind Trainingsdaten + Audit-Quelle.*
+- **[ADR-043](ADR-043-ai-assisted-development.md) — AI-Assisted Development.** Context- und Workflow-Optimization für Engineers mit AI. *Fokus: AI ist Coworker, nicht Tool — Prozesse passen sich an.*
+- **[ADR-066](ADR-066-ai-engineering-team.md) — AI Engineering Squad mit Role-based Agents.** Strukturierte AI-Engineering-Crew mit Rollen. *Fokus: Agent-Rollen statt eines Allzweck-Agents.*
+- **[ADR-070](ADR-070-progressive-autonomy-developer-agent.md) — Progressive Autonomy Pattern.** Agent bekommt schrittweise mehr Autonomie nach erfolgreichen Stufen. *Fokus: Vertrauen wird verdient, nicht angenommen.*
+- **[ADR-080](ADR-080-multi-agent-coding-team-pattern.md) — Multi-Agent Coding Team Pattern.** Strukturiertes Handoff + parallele Branches + Rollback. *Fokus: mehrere Agents arbeiten ohne sich auf die Füße zu treten.*
+- **[ADR-081](ADR-081-agent-guardrails-code-safety.md) — Agent Guardrails & Code Safety.** Scope-Lock, Pre/Post-Gates, Rollback-Strategy. *Fokus: Agent kann nichts kaputtmachen, was nicht reversibel ist.*
+- **[ADR-082](ADR-082-llm-tool-integration-autonomous-coding.md) — LLM Tool Integration.** Stub-Steps werden durch echte LLM-Tool-Calls ersetzt. *Fokus: Übergang von "Agent simuliert" zu "Agent macht wirklich".*
+- **[ADR-085](ADR-085-use-case-pipeline-nl-to-taskgraph.md) — Use Case Pipeline NL→TaskGraph.** Natural Language → strukturierter TaskGraph. *Fokus: User-Ticket wird zu maschinen-ausführbarem Plan.*
+- **[ADR-086](ADR-086-agent-team-workflow.md) — Agent Team Workflow.** Cross-Repo Sprint Execution Pattern. *Fokus: ein Sprint kann mehrere Repos berühren, ohne dass Coordination zerbricht.*
+- **[ADR-107](ADR-107-extended-agent-team-deployment-agent.md) — Extended Agent Team.** Cascade als Tech Lead + Deployment Agent + Review Agent. *Fokus: explizite Rollen entlasten den Hauptagent.*
+- **[ADR-108](ADR-108-agent-qa-cycle.md) — Agent QA Cycle.** Quality Evaluator + Completion Gate + AuditStore. *Fokus: Agent-Output wird systematisch geprüft, nicht blind übernommen.*
+- **[ADR-112](ADR-112-agent-skill-registry-persistent-context.md) — Agent Skill Registry + Persistent Context.** Skills + persistente Kontext-Store über Sessions. *Fokus: Agents vergessen nicht zwischen Sessions.*
+- **[ADR-114](ADR-114-discord-ide-like-communication-gateway.md) — Discord als verlängertes Cascade IDE.** Discord = mobiler Eingang zum Coding-Agent. *Fokus: Code aus dem Café via Discord-Thread starten.*
+- **[ADR-141](ADR-141-discord-agentic-coding-bridge.md) — Discord → Agentic Coding Bridge (Layer 4).** Standardisierte Bridge zwischen Discord und Agent-Backend. *Fokus: Discord-Messages sind erste-Klasse Trigger.*
+- **[ADR-154](ADR-154-autonomous-coding-optimization.md) — Autonomous Coding Optimization.** Information-Flow + Error-Prevention + Continuous Improvement. *Fokus: Agents lernen aus Fehlern, nicht nur aus Erfolgen.*
+- **[ADR-169](ADR-169-enrichment-agent-pattern.md) — iil-enrichment Pattern.** Generic Pattern für Brücke zwischen Records und externem Wissen. *Fokus: "Anreichere Datensatz X mit Quelle Y" als wiederverwendbares Muster.*
+- **[ADR-177](ADR-177-agent-role-specialization.md) — Agent Role Specialization.** Developer-Agent → 5 Spezialisten (DocBot, TestBot, FeatureBot, ReEngineerBot, ArchitectBot). *Fokus: Spezialisten produzieren höhere Qualität als Generalisten.*
+- **[ADR-186](ADR-186-headless-agent-coding-pipeline.md) — Headless Agent-Coding Pipeline.** Devin CLI + Orchestrator-Bridge für Polyrepo-Automation. *Fokus: Coding-Pipeline läuft ohne UI, getriggert via CI.*
+
+---
+
+## 8. Search, RAG & Document-Pipeline
+
+**Konzept-Strang:** **Ein unified Vector Store** (pgvector) + ein **RAG-Stack** + eine **Document-Ingest-Pipeline** plattformweit. Mehrsprachig (multilingual-e5-large), bitemporal (ADR-171).
+
+- **[ADR-087](ADR-087-hybrid-search-architecture.md) — pgvector + FTS Hybrid Search.** Plattformweite semantische Suche mit Reciprocal Rank Fusion. *Fokus: ein Such-Pattern für alle Hubs.*
+- **[ADR-104](ADR-104-research-hub-iil-researchfw.md) — Research-Hub + iil-researchfw.** Zentralisierung der Research-Infrastruktur. *Fokus: Research einmal bauen, in mehreren Hubs nutzen.*
+- **[ADR-105](ADR-105-iil-researchfw-extraction-plan.md) — iil-researchfw Extraction Plan.** Code-Extraktion aus bestehenden Hubs in das Framework. *Fokus: Plan, wie aus bestehendem Code ein wiederverwendbares Lib wird.*
+- **[ADR-160](ADR-160-llm-powered-research-pipeline.md) — LLM-Powered Query Expansion (researchfw).** Query-Expansion + Relevance-Scoring via LLM. *Fokus: bessere Suche durch LLM-Augmentation.*
+- **[ADR-170](ADR-170-iil-ingest-document-ingestion-package.md) — iil-ingest — Document Ingestion Package.** Tier-3 wiederverwendbares Package. *Fokus: Dokumente → Chunks → Embeddings als Standard-Pipeline.*
+- **[ADR-171](ADR-171-temporal-rag-infrastructure.md) — Temporal RAG Infrastructure.** Bitemporal Vector Storage auf pgvector. *Fokus: RAG kennt "was war wann gültig" — wichtig für regulierte Domains.*
+- **[ADR-173](ADR-173-document-intake-routing-pattern.md) — Document Intake Routing Pattern.** Dokument → richtiger Processor je nach Typ. *Fokus: Routing als first-class Konzept, nicht hardcoded if-else.*
+- **[ADR-187](ADR-187-document-intelligence-pipeline.md) — Document Intelligence Pipeline.** iil-ingest + VectorStore + Multi-Tool-Ensemble + RAG. *Fokus: end-to-end Pipeline für Template-Erkennung, RAG, VectorStore-Befüllung.*
+- **[ADR-188](ADR-188-unified-vector-store.md) — Unified Vector Store (multilingual-e5-large).** Konsolidierung mehrerer VectorStores in **einen** plattformweiten. *Fokus: keine Drift mehr zwischen "agent-memory vs. search-chunks vs. rag-chunks".*
+
+---
+
+## 9. Shared Packages & Libraries
+
+**Konzept-Strang:** Plattform = Hubs + **shared Python-Packages**, die als `iil-*` veröffentlicht werden. Konsolidiert auf ~20 Pakete.
+
+- **[ADR-088](ADR-088-notification-registry.md) — Shared Notification Registry.** Multi-Channel-Messaging (Email/SMS/Webhook/Discord/Telegram). *Fokus: jeder Hub schickt Notifications gleich.*
+- **[ADR-096](ADR-096-authoringfw-scope-and-architecture.md) — authoringfw.** Content Orchestration Framework. *Fokus: strukturierte Content-Generierung (statt freie LLM-Prompts).*
+- **[ADR-100](ADR-100-iil-testkit-shared-test-factory-package.md) — iil-testkit.** Shared Test Factory Package. *Fokus: Test-Fixtures + Factory-Pattern einmal lösen.*
+- **[ADR-117](ADR-117-shared-world-layer-worldfw.md) — Shared World Layer (weltenfw).** Weltenhub-DB als SSoT, weltenfw als Schreibkanal. *Fokus: Story-Welten-Daten getrennt von Hub-Logik.*
+- **[ADR-130](ADR-130-content-store-shared-persistence.md) — Shared Django App `content_store`.** Persistenz für AI-generierte Inhalte. *Fokus: AI-Output landet in einer definierten Tabelle, nicht in Ad-hoc-Models.*
+- **[ADR-131](ADR-131-shared-backend-services.md) — Shared Backend Services Library.** Die "Common"-Lib für Django-Hubs. *Fokus: INSTALLED_APPS/MIDDLEWARE/health URLs einmal definiert.*
+- **[ADR-134](ADR-134-module-monetization-strategy.md) — Module Monetization Strategy.** Plattform-Module sind buchbar + monetarisiert. *Fokus: jedes Modul kann eigenständig zahlbar werden.*
+- **[ADR-139](ADR-139-shared-learning-platform-package.md) — iil-learnfw.** Shared Learning Platform Package. *Fokus: LMS-Bausteine wiederverwendbar.*
+- **[ADR-147](ADR-147-concept-templates-package.md) — iil-concept-templates.** Shared Package für strukturierte Konzept-Vorlagen. *Fokus: Konzepte sind Daten, nicht freier Text.*
+- **[ADR-180](ADR-180-package-consolidation-strategy.md) — Package Consolidation Strategy (34→20).** Konsolidierungsplan für die Library-Landschaft. *Fokus: weniger ist mehr — keine ungepflegten Mini-Libs.*
+- **[ADR-181](ADR-181-implementation-plan.md) — Implementierungsplan (produktionsreif).** Konkreter Plan zur Konsolidierung. *Fokus: Sequenz + Migration-Path.*
+- **[ADR-182](ADR-182-review.md) — Principal Architect Assessment.** Review von ADR-147/180. *Fokus: externer Blick auf Konsolidierung.*
+- **[ADR-183](ADR-183-v2-concept-templates-package.md) — iil-concept-templates v2.** Revidiertes Konzept-Template-Package. *Fokus: Iteration auf ADR-147 nach Feedback.*
+
+---
+
+## 10. Testing & Quality Gates
+
+**Konzept-Strang:** 4-Level-Test-Strategie + 28-Type-Taxonomy + Contract-Testing + automatisierte Compliance-Scanner. Tests sind **Gates**, nicht Vorschlag.
+
+- **[ADR-057](ADR-057-platform-test-strategy.md) — Four-Level Test Strategy mit Contract Testing.** Test-Ebenen: Unit, Integration, Contract, E2E. *Fokus: jede Ebene hat einen klaren Zweck.*
+- **[ADR-058](ADR-058-platform-test-taxonomy.md) — 28-Type Test Taxonomy.** Binding-Standard: jeder Test hat exakt einen der 28 Typen. *Fokus: keine "ungeklärten" Tests.*
+- **[ADR-061](ADR-061-hardcoding-elimination-strategy.md) — hardcode_scanner.py.** Statischer Scanner gegen hardgecodete Werte. *Fokus: Konfig gehört in `.env` / Settings, nicht in Code.*
+- **[ADR-155](ADR-155-api-contract-testing.md) — API Contract Testing.** Contract-Tests zwischen iil-Packages und Consumers. *Fokus: API-Bruch ist CI-Fail, nicht Prod-Surprise.*
+- **[ADR-179](ADR-179-postgresql-only-testing.md) — PostgreSQL-Only Testing.** SQLite verboten in Tests, immer Postgres. *Fokus: keine Test/Prod-Divergenz bei DB-Verhalten.*
+- **[ADR-184](ADR-184-contract-testing-strategy.md) — Three-Layer Contract Testing Strategy.** Contracts auf allen Function/Method-Call-Layern. *Fokus: jeder API-Aufruf hat einen verifizierbaren Vertrag.*
+- **[ADR-191](ADR-191-adopt-iil-codeguard-library-first.md) — iil-codeguard.** Library-First Code Compliance Tooling. *Fokus: Compliance-Checks als versionierte Lib, nicht als Repo-lokales Script.*
+
+---
+
+## 11. Hubs, Domains & Produkte
+
+**Konzept-Strang:** Konkrete Produkt-Hubs mit ADR-dokumentierter Architektur. Jeder Hub setzt auf die Foundation auf.
+
+- **[ADR-030](ADR-030-odoo-management-app.md) — Erste Odoo Management-App.** Dual-Framework-Governance Django+Odoo. *Fokus: Odoo als Backend für Business-Operations, integriert via API.*
+- **[ADR-062](ADR-062-central-billing-service.md) — Zentraler Billing-Service.** billing-hub als Plattform-Komponente. *Fokus: ein Billing, alle Hubs.*
+- **[ADR-099](ADR-099-devhub-release-management-ui.md) — dev-hub Release Management UI.** PyPI-Publishing + GitHub-Tag-Workflow via devhub.iil.pet. *Fokus: Releases ohne `twine`/CLI-Magie.*
+- **[ADR-103](ADR-103-ausschreibungs-hub-architektur-v3.md) — ausschreibungs-hub.** KI-gestützte Ausschreibungs- und Angebotsplattform. *Fokus: Tender-Process automatisieren.*
+- **[ADR-115](ADR-115-grafana-agent-controlling-dashboard.md) — Grafana Agent Controlling Dashboard.** Agent-Metrics in Grafana. *Fokus: Agents sind beobachtbar, ihre Kosten/Quality messbar.*
+- **[ADR-118](ADR-118-platform-store-billing-hub-user-registration.md) — billing-hub als Platform Store.** User-Registration + Module-Buchung + Stripe. *Fokus: User-Self-Service vom ersten Klick bis zur Rechnung.*
+- **[ADR-119](ADR-119-authored-content-pipeline-neutral-lore-to-style.md) — AuthoredContent Pipeline (Lore → Style).** Neutral-Lore wird in Autoren-Stil transformiert. *Fokus: Content-Generierung trennt "Was" (Lore) von "Wie" (Stil).*
+- **[ADR-121](ADR-121-iil-outlinefw-story-outline-framework.md) — iil-outlinefw Story-Outline-Framework.** Strukturierte Story-Outlines als Daten. *Fokus: Outlines wiederverwendbar zwischen Hubs (weltenhub, writing-hub).*
+- **[ADR-140](ADR-140-learn-hub.md) — Learn-Hub.** Zentrales Learning Management Hub. *Fokus: LMS als eigenständiger Hub auf iil-learnfw.*
+- **[ADR-143](ADR-143-knowledge-hub-outline-integration.md) — Knowledge-Hub.** Outline-Wiki + research-hub Integration. *Fokus: Wiki ist die menschliche Lese-Oberfläche der Knowledge-Plattform.*
+- **[ADR-144](ADR-144-doc-hub-paperless-ngx.md) — doc-hub (Paperless-ngx).** Paperless-ngx als DMS für Briefpost/PDF. *Fokus: papierne Dokumente digitalisiert + durchsuchbar.*
+- **[ADR-145](ADR-145-knowledge-management-cascade-outline.md) — Cascade ↔ Outline Anti-Knowledge-Drain.** Agent-Lernen wird automatisch nach Outline gespiegelt. *Fokus: Wissen, das ein Agent gewinnt, bleibt der Plattform erhalten.*
+- **[ADR-148](ADR-148-recruiting-hub-architecture.md) — Recruiting Hub.** Multi-Tenant SaaS-Architektur für Recruiting. *Fokus: Recruiting-Hub konkreter Anwendungsfall der Multi-Tenancy.*
+- **[ADR-149](ADR-149-dms-hub-dvelop-platform-service.md) — dms-hub (d.velop Cloud DMS).** d.velop als Plattform-DMS für reglementierte Domains. *Fokus: Compliance-konformes Dokumentenarchiv (vs. Paperless für Brief-Post).*
+- **[ADR-151](ADR-151-recruiting-workflow-e2e.md) — End-to-End Recruiting Workflow.** LinkedIn Recruiter × Hunter CRM × Recruiting Hub. *Fokus: drei Systeme zu einem Workflow verbinden.*
+- **[ADR-153](ADR-153-tax-hub-saas-architecture.md) — tax-hub SaaS-Architektur.** Modul-basierte SaaS für Steuer-Domain. *Fokus: buchbare Steuer-Module pro Mandant.*
+- **[ADR-168](ADR-168-onboarding-platform-architecture.md) — Onboarding-Platform.** Separates Repo auf coach-hub Primitiven + billing-hub Stripe-Pattern. *Fokus: Onboarding-Flow als Produkt, nicht als Setup-Page.*
+- **[ADR-189](ADR-189-sysml-gaphor-ttz-hub.md) — SysML/Gaphor für ttz-hub.** SysML-Modellierung mit Gaphor für Engineering-Hub. *Fokus: Engineering-Artefakte als Modell, nicht als Diagramm-PNG.*
+
+---
+
+## 12. Work Management & Operationen
+
+**Konzept-Strang:** Wie Arbeit getrackt wird (GitHub Issues SSOT), wie durable Workflows laufen (Temporal), wie Bugs/Migration-Konflikte gehandhabt werden.
+
+- **[ADR-055](ADR-055-cross-app-bug-management.md) — Cross-App Bug & Feature Management.** Issues, die mehrere Hubs betreffen, an einer Stelle. *Fokus: Bugs verlieren sich nicht zwischen Repos.*
+- **[ADR-067](ADR-067-work-management-strategy.md) — GitHub Issues + Projects als SSOT.** Ein Tool für Human + AI Work-Tracking. *Fokus: keine Jira/Linear-Drift parallel zu GitHub.*
+- **[ADR-079](ADR-079-temporal-workflow-engine.md) — Temporal Self-Hosted.** Durable-Workflow-Engine für long-running Tasks. *Fokus: Workflows überleben Server-Restarts, Retries werden Engine-managed.*
+- **[ADR-094](ADR-094-django-migration-conflict-resolution.md) — Django Migration Conflict Resolution.** Pattern für Migration-Konflikte bei parallelen Branches. *Fokus: Multi-Agent-Branches kollidieren oft auf Migrations — definierter Resolver-Flow.*
+
+---
+
+## 13. Dokumentation
+
+**Konzept-Strang:** **dev-hub als Unified Documentation Portal**, DIATAXIS-Struktur, AI-generierte Reference-Docs.
+
+- **[ADR-046](ADR-046-docs-hygiene.md) — Documentation Governance.** Hygiene + DIATAXIS + Docs-Agent. *Fokus: Doku ist gepflegt, weil ein Agent + ein Gate dafür sorgt.*
+- **[ADR-158](ADR-158-unified-documentation-architecture.md) — dev-hub als Unified Documentation Portal.** Audience Navigator + AI-Generated Reference Docs. *Fokus: ein Portal für alle Hub-Dokus, AI hält Reference frisch.*
+
+---
+
+## Wie ein Architekt diese Übersicht nutzt
+
+1. **Top-Down Einstieg:** Cluster 1 (Governance) + Cluster 2 (Tenancy) + Cluster 4 (Deployment) — das ist das Skelett. Wer das versteht, versteht 70 % der Plattform.
+2. **Bottom-Up Spezifika:** Wenn der Architekt ein Feature einbringt, prüft er Cluster 7 (Agent-Plattform), 8 (Search/RAG) oder 9 (Shared Packages) auf "gibt es das schon?".
+3. **Hub-Bau:** Wer einen neuen Hub anlegt, liest Cluster 11 (Beispiele anderer Hubs) + Cluster 2, 3, 4, 10 (Pflicht-Standards).
+4. **Drift-Check:** Cluster 10 (Quality Gates) + ADR-059 (Drift Detector) + ADR-193 (Deployment Compliance Audit) sagen, wie Konsistenz erzwungen wird.
+
+> **Wichtigste Querverweise:**
+> - **022 → 071 → 138 → 174 → 190 → 191 → 192 → 193**: Die Compliance-Kette — Standard, Tooling, Tracking, Enforcement, Scanner, Audit.
+> - **007 → 035 → 072 → 109 → 137 → 142 → 161**: Die Tenancy-Kette — von der Ur-Entscheidung bis zu RLS und SSO.
+> - **021 → 056 → 075 → 120 → 156 → 157 → 164 → 166 → 185**: Die Deployment-Kette — von "ein Hub" bis zum gated Auto-Deploy-Agent.
+> - **066 → 070 → 080 → 081 → 082 → 086 → 107 → 108 → 177 → 186**: Die Agent-Plattform-Evolution — vom Squad-Konzept zu spezialisierten headless Pipelines.
+> - **087 → 170 → 171 → 172 → 173 → 187 → 188**: Die RAG-Konsolidierungs-Kette — von Hybrid-Suche zum unified Vector Store.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -1,7 +1,7 @@
 # Architecture Decision Records -- Index
 
-> **Last updated:** 2026-05-08
-> **Next free ADR number:** 189
+> **Last updated:** 2026-05-11
+> **Next free ADR number:** 194
 
 ## Legend
 

--- a/docs/adr/reviews/ADR-194-review.md
+++ b/docs/adr/reviews/ADR-194-review.md
@@ -1,0 +1,219 @@
+# ADR-194 Review: Universal LLM Call Logging via Gateway Choke-Point
+
+**Reviewer**: Claude Opus 4.7 (Sparring Review)
+**Datum**: 2026-05-11
+**ADR**: ADR-194 — Universal LLM Call Logging via Gateway Choke-Point (v1.0, proposed)
+**Reviewer-Note**: Sparring durch die LLM-Instanz, die den ADR selbst entworfen hat — bewusst adversarial, sucht Schwächen im eigenen Vorschlag.
+**Gesamturteil**: ⚠ **REVISIONS REQUIRED** — 1 Blocker, 2 Kritisch, 4 Hoch. Architektonische Richtung stimmt, aber drei substanzielle Lücken (Auth-Modell, Dedup-Story P2, Fallback bei Gateway-Ausfall) müssen vor Acceptance geschlossen werden.
+
+---
+
+## 1. Review-Tabelle
+
+| # | Befund | Severity | Bereich |
+|---|--------|----------|---------|
+| B-01 | Auth-Modell beschreibt **zwei widersprüchliche Produkte** in einem Satz: "validates locally if we issue our own keys, or forwards verbatim for BYOK". Das sind unterschiedliche Finanz- und Sicherheitsmodelle — nicht beide gleichzeitig | **BLOCKER** | Architektur/Security |
+| K-01 | Dedup-Story für **P2-Übergangsphase ist kaputt**: Stop-Hook schreibt `source='claude_code'`, Gateway schreibt `source='llm_gateway'`. UNIQUE INDEX `(source, request_id)` greift nicht → 4 Wochen lang doppelt erfasste Kosten in Dashboard | **KRITISCH** | Correctness |
+| K-02 | Consequence "Audit trail — Sec/legal can inspect prompts + responses centrally" **widerspricht Non-Goal** "Token-level prompt inspection / DLP". Eines davon muss raus | **KRITISCH** | Konsistenz |
+| H-01 | Streaming-Passthrough mit Usage-Extraktion in **3 Tagen** ist zu knapp kalkuliert. Anthropic-SSE hat 7 Event-Typen; `input_tokens` kommt in `message_start`, `output_tokens` im `message_delta`; gleichzeitig muss byte-faithful weitergestreamt werden → Realistisch 5–7 Tage | **HOCH** | Effort |
+| H-02 | Phase **P3 Fallback unvollständig**: nach Entfernung des `aifw.service` INSERT-Pfads ist bei Gateway-Ausfall weder LLM-Call möglich noch logging-Fallback dokumentiert | **HOCH** | Robustheit |
+| H-03 | Latenz-Claim "+30–50 ms p95" **unbelegt**. Vor Acceptance: P0-Messung gegen prod-Anthropic-Endpoint vs prod-Gateway-Endpoint, sonst sind die Negative-Consequences fiktional | **HOCH** | Methodik |
+| H-04 | Drift-Check **LLM-002 ist nicht enforce-bar**: Workstation `~/.bashrc` ist nicht im VCS, CI sieht das nicht. Entweder droppen oder durch `claude doctor`-style Local-Check ersetzen | **HOCH** | Compliance |
+| M-01 | Headless-CLI-Pfad fuzzy: "logging via gateway preferred when CLI honors ANTHROPIC_BASE_URL; fallback remains bridge.py" → **gleiches Dedup-Problem wie K-01** für `headless.claude` vs `llm_gateway` | **MEDIUM** | Correctness |
+| M-02 | Cache-Pricing-Multipliers "1.25x/2x/0.1x" **ohne Quellenangabe**. Per Anthropic-Pricing 2026-05 korrekt, aber ADR muss zitieren oder Test mit gepinntem Snapshot referenzieren | **MEDIUM** | Belege |
+| M-03 | Provider-Scope unklar: Decision Drivers nennt "Anthropic, OpenAI, OpenRouter, Cerebras". OpenRouter ist OAI-compatible (✓), Cerebras hat eigene API. Welche Provider in MVP, welche deferred? | **MEDIUM** | Scope |
+| M-04 | Inkonsistenz: Frontmatter listet **8 consumers**, Body sagt **"19 platform repos"**. Reconcile | **MEDIUM** | Frontmatter |
+| M-05 | HA-Plan "2 Replicas hinter nginx" → **Kosten und Ops-Aufwand nicht quantifiziert**. Falls Gateway nicht HA-betrieben wird, ist das ein zweiter Single-Point-of-Failure | **MEDIUM** | Betrieb |
+| M-06 | Phase **P5 Retirement** hat keinen klaren Gate-Kriterium: "after one billing cycle with zero discrepancy" — was misst "discrepancy", welche Toleranz, welcher Query? | **MEDIUM** | Betrieb |
+| N-01 | Effort-Schätzungen ohne Confidence-Intervall — 6.5 PT total ist plausibel, aber bei Streaming-Komplexität (H-01) liegt p90 wahrscheinlich näher bei 9–10 PT | **NIT** | Planung |
+
+---
+
+## 2. Detailbefunde
+
+### B-01: Auth-Modell ist zwei Produkte in einem Satz — BLOCKER
+
+**Zitat** (§ "Gateway extensions required", Punkt 3):
+> "gateway accepts the user's `x-api-key` header, validates it locally if we issue our own keys, **or** forwards verbatim for BYOK. Keys are not stored beyond a salted hash for attribution."
+
+**Problem**: Das sind zwei grundverschiedene Designs:
+
+| Variante A: Eigene Keys | Variante B: BYOK-Passthrough |
+|---|---|
+| Wir kaufen Anthropic-Credits; User kriegen interne Keys mit Quota | User bringt eigenen Anthropic-Key, wir zahlen nichts |
+| Attribution per User-Key trivial | Attribution nur per `source` möglich; Hashing wozu? |
+| Wir können Rate-Limits/Budgets pro User erzwingen (ADR-116 anwendbar) | Quotas/Limits liegen bei Anthropic des Users |
+| Finanz-Risiko: wir haften für jeden Token | Finanz-Risiko: nur Infra |
+| Security-Audit: wir lagern Anthropic-Keys | Security: wir leiten User-Keys durch, müssen sie nicht speichern |
+
+Beide gleichzeitig anzubieten verdoppelt die Komplexität des Gateways und macht die ADR-116-Budget-Story unklar (welcher Budget greift bei BYOK-User der mit eigenem Geld zahlt?).
+
+**Fix**: ADR muss **eine** Variante wählen. Empfehlung: Variante A (eigene Keys) — passt zu ADR-115/116 Budget-Konzept, klare Attribution, klare Finanzlage. BYOK kann als zukünftiger ADR separat behandelt werden. Falls B gewählt: ADR-116 Budget-Tracking explizit als "only for org-issued keys" annotieren.
+
+---
+
+### K-01: Dedup während P2-Übergangsphase ist kaputt — KRITISCH
+
+**Zitat** (Migrationsplan P2):
+> "Stop hook stays as defense-in-depth for 4 weeks; logs duplicate calls become a comparison check."
+
+Plus Risiko-Mitigation:
+> "Use `request_id` for global dedupe; add UNIQUE INDEX `(source, request_id)` to `llm_calls` as part of P1"
+
+**Problem**: Wenn Stop-Hook `source='claude_code'` schreibt und Gateway `source='llm_gateway'` (oder `claude_code` mit anderem Tag), erzeugt UNIQUE-Constraint **keinen Konflikt** — beide Rows landen in der Tabelle. 4 Wochen lang zeigt das Dashboard ~2× Claude-Code-Cost. Das ist nicht "comparison check", das ist Müll-Datum.
+
+**Lösungsvarianten**:
+1. **Beide Writer schreiben denselben `source`** (z.B. `claude_code`), UNIQUE Index greift, doppelter Eintrag wird verworfen.
+2. **Hook deaktiviert sich**, wenn `ANTHROPIC_BASE_URL` gesetzt ist → Gateway ist single Source, Hook nur als Fallback bei `unset`.
+3. **Comparison-View**: Hook schreibt in eine Shadow-Tabelle `llm_calls_shadow`, nicht ins Haupt-Set; Cron-Job diffed nightly.
+
+**Fix**: ADR muss eine Variante wählen und die UNIQUE-Constraint-Definition mit dem Migrationsplan konsistent machen. Empfehlung: Variante 2 (Hook self-disables) — sauberster Cutover, kein Drift-Risiko.
+
+Gleiches Problem in M-01 für Headless-CLI-Pfad.
+
+---
+
+### K-02: "Audit trail" widerspricht Non-Goal — KRITISCH
+
+**Zitat** (Consequences/Positive):
+> "Audit trail. Sec/legal can inspect prompts + responses centrally (with retention/redaction policies set in one place)."
+
+**Zitat** (Non-goals):
+> "Token-level prompt inspection / DLP. A future ADR may add prompt-content auditing in the gateway; this ADR limits scope to usage/cost."
+
+**Problem**: Wenn der Gateway nur `usage`/`cost` loggt, kann Sec/Legal **keine prompts/responses inspizieren**. Der Audit-Trail-Vorteil ist im aktuellen Scope eine Lüge.
+
+**Fix**: Entweder
+- (a) prompt/response-Storage in Scope nehmen (eigener § "Prompt Retention Policy"), oder
+- (b) Audit-Trail-Vorteil herunterziehen auf "usage/cost audit", Sec/Legal-Anspruch streichen.
+
+Empfehlung: (b) für v1.0 — Prompt-Storage ist DLP-/DSGVO-Thema und braucht eigenen ADR mit Legal-Review.
+
+---
+
+### H-01: Streaming-Effort unterkalkuliert — HOCH
+
+**Zitat** (P1):
+> "Gateway: add `/v1/messages` passthrough + streaming + cache pricing. 3 d"
+
+**Problem**: Anthropic-SSE-Streams emittieren in der Reihenfolge:
+1. `message_start` — enthält `usage.input_tokens` + `cache_creation_input_tokens` + `cache_read_input_tokens`
+2. `content_block_start`, `content_block_delta`, `content_block_stop` (×N)
+3. `message_delta` — enthält finale `usage.output_tokens`
+4. `message_stop`
+
+Der Gateway muss:
+- Stream-Events parsen WHILE byte-faithful streamt (Client darf keine Latenz spüren)
+- Usage aus zwei verschiedenen Events aggregieren
+- Bei Abbruch (Client disconnect, upstream-500) trotzdem partielle Usage loggen — sonst gehen Costs verloren
+- Tests gegen anthropic-sdk Test-Fixtures (Mock-Stream-Generator)
+
+Realistisch: **5–7 Tage**, nicht 3. Bei 3 Tagen kommt entweder schlechte Implementierung oder die Tests werden gekürzt.
+
+**Fix**: Effort auf 5–7 d hochsetzen oder Streaming explizit auf P1.1 (Folge-Phase) verlagern, P1 nur non-streaming.
+
+---
+
+### H-02: P3 Fallback bei Gateway-Ausfall unvollständig — HOCH
+
+**Zitat** (P3):
+> "remove `aifw.service` INSERT path; keep cost-computation utility for compatibility"
+
+Plus Risk-Mitigation:
+> "When the gateway is unreachable, the system should degrade to direct provider calls plus best-effort local logging — never block work."
+
+**Problem**: Wenn `aifw.service` den INSERT-Pfad ENTFERNT hat, gibt es bei Gateway-Down kein "best-effort local logging" mehr — der INSERT-Code existiert nicht mehr im Codebase.
+
+**Optionen**:
+1. INSERT-Pfad behalten als **disabled-by-default Fallback**, aktiviert wenn Gateway-Health-Check rot
+2. Bei Gateway-Down: direkt zu Anthropic, **gar nicht loggen** (akzeptierter Verlust)
+3. Bei Gateway-Down: Calls **blockieren** (Verfügbarkeits-Trade-off zu Gunsten Logging-Vollständigkeit)
+
+**Fix**: Eine Variante wählen und in P3 spezifizieren. Empfehlung: (1) — INSERT-Pfad als Notausgang bleibt in Codebase, mit `if not gateway_reachable():` Guard.
+
+---
+
+### H-03: Latenz-Claim unbelegt — HOCH
+
+**Zitat** (Negative Consequences):
+> "Latency tax. Adding one HTTP hop. Measure during P1; budget +30–50 ms p95."
+
+**Problem**: Das ist Schätzung, keine Messung. P1 misst — aber wenn die Messung +200 ms zeigt, ist Acceptance auf falscher Basis erfolgt.
+
+**Fix**: **Vor Acceptance**: 100-Call-Microbenchmark gegen `api.anthropic.com` direkt vs via `llm-gateway.iil.pet` (mit echtem TLS + Network-Path). Resultat in ADR aufnehmen, ggf. Decision revisiten.
+
+---
+
+### H-04: LLM-002 Drift-Check unenforce-bar — HOCH
+
+**Zitat** (Compliance/Drift Checks):
+> "LLM-002 (warning): Workstation shell profile missing `ANTHROPIC_BASE_URL` once P2 ships."
+
+**Problem**: Workstation-`~/.bashrc` ist nicht im Repo. CI kann das nicht prüfen. iil-codeguard (per ADR-191) ist library-first auf Repo-Code, nicht auf Workstation-Config.
+
+**Fix**: Entweder
+- droppen und durch Runtime-Check ersetzen (`claude doctor`-equivalent das beim Session-Start ANTHROPIC_BASE_URL prüft), oder
+- in versionsverwalteten dotfiles-Repo verschieben, dort von codeguard checken.
+
+---
+
+### M-01: Headless-CLI Dedup unklar — MEDIUM
+
+**Zitat** (Required changes):
+> "Same — these wrap CLIs we do not control. Logging via gateway is preferred when CLI honors `ANTHROPIC_BASE_URL`; fallback remains `bridge.py`"
+
+**Problem**: Gleiches Dedup-Problem wie K-01. Claude Code CLI honoriert `ANTHROPIC_BASE_URL`. Wenn `bridge.py` weiter post-hoc INSERTet UND Gateway loggt → doppelte Rows mit unterschiedlichem `source` (`headless.claude` vs `llm_gateway`).
+
+**Fix**: Headless-Pfad explizit klären — same self-disable Mechanism wie für Stop-Hook empfohlen.
+
+---
+
+### M-02 / M-03 / M-04 / M-05 / M-06
+
+Klein aber sammeln sich:
+- **M-02**: Pricing-Multipliers zitieren (Anthropic Pricing Page URL + Datum) oder Pricing-Test mit Snapshot.
+- **M-03**: Provider-Scope-Tabelle in P1 mit "MVP/Deferred"-Spalte.
+- **M-04**: Consumer-Liste sync (Frontmatter ≈ Body).
+- **M-05**: HA-Cost zumindest Größenordnung ("2× Container, ~€10/Monat, +0.5h Ops/Monat").
+- **M-06**: P5 Gate-Kriterium konkretisieren: "discrepancy" definieren (z.B. `|gateway_count − hook_count| / hook_count < 1% über 7 Tage`).
+
+---
+
+## 3. Was am ADR stark ist
+
+Damit der Review nicht nur Tadel ist:
+
+- **Problem ist quantifiziert**: 658 unsichtbare Calls = $125 in 4 Tagen ist ein harter Beleg, nicht Hypothese.
+- **Options A/B/C ehrlich**: insbesondere Option C (eBPF/Envoy) wird korrekt als unpragmatisch abgelehnt.
+- **Non-Goals explizit**: spart spätere Scope-Kämpfe.
+- **Migration in Phasen mit Feature-Flag (AIFW_USE_GATEWAY)**: Rollout-Risiko sauber gemanagt.
+- **Drift-Checks LLM-001/003 sind konkret und testbar**.
+- **Anknüpfung an ADR-178** ist sauber — kein paralleler Gateway, sondern Ausbau des bestehenden.
+
+---
+
+## 4. Empfohlenes Vorgehen
+
+1. **Pre-Acceptance** (½ Tag Aufwand):
+   - B-01: Auth-Modell festlegen (Empfehlung: Variante A — eigene Keys)
+   - K-01: Dedup-Strategie wählen (Empfehlung: Hook self-disables bei `ANTHROPIC_BASE_URL` gesetzt)
+   - K-02: Audit-Trail-Claim runterziehen oder Prompt-Storage in Scope nehmen
+   - H-02: P3-Fallback spezifizieren
+   - H-03: Latenz-Messung durchführen, Werte ins ADR
+
+2. **Acceptance** mit den Korrekturen → v1.1.
+
+3. **Bei v1.1**: M-01..M-06 in den gleichen Pass mit aufnehmen, kostet ~1h.
+
+4. **Verbleibendes Risiko nach v1.1**: hauptsächlich H-01 (Streaming-Effort) — fließt in Sprint-Planung, nicht ADR.
+
+---
+
+## 5. Tool-Bug-Notiz (separat)
+
+`mcp__orchestrator__review_adr` schlägt fehl mit:
+```
+litellm.BadRequestError: LLM Provider NOT provided. 
+You passed model=claude-3-5-sonnet-20241022
+```
+LiteLLM erwartet Provider-Prefix (`anthropic/claude-3-5-sonnet-20241022`). Fix in `mcp-hub/orchestrator_mcp/server.py` oder dem ADR-Review-Handler — Modell-String beim LLM-Call mit `anthropic/`-Prefix versehen. Ticket empfohlen.

--- a/docs/adr/reviews/ADR-195-review.md
+++ b/docs/adr/reviews/ADR-195-review.md
@@ -1,0 +1,298 @@
+# ADR-195 Review: LiteLLM-Proxy as Logging Engine + Anthropic Admin API as Truth Anchor
+
+**Reviewer**: Claude Opus 4.7 (Sparring Review)
+**Datum**: 2026-05-11
+**ADR**: ADR-195 — LiteLLM-Proxy as Engine + Admin API as Truth (v1.0, proposed)
+**Reviewer-Note**: Sparring durch dieselbe LLM-Instanz, die ADR-195 als Reaktion auf das ADR-194-Review entworfen hat. Bewusst adversarial gegen den eigenen Vorschlag. **Bias-Warnung**: Selbstreview hat strukturell schwächere Adversarialität als Cross-Review — finale Acceptance sollte einen unabhängigen menschlichen Reviewer (Achim) einschließen.
+**Gesamturteil**: ⚠ **REVISIONS REQUIRED** — 1 Blocker, 3 Kritisch, 4 Hoch. Architektonische Richtung ist deutlich gesünder als ADR-194, aber drei tragende Annahmen sind nicht validiert (LiteLLM-Callback-API, Per-Source-Key-Delivery, Provider-Symmetrie) und das "Sidecar überall" ist Ops-seitig zu optimistisch kalkuliert.
+
+---
+
+## 1. Review-Tabelle
+
+| # | Befund | Severity | Bereich |
+|---|--------|----------|---------|
+| B-01 | **Tragende Annahme nicht validiert**: ADR-195 baut ganze Pipeline auf LiteLLM `success_callback` — aber kein Probe-Test gegen LiteLLM zeigt, dass `cache_creation.ephemeral_5m_input_tokens`, `cache_creation.ephemeral_1h_input_tokens`, `cache_read_input_tokens` UND streaming-aggregierte Usage tatsächlich im Callback-Payload landen. Wenn nicht: P5 ist Reverse-Engineering, nicht 1 PT | **BLOCKER** | Architektur-Annahme |
+| K-01 | **Tool-Wahl ADR-fixiert, aber Spike erst in P4**: ADR sagt "LiteLLM oder Helicone, finale Wahl in P4". Falls Helicone gewählt → komplett anderer Callback-Mechanismus, andere Schema-Annahmen. Architektur-Entscheidung darf nicht *nach* ADR-Acceptance passieren | **KRITISCH** | Prozess |
+| K-02 | **Asymmetrische Provider-Coverage**: Truth-Anchor (Admin API) ist Anthropic-only. OpenAI/OpenRouter/Cerebras-Calls landen nur in LiteLLM-Callback ohne Reconcile. Wenn Callback dort einen Bug hat, fällt das nicht auf — kein Drift-Alarm möglich | **KRITISCH** | Coverage |
+| K-03 | **Per-Source-Key-Delivery ungelöst**: ADR listet 5 Keys, sagt aber nicht WIE sie an Cascade-BYOK (Windsurf-UI?), Ad-hoc-Scripts (`.envrc`? PyPI-Lib?), Headless-CI-Runner (Secrets-Injection?) verteilt werden. Operativer Kern fehlt | **KRITISCH** | Betrieb |
+| H-01 | **P4-Effort 0.5 d für Sidecar auf 3 Host-Typen ist optimistisch**: Workstation (Docker), Dev/Prod-Hetzner (systemd), Headless-CI-Runner (?). Realistisch 1.5–2 d inkl. systemd-Unit, Health-Check, Auto-Restart, Update-Mechanismus | **HOCH** | Effort |
+| H-02 | **Stop-Hook-Self-Disable kann Silent-Gap erzeugen**: Wenn `ANTHROPIC_BASE_URL` gesetzt aber Sidecar tot → Hook feuert nicht, Anthropic-Call schlägt fehl, Logging ebenfalls aus. Schlechter als heutiger Stand (Hook würde mindestens Transcript loggen) | **HOCH** | Robustheit |
+| H-03 | **Reconcile-Threshold "1 % über 7 Tage" undefiniert**: Über was 1 %? Tokens? USD? Pro Key? Aggregat? Pro Modell? Welcher Query? Gleiche Kritik wie M-06 im ADR-194-Review — nicht gefixt, nur portiert | **HOCH** | Spezifikation |
+| H-04 | **Admin-Key-Rotation/Access nicht spezifiziert**: Admin-Key ist Crown-Jewel (kann jeden Workspace-Key listen + Spend lesen). ADR sagt "store with same care as production secrets" — das ist Versprechen, kein Mechanismus. Rotation-Intervall? Audit-Log-Pflicht? Single-Laptop-Verlust-Szenario? | **HOCH** | Security |
+| M-01 | **`action_code`-Attribution für Ad-hoc-Scripts unverändert**: Header `x-litellm-metadata` setzt instrumentierter Code. Direkter `import anthropic` ohne Wrapping setzt nichts. ADR claimt verbesserte Attribution — gilt nur für aifw/agent_team, also Status quo | **MEDIUM** | Claim-Realität |
+| M-02 | **`source='litellm'` kollidiert mit ADR-115-Taxonomie**: Bestehende Dashboard-Queries filtern auf `source IN ('aifw', 'agent_team', 'claude_code', ...)`. Neuer Wert `litellm` ist erstens generisch (welcher Caller?), zweitens bricht Filter | **MEDIUM** | Schema-Konsistenz |
+| M-03 | **Bootstrap-Paradox nur teilweise gelöst**: Sidecar auf Workstation läuft auch bei Prod-Down — aber Claude Code → MCP-Hub (prod) → kaputt. Path "CC nutzt lokalen MCP-Hub" nicht spezifiziert | **MEDIUM** | Architektur |
+| M-04 | **ADR-116-Replacement-Claim überzogen**: "Anthropic-side spend limits replace most of ADR-116" — ADR-116 ist Dynamic Model Router mit Budget-aware Routing, nicht nur Spend-Cap. Routing-Logik bleibt komplett erforderlich | **MEDIUM** | Claim-Genauigkeit |
+| M-05 | **Headless-CLI (`bridge.py`) Dedup unklar**: Gleiche Lücke wie M-01 in ADR-194-Review. Wenn Headless-Claude-CLI `ANTHROPIC_BASE_URL` honoriert: doppelter Eintrag. Wenn nicht: bridge.py + Admin API = doppelt. Strategie fehlt | **MEDIUM** | Correctness |
+| M-06 | **Admin-API-Rate-Limit unverifiziert**: ADR sagt "well under limits" ohne Zahl. Mehrere Workspaces × häufiges Polling × Beta-Header → reale Limits prüfen vor Acceptance | **MEDIUM** | Belege |
+| M-07 | **`llm_calls_reconcile`-Schema fehlt**: Neue Tabelle mentioned, kein DDL. Storage-Growth-Schätzung? Retention? Unique-Constraint? | **MEDIUM** | Schema |
+| N-01 | **Acceptance-Gate undefiniert**: "implementation begins after acceptance" — wer akzeptiert, welches Quorum, welcher Review-Gate? Selbstreview reicht nicht (siehe Reviewer-Note oben) | **NIT** | Prozess |
+| N-02 | **5 Keys vs. Workspaces-Frage offen gelassen**: "Open Questions #2" — aber Phase P3 macht es trotzdem. Reihenfolge: erst entscheiden, dann ausführen | **NIT** | Reihenfolge |
+
+---
+
+## 2. Detailbefunde
+
+### B-01: LiteLLM-Callback-Payload nicht validiert — BLOCKER
+
+**Zitat** (Architektur):
+> "success_callback → eurer Callback-Code → INSERT into llm_calls"
+
+Plus P5:
+> "Write callback module: reads LiteLLM `success_callback` payload → applies `pricing.py` → INSERT into `llm_calls`. 1 d"
+
+**Problem**: Die *gesamte* Per-Call-Pipeline hängt davon ab, dass LiteLLM im `success_callback` folgende Felder mit korrekten Werten liefert:
+
+| Erforderlich | LiteLLM liefert? |
+|---|---|
+| `uncached_input_tokens` | wahrscheinlich (`prompt_tokens` Mapping) |
+| `output_tokens` | wahrscheinlich (`completion_tokens`) |
+| `cache_creation.ephemeral_5m_input_tokens` | **unklar** — LiteLLM normalisiert Anthropic-spezifisch? |
+| `cache_creation.ephemeral_1h_input_tokens` | **unklar** — 1h-Tier ist neu (2026) |
+| `cache_read_input_tokens` | wahrscheinlich |
+| Streaming-aggregierte Usage (final delta) | **unklar** — LiteLLM hat hier historisch Bugs |
+| Anthropic `request_id` für Reconcile | **unklar** |
+
+Wenn auch nur eines der `cache_*`-Felder fehlt: Pricing-Math ist falsch (ADR-115-Schema hat eigene Spalten dafür), und Reconcile-Drift-Alarm feuert ständig.
+
+**Fix**: **Vor Acceptance**: 30-Zeilen-Probe-Test gegen lokalen LiteLLM-Proxy mit echtem Anthropic-Call inkl. Cache-Hit und Streaming. Payload-Schema dokumentieren. Falls Felder fehlen: Strategie (LiteLLM-Plugin? Eigener HTTP-Middleware? Fork?) ins ADR — ändert Effort-Schätzung von P5 signifikant.
+
+---
+
+### K-01: Tool-Wahl nach ADR-Acceptance ist Anti-Pattern — KRITISCH
+
+**Zitat** (Open Questions):
+> "LiteLLM-Proxy vs Helicone — final choice deferred to P4 spike (½ day)."
+
+Plus Architektur-Diagramm zeigt explizit "Local LiteLLM-Proxy sidecar".
+
+**Problem**: ADR-195's Diagram, P4-P5-Aufwand, Callback-Modell, Header-Konvention (`x-litellm-metadata`) sind allesamt LiteLLM-shaped. Wenn der P4-Spike Helicone wählt:
+
+- Helicone-Callback-Architektur ist anders (Edge-Functions + Webhooks, kein Python-Callback)
+- Header-Convention ist `helicone-property-*`
+- Self-Hosting-Footprint ist um Größenordnung größer (ClickHouse + Kafka)
+- P5 (Callback-Modul) muss komplett neu geschrieben werden
+
+Das ist nicht "Open Question", das ist **die Kern-Entscheidung des ADRs**.
+
+**Fix**: Entweder
+- (a) ADR auf LiteLLM committen, Helicone aus Optionen rauswerfen (Belege: bereits in `mcp-hub`-Python-Deps, leichtester Footprint, OpenAI-Adapter-Übersetzer matched unsere Multi-Provider-Story), oder
+- (b) ADR-195 in zwei ADRs splitten: ADR-195a "Engine-Spike" + ADR-195b "Final architecture after spike".
+
+Empfehlung: (a) — entscheide jetzt, dokumentiere LiteLLM-Wahl in ADR-195.
+
+---
+
+### K-02: Provider-Asymmetrie bei Truth-Anchor — KRITISCH
+
+**Zitat** (Architektur, Reconcile-Komponente):
+> "Anthropic Admin API → llm_calls_reconcile → diff vs llm_calls"
+
+**Problem**: Admin API ist **Anthropic-only**. Drift-Detection für OpenAI / OpenRouter / Cerebras-Calls existiert in ADR-195 nicht. Das heißt:
+
+- OpenAI-Spend via LiteLLM-Callback → nur LiteLLM-Wahrheit, kein Cross-Check
+- Wenn LiteLLM dort einen Streaming-Bug hat → unerkannt
+- "ADR-195 löst das Truth-Source-Problem" gilt nur für Anthropic
+
+OpenAI hat seit 2024 eine **Usage-API** (`/v1/organizations/{org_id}/usage`) mit ähnlicher Funktionalität. ADR-195 erwähnt sie nicht.
+
+**Fix**: ADR-195 muss entweder
+- (a) Scope auf "Anthropic-only" reduzieren, OpenAI als separates Folge-ADR, oder
+- (b) OpenAI Usage API in den Reconcile-Job aufnehmen (zusätzlicher Effort ~0.5 PT).
+
+Empfehlung: (b) — der Reconcile-Job ist eh ein Poller; einen zweiten Provider hinzuzufügen kostet wenig, und Symmetrie ist Eigenwert. Wenn (a): explizit dokumentieren, dass für non-Anthropic-Provider "trust LiteLLM" gilt.
+
+---
+
+### K-03: Per-Source-Key-Delivery ist Operationale Lücke — KRITISCH
+
+**Zitat** (P3):
+> "Create per-source Anthropic keys + set Anthropic-side spend limits. Inventory which keys land where."
+
+**Problem**: "Inventory which keys land where" ist Hand-Wave. Konkret:
+
+| Source | Key-Bezug heute | ADR-195 spezifiziert? |
+|---|---|---|
+| `aifw` Service auf Prod | `~/.secrets/anthropic_api_key` (gemeinsam) | ❌ wie kommt `key_aifw` exklusiv dahin? |
+| Claude Code Workstation | Anthropic Console Login (OAuth) | ❌ Workstation hat schon Key über CC-Auth — soll der ersetzt werden? |
+| Cascade BYOK in Windsurf-App | Windsurf-UI-Setting (nicht im Repo) | ❌ wer setzt das, wie wird Drift verhindert? |
+| Ad-hoc Python Scripts | `import anthropic; client = Anthropic()` liest `ANTHROPIC_API_KEY` env | ❌ wer setzt env zu `key_scripts`? |
+| Headless-CI-Runner (GitHub Actions) | Repo-Secret | ❌ pro Repo welcher Key? |
+| `agent_team` MCP auf Prod | `~/.secrets/anthropic_api_key` | ❌ separater Key? |
+
+ADR-194-Review-H-04 hat die selbe Klasse Problem ("Workstation `.bashrc` nicht enforce-bar") als BLOCKER kritisiert. ADR-195 portiert genau dieses Problem auf 5 Keys × 3 Host-Typen.
+
+**Fix**: ADR muss konkrete Key-Delivery-Strategie pro Source spezifizieren:
+- Workstation: dotfiles-Repo unter Version-Control, `direnv`-basierte Pro-Repo-Overrides
+- Server: `~/.secrets/`-Subfolder pro Service + systemd `EnvironmentFile=`
+- Windsurf: nicht enforce-bar → akzeptieren, Drift-Detection via Admin-API-`group_by=api_key_id` zeigt falsche Keys
+- CI: `gh secret set` pro Repo, Sync-Script
+
+Ohne diese Tabelle ist P3 = wishful thinking.
+
+---
+
+### H-01: P4-Sidecar-Effort optimistisch — HOCH
+
+**Zitat** (P4):
+> "Deploy LiteLLM-Proxy as sidecar on workstation + dev + prod (Docker compose). 0.5 d"
+
+**Problem**: 0.5 d für drei Deployment-Targets ist nur realistisch wenn alles glatt läuft. Realität:
+
+- **Workstation**: Docker laufen lassen, Port 4000 frei, Auto-Start beim Boot, Log-Rotation, Update-Mechanismus
+- **Dev/Prod Hetzner**: systemd-Unit, EnvironmentFile mit Keys, Health-Check-Endpoint, restart-on-failure, Monitoring-Integration (existierender Grafana-Stack)
+- **Headless-CI-Runner**: Sidecar pro Job oder Shared-Container? Wenn shared: Auth pro Job. Wenn pro Job: Cold-Start-Kosten.
+- **Konfiguration**: LiteLLM `proxy_config.yaml` ins Repo, mit Substitutionen pro Host
+- **Erste-Tag-Bugs**: Streaming-Edge-Cases, TLS-Termination, Connection-Pooling
+
+Realistisch: **1.5–2 d**. Bei 0.5 d wird's halbgar oder Tests werden gekürzt.
+
+**Fix**: P4 auf 1.5 d erhöhen oder explizit "Headless-CI-Runner" auf P-N (later) schieben.
+
+---
+
+### H-02: Stop-Hook-Self-Disable erzeugt Silent-Gap — HOCH
+
+**Zitat** (P4):
+> "Stop hook stays active as DEFENSE-IN-DEPTH but self-disables when `ANTHROPIC_BASE_URL` is set"
+
+**Problem**: Scenarien:
+- ✅ Normal: ENV gesetzt + Sidecar läuft → LiteLLM loggt, Hook still
+- ❌ ENV gesetzt + Sidecar TOT → Anthropic-Call schlägt fehl, Hook trotzdem still (kein Transcript-Logging mehr), User merkt's spät
+- ❌ ENV gesetzt + Sidecar antwortet aber Callback bricht silent → kein Log, Hook still
+
+Heutiger Status quo: Hook *immer* aktiv, Transcript wird *immer* geschrieben (auch wenn API-Call fehlschlägt — Transcript zeigt Error). ADR-195 macht das schlechter.
+
+**Fix**: Hook-Self-Disable-Logik präziser: Hook deaktiviert sich nur wenn (a) ENV gesetzt UND (b) Sidecar-Health-Check innerhalb der letzten 60s grün UND (c) Callback-Liveness-Beacon (Counter in `llm_calls_reconcile`) erhöht sich. Sonst: Hook bleibt aktiv, schreibt mit `source='claude_code_fallback'`, Reconcile-Job dedupliziert per `request_id` falls Anthropic-Response erhalten.
+
+Alternative: Hook bleibt **immer** aktiv, schreibt in Shadow-Tabelle `llm_calls_shadow`. Reconcile vergleicht beide. Kein Silent-Gap-Risiko. Kosten: Shadow-Tabelle Storage.
+
+---
+
+### H-03: Reconcile-Threshold undefiniert (M-06 aus ADR-194 nicht gefixt) — HOCH
+
+**Zitat** (Compliance/Drift Checks):
+> "`LLM-003` (warning): `llm_calls_reconcile` drift > 1 % over 7 days → alert."
+
+**Problem**: Exakt dieselbe Kritik wie M-06 im ADR-194-Review — und auch hier nicht aufgelöst:
+- 1 % wovon? Token-Count? USD?
+- Aggregat über alle Sources? Pro Source? Pro Modell?
+- Welcher SQL-Query liefert "drift"?
+- Was zählt als "Alert" — Slack? Grafana-Panel rot? Pager?
+
+**Fix**: Konkrete Definition ins ADR:
+```sql
+-- Beispiel-Definition:
+WITH daily AS (
+  SELECT date_trunc('day', ts) AS d, source, model,
+         SUM(cost_usd) AS gw_cost
+  FROM llm_calls
+  WHERE source != 'admin_api'
+  GROUP BY 1,2,3
+),
+truth AS (
+  SELECT date_trunc('day', ts) AS d, model,
+         SUM(cost_usd) AS truth_cost
+  FROM llm_calls_reconcile
+  GROUP BY 1,2
+)
+SELECT d, model, gw_cost, truth_cost,
+       ABS(gw_cost - truth_cost) / NULLIF(truth_cost,0) AS drift
+FROM daily JOIN truth USING (d, model)
+WHERE drift > 0.01
+```
+Plus: Toleranz pro Modell (kleine Modelle mit niedrigen Kosten haben höhere Relative-Drift bei kleinen Absolute-Diffs — vielleicht 5 % unter $1/Tag).
+
+---
+
+### H-04: Admin-Key-Security unterspezifiziert — HOCH
+
+**Zitat** (Risks):
+> "Admin keys are highest privilege — store with same care as production secrets; rotation procedure documented"
+
+**Problem**: "Documented" ohne Mechanismus = nicht passiert. Konkrete Lücken:
+
+- **Rotation-Intervall**: 90 Tage? 30? Nie?
+- **Wer hat Zugriff**: Achim only? Service-Account auf welchem Host?
+- **Audit**: Anthropic-Console-Login-Logs reichen? Wir loggen lokale `cat` auf den Key nicht
+- **Compromise-Recovery**: Was tun wenn `~/shared/secrets-inbox/anthropic_admin_api_key` leaked? Revoke + neuer Key + alle laufenden Reconcile-Jobs swappen — Prozedur fehlt
+- **Single-Laptop-Risk**: Wenn der Key nur auf der Workstation liegt und Laptop verloren geht → einer kann Org-Spend einsehen und (laut Admin-API-Doku) Workspaces verwalten
+
+**Fix**: Konkrete Section "Admin Key Lifecycle":
+- Rotation: 90 Tage, Reminder via Cron
+- Storage: `~/shared/secrets-inbox/anthropic_admin_api_key` (chmod 600), ZUSÄTZLICH Bitwarden/1Password-Backup
+- Access: nur Reconcile-Job-Service-User, kein interaktiver Read
+- Revocation-Runbook: ein Markdown-File in `~/github/platform/docs/runbooks/`
+
+---
+
+### M-01..M-07
+
+Zusammengefasst, jeweils ein Satz Fix:
+
+- **M-01** (action_code für ad-hoc): ADR ehrlich umformulieren — `action_code`-Coverage bleibt ~Status quo, nur Cost-Coverage wird 100 %.
+- **M-02** (`source='litellm'`): Source-Wert sollte den *ursprünglichen* Caller reflektieren, nicht das Transport-Layer. Vorschlag: LiteLLM-Callback liest `x-source` Header → schreibt `source` entsprechend (`'cascade_byok'`, `'claude_code'`, etc.). `'litellm'` als Wert vermeiden.
+- **M-03** (Bootstrap-Paradox): Anmerkung im ADR — Sidecar löst nur den *Anthropic-Hop*, nicht MCP-Hub-Abhängigkeit. Für letzteres: separate Diskussion.
+- **M-04** (ADR-116-Claim): Formulierung weicher — "Anthropic-side spend limits ergänzen ADR-116 als Hard-Cap, ersetzen aber nicht die Routing-Logik".
+- **M-05** (bridge.py): Explizit gleiche Self-Disable-Logik wie für Stop-Hook (H-02 oben), oder Shadow-Tabelle.
+- **M-06** (Admin-API-Rate-Limit): Tatsächliche Zahl recherchieren (Anthropic Docs nennen 50 req/min für Admin-Endpoints — bei 24h-Buckets reicht 1 req/Tag, kein Problem; aber dokumentieren).
+- **M-07** (Reconcile-DDL): 10-Zeilen-Schema-Skizze ins ADR.
+
+---
+
+### N-01: Acceptance-Gate
+
+**Zitat**: "Implementation begins after acceptance."
+
+**Problem**: Nicht definiert wer akzeptiert. Bei ADR-194 hat dasselbe Vakuum existiert — Acceptance war implizit "Achim sagt ok". Für ein ADR dieser Tragweite (5 Migration-Phasen, 19 Repos indirekt) sollte explizit stehen: "Acceptance Gate = Achim + 1 Maintainer-Approval + B-01 vorab gelöst".
+
+---
+
+## 3. Was am ADR stark ist
+
+Damit der Review nicht nur Tadel ist:
+
+- **Layer-Ownership-Tabelle** ist konkret und testbar — "LiteLLM owns nothing of value" ist eine klare Aussage, gegen die später gemessen werden kann
+- **Anti-Lock-In-Regeln** (5 explizite Commitments) sind hands-on, nicht abstrakt
+- **Sidecar statt Central-Choke** löst SPoF und Bootstrap-Paradox sauber (wenn auch nicht zu 100 %, siehe M-03)
+- **Truth-Anchor-Idee** (Admin API als Cost-Source-of-Truth) ist architektonisch sauber: Anthropic = Ground Truth, alles andere = Approximation
+- **Hook-Self-Disable** behebt K-01 aus ADR-194-Review (Dedup-Strategie)
+- **Audit-Trail-Claim entfernt** behebt K-02 aus ADR-194-Review
+- **Reconcile-Job** ist die ehrliche Validierungsmechanik die in ADR-194 komplett fehlte
+- **2.5 PT vs 6.5 PT** mit datenbasierter C-Decision nach 3 Monaten ist Optionalitäts-Strategie, kein Sunk-Cost-Pfad
+- **Cascade-BYOK 80%→100%** ohne Agent-Cooperation ist konkrete Verbesserung gegenüber Status quo
+
+---
+
+## 4. Empfohlenes Vorgehen
+
+### Pre-Acceptance (ca. ½ Tag)
+
+1. **B-01 lösen**: 30-Zeilen-Probe-Test gegen lokales LiteLLM, Payload-Schema für Cache-Felder + Streaming verifizieren. Ergebnis ins ADR als § "LiteLLM Callback Validation".
+2. **K-01 fixen**: Auf LiteLLM committen, Helicone aus Architekturpfad streichen (kann als verworfene Alternative kurz dokumentiert bleiben).
+3. **K-02 fixen**: OpenAI Usage API in Reconcile-Scope aufnehmen oder Scope explizit auf Anthropic begrenzen.
+4. **K-03 fixen**: Key-Delivery-Tabelle pro Source.
+5. **H-04 fixen**: Admin-Key-Lifecycle-Section.
+
+### Acceptance mit den Korrekturen → v1.1
+
+### Bei v1.1
+
+- H-01..H-03 in selben Pass.
+- M-01..M-07 in 1 h.
+
+### Verbleibendes Risiko nach v1.1
+
+- Hauptsächlich operational (Sidecar-Stabilität, Key-Rotation-Disziplin) — fließt in Runbooks, nicht ADR.
+
+---
+
+## 5. Selbst-Reflexions-Notiz
+
+Dieser Review wurde vom selben Modell verfasst, das ADR-195 entworfen hat. Das ist strukturell ein schwächeres Sparring als ein unabhängiger Reviewer. Konkret riskiere ich:
+
+- **Blindspots gegen eigene Annahmen**: Z.B. "LiteLLM Callback liefert alle Felder" wurde im ADR als Selbstverständlichkeit angenommen — der B-01-Befund fühlte sich beim Review-Schreiben wie eine Entdeckung an, hätte aber schon beim ADR-Schreiben da sein müssen.
+- **Konsistenz-Pull**: Tendenz, das eigene Pattern zu verteidigen statt fundamentale Alternativen (z.B. "kein Logging, nur Admin API + Anthropic-Spend-Limits") nochmal zu prüfen.
+
+Empfehlung: **vor Acceptance** einmal eine zweite menschliche oder anderer-Modell-Stimme drüberlaufen lassen. Achim ist faktisch der einzige Entscheider — eine 15-min-Lese-Session mit konkreten Push-Backs ("warum nicht nur Admin API ohne LiteLLM?") wäre der wertvollste nächste Schritt.

--- a/docs/concepts/token-reduction-strategy.md
+++ b/docs/concepts/token-reduction-strategy.md
@@ -1,0 +1,178 @@
+---
+title: Token-Reduction Strategy
+date: 2026-05-11
+author: Achim Dehnert
+status: draft
+context: Max-Plan-Quota schonen, vermeidbare Opus-Last reduzieren
+data_basis: llm_calls (1123 calls / 7d, claude_code source)
+---
+
+# Konzept: Token-Verbrauch reduzieren
+
+## 1. Truth-Source-Klärung (kritisch)
+
+| Was wir messen | Was wir zahlen | Quelle |
+|---|---|---|
+| `cost_usd` in `llm_calls` (~$260/Tag heute) | **$0** zusätzlich — Max-Plan-Flatrate | API-Pricing × Token-Counts |
+| Per-Turn-Tokens (Opus, Sonnet) | Verbrauchen **Max-Plan-Quota** | Anthropic Console (`claude.ai/settings/usage`) |
+| OpenAI/OpenRouter via `task_pipeline` | **Real-paid** | Token-Counts × API-Preis |
+
+**Wichtig**: Anthropic Admin API zeigt **nur API-Workspace-Calls**, nicht Max-Plan-CC-Traffic. Quota-Visibility nur via `claude.ai/settings/usage` (kein API-Endpoint). Echte-$-Visibility via Admin-API für `task_pipeline`/`agent_team`/`aifw`.
+
+## 2. Was die Daten zeigen (letzte 7 Tage)
+
+### Pro-Turn-Verteilung (Claude Code)
+
+| Perzentil | Tokens |
+|---|---|
+| p50 | 84,845 |
+| p90 | 198,872 |
+| p99 | 347,166 |
+| max | 370,185 |
+
+**Median-Turn = 85k Tokens.** Die Hälfte aller Turns ist groß.
+
+### Top-Sessions nach Verbrauch
+
+| Session | Turns | Ø Tok/Turn | Total Tok | Notional $ |
+|---|---|---|---|---|
+| `cc-2132b232` (jetzt) | 193 | 217k | **42.0M** | $90.63 |
+| `cc-41d3a1c2` | 127 | 100k | 12.7M | $29.98 |
+| `cc-5dae04fd` | 107 | 83k | 8.8M | $18.55 |
+| `cc-37b8f513` | 80 | 108k | 8.7M | $26.32 |
+| `cc-92384772` | 82 | 105k | 8.6M | $23.35 |
+
+### Per-Turn-Wachstum (Beispiel `cc-2132b232`)
+
+```
+turn  1:  27k tokens
+turn 10:  63k
+turn 20:  86k
+turn 25: 111k
+turn 50: ~150k   (extrapoliert)
+turn100: ~250k   (extrapoliert)
+turn193: 343k    (real, letzter Turn)
+```
+
+**Konversation wächst um ~3–4k Tokens pro Turn.** Bei 200 Turns landet jeder Turn bei 300k+.
+
+### Overkill-Pattern
+
+| Klasse | Calls | Total Tok | Notional |
+|---|---|---|---|
+| **overkill** (out<500 tok, in>100k) | 244 | 37.4M | $77.56 |
+| maybe (out<500 tok, in>30k) | 223 | 14.6M | $46.19 |
+| fine | 437 | 53.0M | $165.33 |
+
+**22% aller Opus-Calls sind Overkill** — riesiger Input für winzige Antwort. Klassische "Was ist X?"-Fragen die ein Sonnet-Lookup auch geleistet hätte.
+
+### Cache-Hit-Rate
+
+`prompt_share = 0.99` über alle großen Sessions = **99% des Inputs ist Cache-Read** (0.1× Preis). Anthropic-Caching greift exzellent. Aber: Cache-Reads zählen voll zur Token-Quota auch wenn sie billig sind.
+
+## 3. Ursachenanalyse (priorisiert)
+
+| Ursache | Anteil am Tokenverbrauch | Mechanismus |
+|---|---|---|
+| **Lange Sessions ohne Reset** | ~60% | Konversation wächst linear, jeder Turn sendet bisherigen State |
+| **Overkill-Calls auf Opus** | ~22% | Trivial-Antwort auf Riesen-Context |
+| **Tool-Output-Akkumulation** | ~10% | grep/read-Output bleibt im Context, wird Turn-für-Turn re-gesendet |
+| **CLAUDE.md / Memory-Bloat** | ~5% | Pro-Repo CLAUDE.md + globale Memory wird in jedem Turn mitgeschickt |
+| **Echte Heavy-Reasoning** | ~3% | ADR-Review, komplexe Analyse — gerechtfertigter Opus-Einsatz |
+
+## 4. Hebel (priorisiert nach Wirkung × Aufwand)
+
+### H1 — Session-Discipline (höchster Impact, niedriger Aufwand)
+
+**Problem**: 193-Turn-Sessions im selben Topic (siehe `cc-2132b232` heute).
+**Maßnahme**:
+- **Neue Session** bei Themenwechsel — nicht "weiter im selben Chat"
+- Faustregel: nach 30 Turns prüfen ob Topic noch dasselbe ist; wenn nein → `Ctrl+L` (Clear) oder neue Session
+- `/clear` löscht Konversation, neue Session beginnt bei ~5k Tokens statt 200k+
+- Erwartete Reduktion: **50–70 %** auf Long-Tail-Sessions
+
+**Quantifizierung**: heute `cc-2132b232` = 42M Tokens. Bei 5 Sessions à 38 Turns statt 1 Session à 193 Turns: ~12M Tokens (= 71% Reduktion).
+
+### H2 — `/compact` periodisch (moderater Impact, kein Aufwand)
+
+**Problem**: Auch innerhalb sinnvoller Sessions wächst Context.
+**Maßnahme**:
+- Alle ~30 Turns oder bei Erreichen von ~100k Total-Context: `/compact`
+- CC erstellt eine Zusammenfassung, ersetzt frühere Turns
+- Erwartete Reduktion: **30–50 %** auf die Folge-Turns
+
+### H3 — Model-Switching pro Subtask (hoher Impact, manuell)
+
+**Problem**: Sonnet-Quota = **0%** genutzt, alles auf Opus.
+**Maßnahme**:
+- `/model sonnet` für: File-Lesen + Zusammenfassen, Tool-Glue, Status-Checks, Linting-Output
+- `/model haiku` für: einzelne Lookups, Boolean-Fragen, einfache Klassifikation
+- `/model opus` nur für: Reasoning-heavy (ADR-Analyse, Architektur, komplexer Code)
+- Erwartete Reduktion: **40–60 %** Opus-Quota-Last bei gleichem Output
+
+**Quantifizierung**: 244 Overkill-Calls × 200k Ø = 49M Tok → wenn auf Sonnet (3x cheaper): gleiche Token-Anzahl, aber **schont Opus-Quota komplett** und nutzt freie Sonnet-Quota.
+
+### H4 — `task_pipeline` als MCP-Tool (hoher Impact, bereits gebaut)
+
+**Problem**: Sub-Aufgaben (Listen, Audit, simple Code) laufen in Opus statt delegiert.
+**Maßnahme**:
+- CC ruft `orchestrator__plan_and_execute(prompt)` für delegierbare Sub-Aufgaben
+- Pipeline routed via Matrix → gpt-4o-mini / gpt-4o → **0 Anthropic-Quota**
+- Setup ist live (siehe ADR-Konversation heute)
+- Erwartete Reduktion: **100 % auf delegierte Subtasks** (= komplett quota-frei)
+
+**Wann anwenden**: Tasks die als "List", "Audit", "Generate Tests", "Refactor X to Y" beschreibbar sind.
+
+### H5 — Tool-Output-Hygiene (mittlerer Impact, technisch)
+
+**Problem**: `grep` mit `head -100` bleibt im Context — nächste 50 Turns sehen diese 100 Zeilen jedesmal.
+**Maßnahme**:
+- Pro Tool-Call nur das Minimum lesen (`head`, `tail`, `--limit`, gezielte Pfade)
+- Bei großen File-Reads: zuerst `wc -l`, dann gezielter Range
+- Hook-Idee: `PostToolUse` für `Bash` truncated Outputs > 5k Zeichen mit Hinweis
+- Erwartete Reduktion: **5–15 %** Baseline pro Session
+
+### H6 — CLAUDE.md-Diet (niedriger Impact, einmaliger Aufwand)
+
+**Problem**: Jeder Turn schickt CLAUDE.md + Memory mit. Wenn die 5k Tokens groß sind, summiert sich das.
+**Maßnahme**:
+- CLAUDE.md auf < 2k Tokens halten
+- MEMORY.md unter 200 Zeilen (System sagt nach 200 wird truncated — ist also schon implementiert)
+- Erwartete Reduktion: **3–8 %** Baseline pro Turn
+
+## 5. Was NICHT funktioniert (geprüft / verworfen)
+
+| Idee | Warum nicht |
+|---|---|
+| CC-Modell zentral auf Sonnet zwingen | CC-Sessions sind kontextgebunden — Opus-Routing für Reasoning oft gerechtfertigt |
+| Pre-Session-Hook der Modell vorschlägt | LLM-Klassifikation der ersten Nachricht kostet selbst Tokens; ROI fraglich |
+| Auto-`/compact`-Hook nach N Turns | CC unterstützt Hooks aber nicht Modifikation der laufenden Konversation |
+| ADR-194 Universal-Gateway | SPoF + Bootstrap-Paradox; siehe Reviews |
+| OpenRouter für alles | 5% Markup, US-Daten-Routing, CC-Compat-Risiko |
+
+## 6. Aktionsplan
+
+| Phase | Maßnahme | Aufwand | Erwartete Reduktion | Verantwortlich |
+|---|---|---|---|---|
+| **Sofort** | Session-Discipline (H1) — Faustregel "neue Session bei Themenwechsel" | 0 | -50% | du |
+| **Sofort** | `/model sonnet` für Routine-Tasks (H3) | 0 | -40% Opus-Quota | du |
+| **Sofort** | `task_pipeline` MCP-Tool für delegierbare Subtasks (H4) | 0 | -100% auf delegiert | du (bei jedem passenden Prompt) |
+| **Diese Woche** | Tool-Output-Hygiene-Hook (H5) | ~1 PT | -5–15 % | mir, falls gewünscht |
+| **Diese Woche** | CLAUDE.md-Audit pro Repo (H6) | ~0.5 PT | -3–8 % | du oder mir |
+| **2 Wochen** | Wöchentlicher Token-Report (Memory-Pflege "selbstlernende Matrix" Stufe 2) | ~1 PT | Sichtbarkeit | mir |
+| **2 Wochen** | Dashboard-Panel "Top Overkill-Calls" | ~0.3 PT | Awareness | mir |
+
+## 7. Messgrößen
+
+Erfolg messen anhand:
+1. **Avg-Tokens-per-Turn** (Ziel: p50 < 50k, p90 < 150k — heute 85k / 199k)
+2. **Wöchentliche Anthropic-Max-Quota** (claude.ai/settings/usage — Ziel: <50% bei aktueller Workload)
+3. **Sonnet-Quota-Auslastung** (heute: 0% — Ziel: 20–40% = Opus-Entlastung)
+4. **Tasks via `plan_and_execute`** (heute: ~5 — Ziel: alle delegierbaren Sub-Aufgaben)
+5. **Anteil "overkill"-Calls** (heute 22% — Ziel: <10%)
+
+## 8. Offene Fragen
+
+1. **Hat Anthropic einen Pre-Session-Model-Picker?** Wenn CC eine "auto-mode" oder Routing-API anbietet (Claude Code Speed Mode beta `fast-mode-2026-02-01`), könnte das Modell pro Turn dynamisch wählen. Stand 2026-01: nur statisches `/model`.
+2. **`/compact` Quality-Loss messbar?** Wenn Compact wichtige Details vergisst, kann's teurer werden weil Re-Erklärung nötig. Erst beobachten.
+3. **Wann lohnt sich `task_pipeline` nicht?** Bei Tasks die echtes Reasoning + großen Codebase-Context brauchen (z.B. "audit this ADR"), ist Opus im CC besser. Faustregel: wenn Sub-Task selbständig formulierbar ist und Output kompakt, dann delegieren.


### PR DESCRIPTION
## Problem

Deploy-Runs in repos wie `dev-hub` blieben permanent in `queued` — `deploy / 🔍 Resolve` zeigte leere Runner-Spalte trotz aktivem Runner.

## Root Cause

Zwei Ursachen kombiniert:
1. Kein `concurrency` auf Workflow-Ebene in repo-seitigen `deploy.yml` Dateien → mehrere Deploy-Runs starten gleichzeitig
2. **`cancel-in-progress: false` auf Staging-Job-Ebene** → steckengebliebene `deploy-{app}-staging` Concurrency-Locks werden nie released → neue Runs können den `🔍 Resolve` Job nicht starten

## Fix

Staging-Job `cancel-in-progress: false` → **`true`**

Staging sollte immer den neuesten Code deployen — alte Staging-Deploys abbrechen ist sicher und erwünscht.

Production behält `cancel-in-progress: false` — laufende Prod-Deploys nie unterbrechen.

## Companion Fix

`dev-hub/deploy.yml` (und künftig alle Repos) bekommen Workflow-level concurrency:
```yaml
concurrency:
  group: deploy-{app_name}-${{ github.ref_name }}
  cancel-in-progress: true
```
Dies ist die primäre Absicherung. Dieser PR ist die sekundäre Absicherung auf Platform-Ebene.