### PR TITLE
fix(guardian): drop unused multiline JSON output to $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/guardian.yml
+++ b/.github/workflows/guardian.yml
@@ -34,7 +34,6 @@ jobs:
         id: guardian
         run: |
           python -m agents.guardian --diff /tmp/pr.diff --format json > /tmp/result.json || true
-          echo "result=$(cat /tmp/result.json)" >> $GITHUB_OUTPUT
           python -m agents.guardian --diff /tmp/pr.diff --format markdown > /tmp/comment.md || true
 
       - name: Post PR Comment


### PR DESCRIPTION
## Summary
- Architecture-Guardian-Workflow schreibt mehrzeiliges JSON ohne Heredoc nach `$GITHUB_OUTPUT` → GH-Actions verwirft die Folgezeilen und markiert den Step `failure`, selbst wenn keine Architektur-Verstöße gefunden wurden.
- Der `result`-Output wird nirgendwo konsumiert (Post-Step liest `/tmp/result.json` direkt via fs).
- Fix: die tote Zeile entfernen.

## Impact
Entblockt z.B. PR #133 (`feat(create-pdf): folder-rekursiv + Cerebras+Groq-Routing`), wo Guardian zwar "✅ Passed — No violations found" kommentierte, der Check aber dennoch `FAILURE` war.

## Test plan
- [x] Diff geprüft: nur die `echo …` Zeile entfernt, restlicher Workflow unverändert
- [ ] CI auf diesem PR muss grün durchlaufen (Self-Test des Guardian-Workflows auf einem Workflow-File-Change)
- [ ] Nach Merge: PR #133 re-run → Guardian-Check sollte success sein

🤖 Generated with [Claude Code](https://claude.com/claude-code)