### PR TITLE
chore(workflows): rename Cascade-specific terms to tool-agnostic

### DIFF
--- a/.windsurf/workflows/agent-session-start.md
+++ b/.windsurf/workflows/agent-session-start.md
@@ -4,7 +4,7 @@ description: Pflicht-Ritual vor jeder Coding-Agent-Session — Kontext laden, St
 
 # Agent Session Start Workflow
 
-**Trigger:** Jede neue Windsurf/Cascade-Session, bevor der erste Code-Change gemacht wird.
+**Trigger:** Jede neue Windsurf/Agent Session, bevor der erste Code-Change gemacht wird.
 
 > Dieses Ritual verhindert, dass ein Agent ohne Kontext blind drauflos arbeitet.
 > Dauer: ~2 Minuten. Spart Stunden an Debugging und Rollbacks.
@@ -252,7 +252,7 @@ Am Ende **jeder** Session, bevor die Verbindung getrennt wird:
 | Windsurf-Verbindung tot | `/windsurf-clean` |
 | Wissen sichern nach Session | `/knowledge-capture` |
 | Third-Party Stack upgraden | `/stack-upgrade` |
-| Repo-Sync nach Cascade-Session | `/sync-repo` |
+| Repo-Sync nach Agent Session | `/sync-repo` |
 | Shell hängt komplett | `/windsurf-clean` dann Neustart |
 
 ## MCP-Server Quick-Reference

--- a/.windsurf/workflows/deploy.md
+++ b/.windsurf/workflows/deploy.md
@@ -60,7 +60,7 @@ MCP: mcp2_adr_freshness(repo_path="${GITHUB_DIR}/<SERVICE>")
    - `image_tag`: `latest` oder SHA
    - `has_migrations`: `true` oder `false`
 
-### 2. Service deployen (Agent / Cascade)
+### 2. Service deployen (Agent)
 Verwende `<deployment-mcp>_cicd_manage` *(Prefix aus mcp-tools.md)* mit `action: dispatch`:
 ```
 owner: achimdehnert

--- a/.windsurf/workflows/knowledge-capture.md
+++ b/.windsurf/workflows/knowledge-capture.md
@@ -171,9 +171,9 @@ Beispiele für Cross-Repo-Wissen:
 
 ---
 
-## Step 6: Cascade Memory mit Outline-Verweis updaten
+## Step 6: agent memory mit Outline-Verweis updaten
 
-Ergänzend zum Outline-Eintrag: Cascade Memory mit kurzem **Verweis auf das Outline-Dokument** aktualisieren.
+Ergänzend zum Outline-Eintrag: agent memory mit kurzem **Verweis auf das Outline-Dokument** aktualisieren.
 
 ```
 Memory: "<Thema> — Runbook in Outline: <Titel>"

--- a/.windsurf/workflows/platform-audit.md
+++ b/.windsurf/workflows/platform-audit.md
@@ -323,7 +323,7 @@ mcp8_create_issue(
 )
 ```
 
-### 5.4 Cascade Memory updaten
+### 5.4 agent memory updaten
 
 ```
 Memory: "Platform Audit {DATUM} — {N} Findings, Score {N}/100 — Report in Outline"

--- a/.windsurf/workflows/session-ende.md
+++ b/.windsurf/workflows/session-ende.md
@@ -72,7 +72,7 @@ Falls ja: Explizit als TODO dokumentieren mit konkretem Befehl zur Übernahme.
 3. **Klassifizieren** — Runbook / Konzept / Lesson / Update?
 4. **Outline schreiben** — `mcp5_create_runbook`, `mcp5_create_concept`, `mcp5_create_lesson` oder `mcp5_update_document`
 5. **Cross-Repo Tagging** — "Gilt für" Abschnitt bei Hub-übergreifendem Wissen
-6. **Cascade Memory updaten** — Verweis auf Outline-Dokument
+6. **agent memory updaten** — Verweis auf Outline-Dokument
 
 ---
 

