### PR TITLE
feat(create-pdf): folder-rekursiv + Cerebras+Groq-Routing für print_agent

### DIFF
--- a/.windsurf/workflows/create-pdf.md
+++ b/.windsurf/workflows/create-pdf.md
@@ -1,23 +1,26 @@
 ---
-description: Markdown → PDF mit Design-Switcher (meiki | iil | ttz)
+description: Markdown → PDF mit Design-Switcher (meiki | iil | ttz) — Datei oder Ordner
 ---
 # /create-pdf — IIL Print Agent
 
-Erzeugt ein PDF aus einer Markdown-Datei mit dem passenden Corporate Design.
+Erzeugt ein PDF aus einer Markdown-Datei (oder allen `.md` eines Ordners) mit dem passenden Corporate Design.
 
 **Verwendung:**
-- `/create-pdf <pfad_zur_md>` — erkennt Design automatisch aus Dateiname/Pfad
-- `/create-pdf <pfad_zur_md> --design iil` — Design explizit angeben
+- `/create-pdf <pfad_zur_md>` — einzelne Datei, Design-Auto-Erkennung
+- `/create-pdf <pfad_zum_folder>` — **alle** `.md`-Dateien im Ordner (rekursiv)
+- `/create-pdf <pfad> --design iil` — Design explizit angeben
 
 **Verfügbare Designs:** `meiki` (Standard) · `iil` · `ttz`
 **SSoT:** `achimdehnert/platform` → `tools/print_agent/` (lokal: `${GITHUB_DIR:-~/github}/platform/tools/print_agent/`)
 
 ---
 
-## Schritt 1 — Datei und Design bestimmen
+## Schritt 1 — Input-Typ, Datei(en) und Design bestimmen
 
-Wenn der User einen vollständigen Pfad angibt: direkt verwenden.
-Sonst: Datei im aktiven Repo suchen (typisch `docs/`, `docs/adr/`, `docs/04-entscheidungsunterlagen/`).
+**Erst prüfen: Datei oder Ordner?**
+- `[ -f "$INPUT" ]` → Single-File-Modus (Schritt 2a)
+- `[ -d "$INPUT" ]` → Folder-Modus: alle `*.md` rekursiv via `find "$INPUT" -type f -name '*.md'` (Schritt 2b)
+- sonst: Fehler an User, mit Suche im aktiven Repo (typisch `docs/`, `docs/adr/`, `docs/04-entscheidungsunterlagen/`)
 
 **Design-Auto-Erkennung** (wenn nicht explizit angegeben):
 - Pfad enthält `ttz-hub` oder `ttz` → `--design iil` (IIL liefert an TTZ)
@@ -48,19 +51,49 @@ OUT_DIR   = $REPO_ROOT/pdfs/$(dirname $REL_PATH)
 - Wenn MD **nicht** unter `docs/` liegt → Output = Verzeichnis der MD-Datei
 - Fallback: `~/pdf-output/`
 
-## Schritt 2 — PDF erzeugen
+## Schritt 2a — PDF erzeugen (Single-File-Modus)
 
 // turbo
 ```bash
 PRINT_AGENT="${GITHUB_DIR:-$HOME/github}/platform/tools/print_agent/print_agent.py"
-REPO_ROOT="$(git -C "$(dirname "<vollständiger_pfad_zur_md_datei>")" rev-parse --show-toplevel)"
-REL_PATH="${<vollständiger_pfad_zur_md_datei>#$REPO_ROOT/docs/}"
+MD_PATH="<vollständiger_pfad_zur_md_datei>"
+REPO_ROOT="$(git -C "$(dirname "$MD_PATH")" rev-parse --show-toplevel)"
+REL_PATH="${MD_PATH#$REPO_ROOT/docs/}"
 OUT_DIR="$REPO_ROOT/pdfs/$(dirname "$REL_PATH")"
 mkdir -p "$OUT_DIR"
-python3 "$PRINT_AGENT" \
-  "<vollständiger_pfad_zur_md_datei>" \
-  "$OUT_DIR" \
-  --design <design>
+python3 "$PRINT_AGENT" "$MD_PATH" "$OUT_DIR" --design <design>
+```
+
+## Schritt 2b — PDFs erzeugen (Folder-Modus)
+
+Schleife über alle `.md` im Ordner (rekursiv), Output-Verzeichnis pro Datei spiegeln.
+Fehler einer einzelnen Datei stoppt die Schleife **nicht** — am Ende Zusammenfassung.
+
+// turbo
+```bash
+PRINT_AGENT="${GITHUB_DIR:-$HOME/github}/platform/tools/print_agent/print_agent.py"
+FOLDER="<vollständiger_pfad_zum_folder>"
+DESIGN="<design>"
+REPO_ROOT="$(git -C "$FOLDER" rev-parse --show-toplevel 2>/dev/null || echo "$FOLDER")"
+
+OK=0; FAIL=0; FAILED_FILES=()
+while IFS= read -r -d '' MD_PATH; do
+  REL_PATH="${MD_PATH#$REPO_ROOT/docs/}"
+  if [ "$REL_PATH" = "$MD_PATH" ]; then
+    OUT_DIR="$(dirname "$MD_PATH")"        # MD nicht unter docs/ → daneben ablegen
+  else
+    OUT_DIR="$REPO_ROOT/pdfs/$(dirname "$REL_PATH")"
+  fi
+  mkdir -p "$OUT_DIR"
+  if python3 "$PRINT_AGENT" "$MD_PATH" "$OUT_DIR" --design "$DESIGN"; then
+    OK=$((OK+1))
+  else
+    FAIL=$((FAIL+1)); FAILED_FILES+=("$MD_PATH")
+  fi
+done < <(find "$FOLDER" -type f -name '*.md' -print0 | sort -z)
+
+echo "── Zusammenfassung ── erstellt: $OK · fehlgeschlagen: $FAIL"
+for f in "${FAILED_FILES[@]}"; do echo "  ❌ $f"; done
 ```
 
 Der Agent ruft **gpt-4o-mini** auf (~$0.00005/Dokument) für Executive Summary + Keywords.
@@ -70,12 +103,22 @@ Fallback: Ohne API-Key wird das PDF ohne LLM-Anreicherung erzeugt.
 
 // turbo
 ```bash
+# Single-File-Modus:
 ls -lh "$OUT_DIR/<name>.pdf"
+
+# Folder-Modus: alle erzeugten PDFs unter pdfs/ auflisten
+find "$REPO_ROOT/pdfs" -type f -name '*.pdf' -newer "$PRINT_AGENT" -printf '%p  %s bytes\n' | sort
 ```
 
 ## Schritt 4 — Ausgabe
 
-Teile dem User mit:
+**Single-File:**
 - ✅ PDF-Pfad: `file://<output_verzeichnis>/<name>.pdf`
 - Design, Dateigröße
-- Hinweis: MD-Datei bearbeiten → Schritt 2 erneut ausführen
+- Hinweis: MD-Datei bearbeiten → Schritt 2a erneut ausführen
+
+**Folder:**
+- ✅ Anzahl erzeugter PDFs, Wurzelpfad (`pdfs/...`)
+- ❌ Liste fehlgeschlagener Dateien (falls vorhanden)
+- Design, Gesamt-Größe
+- Hinweis: Einzelne Datei neu erzeugen → Schritt 2a auf diese Datei

--- a/tools/print_agent/print_agent.py
+++ b/tools/print_agent/print_agent.py
@@ -172,7 +172,7 @@ def llm_enrich(title: str, md_text: str, design: dict) -> dict:
     """Executive Summary + Keywords. Default Cerebras Llama-3.3-70b → Groq 8B-Fallback.
 
     ENV-Overrides:
-      PRINT_AGENT_LLM_PRIMARY   (Default: cerebras/llama-3.3-70b)
+      PRINT_AGENT_LLM_PRIMARY   (Default: cerebras/llama3.1-8b)
       PRINT_AGENT_LLM_FALLBACK  (Default: groq/llama-3.1-8b-instant, leer = aus)
     """
     primary = os.environ.get("PRINT_AGENT_LLM_PRIMARY", _DEFAULT_PRIMARY).strip()