--- a/.windsurf/workflows/session-start.md
+++ b/.windsurf/workflows/session-start.md
@@ -254,7 +254,7 @@ else
   echo "   ABBRUCH — pgvector ist Pflicht, kein Fallback erlaubt."
 fi
 ```
-→ **KEIN Fallback auf Cascade Memory erlaubt.** pgvector MUSS laufen.
+→ **KEIN Fallback auf agent memory erlaubt.** pgvector MUSS laufen.
 → Bei Fehler: Session NICHT fortsetzen bis Tunnel steht.
 
 ### 0.6 Deploy-Infrastruktur prüfen (ADR-156)

--- a/.windsurf/workflows/stack-upgrade.md
+++ b/.windsurf/workflows/stack-upgrade.md
@@ -135,5 +135,5 @@ Dann Root Cause analysieren, Breaking Changes prüfen, ggf. Env-Vars anpassen.
 [ ] Daten intakt (gleiche Anzahl)
 [ ] Altes Image entfernt
 [ ] Repo aktualisiert + committed
-[ ] Cascade Memory aktualisiert
+[ ] agent memory aktualisiert
 ```

--- a/.windsurf/workflows/sync-repo.md
+++ b/.windsurf/workflows/sync-repo.md
@@ -37,7 +37,7 @@ Die laufen dort nur als Docker-Container. Updates kommen via `docker pull`, nich
 
 ---
 
-## Normalfall: CWD-Repo nach Cascade-Session syncen
+## Normalfall: CWD-Repo nach Agent Session syncen
 
 // turbo
 ```bash
@@ -90,7 +90,7 @@ Dauer: ~30–60 Sekunden für alle Nodes.
 
 ## Empfehlung: In täglichen Workflow integrieren
 
-Am Anfang **jeder** Cascade-Session:
+Am Anfang **jeder** Agent Session:
 ```bash
 bash ${GITHUB_DIR:-$HOME/github}/platform/scripts/sync-repo.sh
 ```


### PR DESCRIPTION
## Summary
Konservative Sprachglättung in 8 von 59 Windsurf-Workflows. Voraussetzung für T1 der Single-Source-of-Truth-Strategie: dieselben Markdown-Prompts laufen in Claude Code (via `~/.claude/commands/` Symlink-Farm) und Cascade IDE.

## Was geändert wurde
| Pattern | Anzahl | Begründung |
|---|---|---|
| `Cascade Memory` → `agent memory` | 5 | beide Tools haben ein Memory-Subsystem; Begriff ist generisch |
| `Cascade-Session` → `Agent Session` | 2 | Session ist tool-agnostisch |
| `(Agent / Cascade)` → `(Agent)` | 1 | redundant, Cascade IST der Agent in Windsurf |

## Was bewusst NICHT angefasst wurde
- Python-Code `agent: "cascade"` (DB-Wert, Bruch-Risiko)
- Slash-Command-Name `/cascade-auftraege` (Outline-Board-Identität)
- Dateinamen `cascade-auftraege.md`, `windsurf-rules/`
- Pfad-Beispiele `/home/adehnert/CascadeProjects/...`
- Speaker-Labels `Cascade:` in Dialogen (separater PR, Stil-Frage)

## Kontext
T1 der Workflow-SoT-Strategie wurde live geschaltet:
```
~/.claude/commands -> ~/github/platform/.windsurf/workflows
```
Jede Claude-Code-Session hat damit alle 59 Workflows als Slash-Commands. Dieser PR macht 8 davon sprachlich neutral.

## Test plan
- [x] grep verifiziert: keine Zielpatterns mehr in den 8 Files
- [x] Python-Code unangetastet (`grep "agent: \"cascade\""` Treffer in den 8 Files: 3 → unverändert)
- [ ] guardian + validate Checks gruen
- [ ] Optional: Cascade-User testet `/session-start` und `/knowledge-capture` weiterhin OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)