--- a/tools/print_agent/print_agent.py
+++ b/tools/print_agent/print_agent.py
@@ -4,7 +4,10 @@ IIL Print Agent — LLM-gestützter PDF-Generator mit Design-Switcher
 Usage: python3 print_agent.py <input.md> [output_dir] [--design meiki|iil]
 
 Designs: meiki (Standard), iil (IIL GmbH Corporate)
-LLM: OpenAI gpt-4o-mini (~$0.00005/Dokument)
+LLM (Default): cerebras/llama3.1-8b (schnell+günstig), Fallback groq/llama-3.1-8b-instant.
+  Override via ENV PRINT_AGENT_LLM_PRIMARY und PRINT_AGENT_LLM_FALLBACK
+  (litellm-Modellstring; leerer Fallback = kein Fallback).
+  Für höhere Qualität auf Cerebras: PRINT_AGENT_LLM_PRIMARY=cerebras/qwen-3-235b-a22b-instruct-2507
 Fallback: Ohne LLM direkt PDF erzeugen
 """
 
@@ -26,6 +29,7 @@ from weasyprint import HTML, CSS
 OUTPUT_DIR = Path.home() / "pdf-output"
 SECRETS_DIRS = [
     Path("/home/devuser/shared/secrets"),
+    Path("/home/devuser/shared/secrets-inbox"),
     Path.home() / ".secrets",
 ]
 _TEMPLATES_DIR = Path(__file__).parent / "print_templates"
@@ -116,12 +120,63 @@ def get_secret(name: str) -> str | None:
     return None
 
 
-def llm_enrich(title: str, md_text: str, design: dict) -> dict:
-    """gpt-4o-mini — Executive Summary + Keywords (~$0.00005/Dokument)."""
-    api_key = get_secret("openai_api_key")
+_DEFAULT_PRIMARY = "cerebras/llama3.1-8b"
+_DEFAULT_FALLBACK = "groq/llama-3.1-8b-instant"
+
+
+def _secret_name_for_model(model: str) -> str | None:
+    """Mappt litellm-Modellstring auf Secret-Name (cerebras_api_key etc.)."""
+    m = model.lower()
+    if m.startswith("cerebras/"):
+        return "cerebras_api_key"
+    if m.startswith("groq/"):
+        return "groq_api_key"
+    if m.startswith("anthropic/") or m.startswith("claude-"):
+        return "anthropic_api_key"
+    if m.startswith("mistral/"):
+        return "mistral_api_key"
+    if m.startswith("together/") or m.startswith("together_ai/"):
+        return "together_api_key"
+    if m.startswith("openai/") or m.startswith("gpt-"):
+        return "openai_api_key"
+    return None
+
+
+def _try_completion(model: str, prompt: str) -> dict | None:
+    """Ein LLM-Versuch — gibt {} bei No-Key zurück, None bei Fehler, dict bei Erfolg."""
+    secret_name = _secret_name_for_model(model)
+    api_key = get_secret(secret_name) if secret_name else None
     if not api_key:
-        print("⚠️  Kein OpenAI API-Key — LLM-Schritt übersprungen")
-        return {}
+        print(f"⚠️  Kein API-Key für {model} ({secret_name}) — übersprungen")
+        return None
+    try:
+        response = litellm.completion(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=300,
+            temperature=0.3,
+            api_key=api_key,
+            timeout=15,
+        )
+        raw = response.choices[0].message.content.strip()
+        m = re.search(r"\{.*\}", raw, re.DOTALL)
+        if m:
+            return json.loads(m.group(0))
+        print(f"⚠️  {model}: kein JSON in Antwort")
+    except Exception as e:
+        print(f"⚠️  {model}: {e}")
+    return None
+
+
+def llm_enrich(title: str, md_text: str, design: dict) -> dict:
+    """Executive Summary + Keywords. Default Cerebras Llama-3.3-70b → Groq 8B-Fallback.
+
+    ENV-Overrides:
+      PRINT_AGENT_LLM_PRIMARY   (Default: cerebras/llama-3.3-70b)
+      PRINT_AGENT_LLM_FALLBACK  (Default: groq/llama-3.1-8b-instant, leer = aus)
+    """
+    primary = os.environ.get("PRINT_AGENT_LLM_PRIMARY", _DEFAULT_PRIMARY).strip()
+    fallback = os.environ.get("PRINT_AGENT_LLM_FALLBACK", _DEFAULT_FALLBACK).strip()
 
     context = design.get("llm_context", "Technologie und KI")
     preview = md_text[:1200].strip()
@@ -138,21 +193,15 @@ Antworte mit:
   "keywords": ["<Stichwort1>", "<Stichwort2>", "<Stichwort3>", "<Stichwort4>", "<Stichwort5>"]
 }}"""
 
-    try:
-        response = litellm.completion(
-            model="gpt-4o-mini",
-            messages=[{"role": "user", "content": prompt}],
-            max_tokens=300,
-            temperature=0.3,
-            api_key=api_key,
-            timeout=15,
-        )
-        raw = response.choices[0].message.content.strip()
-        m = re.search(r"\{.*\}", raw, re.DOTALL)
-        if m:
-            return json.loads(m.group(0))
-    except Exception as e:
-        print(f"⚠️  LLM-Fehler: {e} — fahre ohne Summary fort")
+    for attempt, model in enumerate([primary, fallback], start=1):
+        if not model:
+            continue
+        label = "Primary" if attempt == 1 else "Fallback"
+        print(f"   🤖 {label}: {model}")
+        result = _try_completion(model, prompt)
+        if result is not None:
+            return result
+    print("⚠️  Alle LLM-Versuche fehlgeschlagen — fahre ohne Summary fort")
     return {}
 
 


### PR DESCRIPTION
## Summary
- `/create-pdf` akzeptiert jetzt **Folder-Pfade** und verarbeitet alle `*.md` rekursiv (find -print0), pro Datei `docs/ → pdfs/`-Spiegelung; Single-File-Modus unverändert
- `print_agent.py` `llm_enrich()` ersetzt OpenAI gpt-4o-mini durch **Cerebras+Groq-Routing** (Tier 1a/1b laut llm-routing-Policy)
  - Default Primary `cerebras/llama3.1-8b`, Fallback `groq/llama-3.1-8b-instant`
  - ENV-Overrides `PRINT_AGENT_LLM_PRIMARY` / `PRINT_AGENT_LLM_FALLBACK` (leerer Fallback = aus)
  - Secret-Lookup nach Modell-Prefix (`cerebras_/groq_/openai_/anthropic_/mistral_/together_api_key`)
  - `SECRETS_DIRS` um `~/shared/secrets-inbox/` erweitert (sonst keine Cerebras/Groq-Keys gefunden)

## Begründung
LLM-Call war ein 300-Token Background-Summary auf gpt-4o-mini. Per `llm-routing.md` Tier 1 (Cerebras/Groq) für solche Tasks vorgeschrieben — 1-2 Größenordnungen günstiger pro Token.

## Test plan
- [x] Smoketest `python3 print_agent.py README.md /tmp/print_agent_test --design iil` → Cerebras-Primary getroffen, 74 KB PDF
- [x] Cerebras-Modell-ID gegen `GET /v1/models` verifiziert (Account hat kein 70B Llama)
- [ ] Folder-Modus an einem echten `docs/`-Verzeichnis testen
- [ ] ENV-Override mit `PRINT_AGENT_LLM_PRIMARY=groq/llama-3.3-70b-versatile` prüfen

🤖 Generated with [Claude Code](https://claude.com/claude-code)