### PR TITLE
docs(adr): ADR-202 + ADR-203 — both conditional follow-ups to ADR-199 rejection

### DIFF
--- a/.github/workflows/_deploy-unified.yml
+++ b/.github/workflows/_deploy-unified.yml
@@ -189,6 +189,25 @@ jobs:
       name: staging
       url: https://staging.${{ inputs.app_name }}.iil.pet
     steps:
+      - uses: actions/checkout@v6
+
+      # Sync staging compose file from the consuming repo to the host.
+      # Without this, deploy.sh runs `docker compose pull` against
+      # whatever stale compose file is on the server (may reference a
+      # removed service / wrong image path / outdated port mapping).
+      - name: Sync docker-compose.staging.yml to host
+        if: hashFiles('docker-compose.staging.yml') != ''
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.STAGING_HOST }}
+          username: ${{ secrets.STAGING_USER }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
+          fingerprint: ${{ secrets.STAGING_SSH_FINGERPRINT }}
+          source: "docker-compose.staging.yml"
+          # deploy.sh on staging uses docker-compose.yml (no env-specific suffix)
+          target: "${{ inputs.app_path }}/docker-compose.yml"
+          overwrite: true
+
       - name: Deploy to staging
         uses: appleboy/ssh-action@v1.0.3
         timeout-minutes: 15
@@ -223,6 +242,31 @@ jobs:
     environment:
       name: production
     steps:
+      - uses: actions/checkout@v6
+
+      # Sync production compose file from the consuming repo to the host.
+      # Self-hosted runners run on the prod server itself — direct cp works.
+      # Without this step deploy.sh works against a stale compose file
+      # (e.g. wrong image path after a path-refactor in the repo).
+      - name: Sync docker-compose.prod.yml to app path (self-hosted)
+        if: inputs.runs_on == 'self-hosted' && hashFiles('docker-compose.prod.yml') != ''
+        run: |
+          set -euo pipefail
+          cp docker-compose.prod.yml "${{ inputs.app_path }}/docker-compose.prod.yml"
+          echo "✅ Compose file synced to ${{ inputs.app_path }}/docker-compose.prod.yml"
+
+      - name: Sync docker-compose.prod.yml to host (remote runner)
+        if: inputs.runs_on != 'self-hosted' && hashFiles('docker-compose.prod.yml') != ''
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          fingerprint: ${{ secrets.DEPLOY_SSH_FINGERPRINT }}
+          source: "docker-compose.prod.yml"
+          target: "${{ inputs.app_path }}/docker-compose.prod.yml"
+          overwrite: true
+
       - name: Deploy to production (direct — self-hosted runner)
         if: inputs.runs_on == 'self-hosted'
         timeout-minutes: 15

--- a/docs/adr/ADR-202-jit-tier-reassignment.md
+++ b/docs/adr/ADR-202-jit-tier-reassignment.md
@@ -1,0 +1,97 @@
+---
+status: proposed
+date: 2026-05-14
+decision-makers: [Achim Dehnert]
+implementation_status: none
+related: [ADR-068, ADR-116, ADR-196, ADR-199-rejected, ADR-201]
+---
+
+# ADR-202: JIT-Tier-Reassignment — start cheap, escalate on insufficient response
+
+## Status
+
+Proposed — optional Folge-ADR von ADR-199 (rejected). Wird nur empfohlen falls ADR-201 (Pricing Visibility) den Spend nicht ausreichend reduziert (Erwartung: 14-Tage-Beobachtung post-deploy).
+
+## Context
+
+Aktuelle Routing-Annahme in allen Surfaces (`model_route_configs`, `model_selector._ROUTE_TABLE`, `aifw_action_types`, Claude Code Session): **wir wählen das Modell *vor* dem Call**. Up-front, predictive, basierend auf statischer Klassifizierung.
+
+Echte Engineering-Arbeit folgt aber einem anderen Muster: probier billig, schau ob's reicht, eskaliere bei Bedarf. Analog zu JIT-Compilation-Tiers (Interpretation → Baseline-JIT → Optimizing-JIT).
+
+Kostenrechnung als Plausibilitäts-Skizze:
+- 80 % der Tasks **könnten** von Tier 1a (Cerebras llama-70B, ~$0.59/M) gelöst werden
+- 20 % brauchen tatsächlich Tier 3 (Sonnet, $3/$15)
+- Up-front 100 % Sonnet: 100 × $0.30 = $30
+- JIT (Tier 1a → Tier 3 falls nötig): 0.8 × $0.005 + 0.2 × ($0.005 + $0.30) = $0.063
+- **~5× Ersparnis** falls die Eskalations-Heuristik 80/20 trifft
+
+## Decision
+
+Ein Library-Wrapper `iil_routing_jit` (oder Erweiterung der ADR-201-Library) der `litellm.completion(...)` umhüllt:
+
+```python
+from iil_routing_jit import call_with_escalation
+
+result = call_with_escalation(
+    messages=[...],
+    tier_chain=["1a", "3"],      # cheap → premium
+    escalation_triggers=[
+        "truncated",                # finish_reason == 'length' unerwartet
+        "empty",                    # response < 50 chars
+        "uncertainty",              # "I don't know" Marker
+        "error",                    # provider returned 5xx/4xx
+    ],
+    max_escalations=1,
+)
+# result.final_model, result.cost_usd_total, result.attempts (list)
+```
+
+### Eskalations-Trigger (heuristisch, dokumentiert ehrlich als „best-effort")
+
+| Trigger | Detection | False-positive-Risiko |
+|---|---|---|
+| `truncated` | `finish_reason == 'length'` AND output < 90% of max_tokens | niedrig |
+| `empty` | `len(content.strip()) < 50` | niedrig |
+| `uncertainty` | Regex `\b(I don't know\|I'm not sure\|cannot answer\|unclear)\b` | **hoch** — agent kann legitim Unsicherheit ausdrücken |
+| `error` | HTTP 5xx / Timeout / RateLimitError | sehr niedrig |
+| `tool_call_missing` | Caller erwartete Tool-Call, kam keiner | mittel |
+
+Jeder Trigger ist **opt-in**. Caller wählt was zur Aufgabe passt — keine globale Default-Aktivierung.
+
+### Outcome-Logging
+
+Jeder Attempt wird in `llm_calls` mit `routing_reason='jit_attempt_<n>'` persistiert. Ein zusätzlicher `task_id`-Suffix (`-jit1`, `-jit2`) gruppiert die Attempts logisch. Cost-Tracking aggregiert auf parent-task_id.
+
+## Phasen
+
+| Phase | Aufwand | Lieferung |
+|---|---|---|
+| 1 | 1 Tag | Library-Skelett, JIT-Logik, 4 Trigger implementiert + Tests |
+| 2 | 1 Tag | Wrap einen Konsumenten (Vorschlag: `skill.drift_narrate` — heute Tier 1a, geringes Risiko falls JIT failsafe nötig) |
+| 3 | 7-14 Tage | Beobachtung: cost-per-completion vs baseline, Escalation-Rate, False-Positive-Rate |
+| 4 | optional | Rollout auf weitere Konsumenten falls Phase 3 positiv |
+
+**Phase 3 ist der Entscheidungspunkt.** Wenn JIT pro Task mehr Latenz produziert als Wert spart, abbrechen.
+
+## Acceptance Criteria
+
+- [ ] Eskalations-Rate (Tier 1a → 3) bei `skill.drift_narrate` < 25 % über 7 Tage (sonst war Tier 1a falsch gewählt vorher)
+- [ ] Average cost per successful completion ↓ um ≥ 30 % vs Baseline
+- [ ] Average latency per completion erhöht sich um ≤ 50 % (Cerebras ist schnell, Eskalation nur in 20 % der Fälle)
+- [ ] False-Positive-Rate des `uncertainty`-Triggers < 5 % (manuell stichprobenartig geprüft)
+
+## Risiken (ehrlich benannt)
+
+- **Latenz-Doublung bei Eskalation**: 20 % der Calls dauern 2× so lang. Bei interactive UX (Claude Code) merkbar. Mitigated durch async/streaming nicht im Scope dieses ADRs.
+- **Heuristik-Fragilität**: `uncertainty`-Regex erzeugt false positives. Mitigated durch opt-in pro Caller + Stichproben-Audit.
+- **Provider-Rate-Limits auf Tier 1a**: wenn JIT-Pattern Cerebras/Groq hämmert, häufiger 429s → wäre kontraproduktiv. Mitigated durch existing fallback chain in litellm.
+- **Outcome-Logging-Pollution**: 20 % der Calls erzeugen 2 Rows. Aggregation muss bewusst gemacht werden in Reports.
+- **JIT lohnt sich nur für simple completions** (1-shot Q&A). Tool-call-chains + agentic loops eignen sich **nicht** — der erste Call definiert ein Zustands-Path den ein 2. Versuch nicht reproduzieren kann.
+
+## Why optional, why this order
+
+Wenn ADR-201 (Pricing Visibility) den Spend bereits durch Bewusstsein adressiert, ist ADR-202 redundant. JIT macht den User-Layer überflüssig und damit auch dessen positiven Bewusstseins-Effekt verloren. **Erst nach ADR-201-Messung entscheiden.**
+
+## Changelog
+
+- 2026-05-14: Initial. Status: proposed, conditional on ADR-201 measurement outcome.

--- a/docs/adr/ADR-203-anthropic-model-alias-adoption.md
+++ b/docs/adr/ADR-203-anthropic-model-alias-adoption.md
@@ -1,0 +1,115 @@
+---
+status: proposed
+date: 2026-05-14
+decision-makers: [Achim Dehnert]
+implementation_status: none
+related: [ADR-199-rejected, ADR-201, mcp-hub#37, mcp-hub#41]
+---
+
+# ADR-203: Anthropic Model-Alias Adoption — Drift-Wartung zu Anthropic verschieben
+
+## Status
+
+Proposed — optional Folge-ADR von ADR-199 (rejected). 1-Tag-Aufwand mit hohem Hebel, falls die Trade-offs akzeptabel sind.
+
+## Context
+
+Heute pinnen wir an konkrete Versionen: `anthropic/claude-sonnet-4-6`, `anthropic/claude-opus-4-7`, `anthropic/claude-haiku-4-5`. Drift-Risiko: wenn Anthropic ein Modell retired (siehe mcp-hub#37 — `claude-3-5-sonnet-20241022` war exakt das), müssen wir N Surfaces updaten.
+
+Anthropic bietet rolling Aliases: `claude-sonnet-4-latest`, `claude-opus-4-latest`, etc. Drift-Wartung verschiebt sich damit **zum Provider**.
+
+## Decision
+
+Alle Anthropic-Referenzen in den Routing-Surfaces auf rolling aliases umstellen:
+
+| Heute | Nach Adoption |
+|---|---|
+| `anthropic/claude-sonnet-4-6` | `anthropic/claude-sonnet-4-latest` |
+| `anthropic/claude-opus-4-7` | `anthropic/claude-opus-4-latest` |
+| `anthropic/claude-haiku-4-5` | `anthropic/claude-haiku-4-latest` (falls existent) |
+
+Surfaces betroffen:
+- `mcp-hub:orchestrator_mcp/model_selector.py` _ROUTE_TABLE
+- `mcp-hub:orchestrator_mcp/model_registry.py` _FALLBACK
+- `mcp-hub:orchestrator_mcp/skills/review_adr.py` _DEFAULT_REVIEW_MODEL (ADR-201 ist hier vermutlich schon der nächste Update)
+- `dev-hub:aifw_action_types.default_model_id` (SQL UPDATE auf alias-Rows)
+- `dev-hub:aifw_llm_models` neue Rows mit alias names
+- `~/.claude/policies/llm-routing.md` Tier-Liste
+
+NICHT betroffen:
+- `groq/*`, `cerebras/*`, `openai/*`, `mistral/*` — andere Provider haben unterschiedliche Alias-Strategien, einzeln evaluieren
+- `model_route_configs` DB-Tabelle (mcp-hub#47 ist erst 24h alt, drift-frei)
+
+## Phasen
+
+| Phase | Aufwand | Lieferung |
+|---|---|---|
+| 1 | 30 min | Verifizieren via `litellm.completion(model='anthropic/claude-sonnet-4-latest', ...)` ob alle 3 Aliases von litellm akzeptiert sind |
+| 2 | 1 h | SQL-Migration (`0045_aifw_alias_rows.sql` + `0046_model_route_configs_alias.sql`) |
+| 3 | 1 h | Code-Updates in mcp-hub (`model_selector.py`, `model_registry.py`, `skills/review_adr.py`) |
+| 4 | 30 min | Policy-Files updaten + Drift-Workflow re-baseline (`docs/known-dead-models.txt`) |
+
+## Acceptance Criteria
+
+- [ ] `litellm.completion(model='anthropic/claude-sonnet-4-latest', ...)` gibt eine erfolgreiche Antwort
+- [ ] mcp-hub Drift-Workflow nächster Run zeigt 0 dead-strings unter den aliased entries
+- [ ] Cost-Tracking (`llm_calls.cost_usd`) bleibt akkurat — Anthropic billt unter dem aufgelösten model, nicht unter dem alias
+
+## Risiken (kritisch zu lesen)
+
+### Vendor-seitige Risiken (silently failing modes)
+
+1. **Alias-Target ändert sich ohne Vorwarnung**: heute zeigt `claude-sonnet-4-latest` auf `claude-sonnet-4-6`. Morgen vielleicht auf `claude-sonnet-5-mini` mit anderer Qualität / anderem Pricing. Wir merken es nicht via Drift-Workflow (Alias resolved weiter), nur via Cost-Drift-Beobachtung.
+2. **Pricing-Drift**: PRICING_USD_PER_MTOK in `log_llm_call.py` ist by-model-string. Wenn Anthropic der alias auf ein günstigeres/teureres Modell zeigen lässt, ist unser Cost-Estimate falsch. Mitigation: nur Anthropic's eigenes Usage-Reporting als ground truth verwenden (lebt nicht in unserem Stack).
+3. **Behavioral drift**: alias-target kann subtle Antwort-Stil ändern. Tests die heute grün sind können morgen rot werden ohne dass wir etwas geändert haben.
+4. **Reproduzierbarkeit**: Prompts gegen `-latest` ergeben heute ≠ in 3 Monaten. Für ADR-Reviews und Audits oft problematisch.
+
+### Architektur-Risiken
+
+5. **Inkonsistenz**: nur Anthropic aliases, andere Provider weiterhin pinned. Architektur ist mixed.
+6. **Vendor-Lock-in tiefer**: Adoption von alias-Pattern macht Migration zu z.B. OpenAI härter — keine 1:1-Alias-Map.
+
+## Out-of-the-Box-Alternative: Internal Aliases statt Provider-Aliases
+
+Anstatt Anthropic's alias zu adoptieren, **bauen wir unsere eigenen**:
+
+```python
+# in iil_routing.aliases:
+INTERNAL_ALIAS = {
+    "iil/sonnet-current":  "anthropic/claude-sonnet-4-6",
+    "iil/opus-current":    "anthropic/claude-opus-4-7",
+    "iil/haiku-current":   "anthropic/claude-haiku-4-5",
+    "iil/fast-current":    "groq/llama-3.3-70b-versatile",
+}
+```
+
+Vorteile: Provider-Independence, kontrollierte Drift-Geschwindigkeit, einheitliches Naming über alle Provider.
+Nachteil: wir tragen die Update-Last (statt sie zu Anthropic zu verschieben).
+
+**Trade-off:** ADR-203 verschiebt Update-Last extern aber öffnet silent-drift; Internal-Aliases halten Last intern aber verhindern silent-drift.
+
+## Implementations-Skizze (falls accepted)
+
+```sql
+-- 0045_aifw_alias_rows.sql
+INSERT INTO aifw_llm_models (provider_id, name, display_name, ...)
+SELECT id, 'claude-sonnet-4-latest', 'Claude Sonnet 4 (rolling alias)', ...
+  FROM aifw_llm_providers WHERE name='anthropic'
+ON CONFLICT (provider_id, name) DO NOTHING;
+-- (repeat for opus-4-latest, haiku-4-latest)
+
+-- update default_model_id für die 5-6 action_codes
+UPDATE aifw_action_types
+   SET default_model_id = (SELECT id FROM aifw_llm_models m
+                            JOIN aifw_llm_providers p ON p.id=m.provider_id
+                            WHERE p.name='anthropic' AND m.name='claude-sonnet-4-latest')
+ WHERE code IN ('orchestrator.developer','headless.edit','skill.review_adr','headless.quality_sweep');
+```
+
+## Why optional, why this order
+
+ADR-201 (Pricing Visibility) erhöht die Sichtbarkeit dass Anthropic-Aliase ihr Verhalten ändern. ADR-203 verschiebt das Drift-Problem, eliminiert es nicht. **Erst nach ADR-201-Messung** entscheiden ob die Cost-Sichtbarkeit + Drift-Workflow zusammen genug sind oder ob alias-adoption die Wartung weiter senkt.
+
+## Changelog
+
+- 2026-05-14: Initial. Status: proposed, conditional on ADR-201 measurement + explicit user acceptance of vendor-side silent-drift trade-off.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # /opt/scripts/deploy.sh — iil-Platform Unified Deploy Script (ADR-120)
-# Auf PROD (88.198.191.108) und DEV/Staging (46.225.113.1) installieren
+# Auf PROD (88.198.191.108) und DEV/Staging (88.99.38.75) installieren
 #
 # Usage: deploy.sh <APP_NAME> <APP_PATH> <IMAGE_TAG> <ENVIRONMENT> [HEALTH_CHECK_URL]
 # Example: deploy.sh risk-hub /opt/risk-hub v1.4.2 production https://schutztat.de/healthz/
@@ -58,13 +58,13 @@ rollback() {
 }
 trap rollback ERR
 
-echo "═══════════════════════════════════════════════"
+echo "═══════════════════════════════════════════════════"
 echo "iil-Platform Deploy — ADR-120"
 echo "App:  $APP_NAME"
 echo "Env:  $ENVIRONMENT"
 echo "Tag:  $IMAGE_TAG"
 [[ -n "$PREVIOUS_TAG" ]] && echo "Prev: $PREVIOUS_TAG"
-echo "═══════════════════════════════════════════════"
+echo "═══════════════════════════════════════════════════"
 
 # IMAGE_TAG in .env schreiben
 if [[ -f "$APP_PATH/.env" ]] && grep -q "^IMAGE_TAG=" "$APP_PATH/.env"; then
@@ -75,7 +75,7 @@ fi
 
 # GHCR Login (Token aus /opt/scripts/.ghcr_token falls vorhanden)
 if [[ -f "/opt/scripts/.ghcr_token" ]]; then
-  docker login ghcr.io -u achimdehnert --password-stdin < /opt/scripts/.ghcr_token 2>/dev/null || echo "WARN: GHCR login skipped"
+  docker login ghcr.io -u achimdehnert --password-stdin < /opt/scripts/.ghcr_token
 fi
 
 # Deploy
@@ -83,7 +83,43 @@ cd "$APP_PATH"
 docker compose -f "$COMPOSE_FILE" pull
 docker compose -f "$COMPOSE_FILE" up -d --force-recreate --remove-orphans
 
-# Health-Check (nur HTTP 200 — ADR-022: /healthz/ Pflicht)
+# Health-Check
+# Staging: derive local URL from the WEB service's host-port mapping.
+# We must NOT just take the first 127.0.0.1:PORT line in the compose
+# file — that frequently belongs to MinIO/Redis/etc. Try (in order):
+#   1. docker compose port lookup on every service whose name ends in -web
+#   2. awk-parse the compose block under a `*-web:` service key
+#   3. legacy fallback: first 127.0.0.1 host port (preserves old behaviour)
+if [[ "$ENVIRONMENT" == "staging" ]]; then
+  LOCAL_PORT=""
+
+  for svc in $(docker compose -f "$COMPOSE_FILE" config --services 2>/dev/null | grep -E '(^|-)web$' || true); do
+    LOCAL_PORT=$(docker compose -f "$COMPOSE_FILE" port "$svc" 8000 2>/dev/null | awk -F: '{print $NF}' | head -1 || true)
+    [[ -n "$LOCAL_PORT" ]] && break
+  done
+
+  if [[ -z "$LOCAL_PORT" ]]; then
+    LOCAL_PORT=$(awk '
+      /^  [a-zA-Z0-9_-]+-web:[[:space:]]*$/ { in_web=1; next }
+      /^  [a-zA-Z0-9_-]+:[[:space:]]*$/     { in_web=0 }
+      in_web && match($0, /127\.0\.0\.1:[0-9]+/) {
+        s = substr($0, RSTART, RLENGTH)
+        sub(/.*:/, "", s)
+        print s; exit
+      }
+    ' "$APP_PATH/$COMPOSE_FILE" || true)
+  fi
+
+  if [[ -z "$LOCAL_PORT" ]]; then
+    LOCAL_PORT=$(grep -oP '127\.0\.0\.1:\K\d+' "$APP_PATH/$COMPOSE_FILE" | head -1 || true)
+  fi
+
+  if [[ -n "$LOCAL_PORT" ]]; then
+    HEALTH_CHECK_URL="http://127.0.0.1:${LOCAL_PORT}/livez/"
+    echo "Staging: using local health check $HEALTH_CHECK_URL"
+  fi
+fi
+
 if [[ -n "$HEALTH_CHECK_URL" ]]; then
   echo "Health-Check: $HEALTH_CHECK_URL"
   for i in $(seq 1 12); do
@@ -109,6 +145,6 @@ fi
 docker image prune -f 2>/dev/null || true
 
 trap - ERR
-echo "═══════════════════════════════════════════════"
+echo "═══════════════════════════════════════════════════"
 echo "✅ Deploy erfolgreich: $APP_NAME:$IMAGE_TAG ($ENVIRONMENT)"
-echo "═══════════════════════════════════════════════"
+echo "═══════════════════════════════════════════════════"


### PR DESCRIPTION
## Summary

Two optional successor-ADRs to ADR-199 (rejected, see [PR #135](https://github.com/achimdehnert/platform/pull/135)). Both are **conditional on ADR-201 measurement outcome** — if pricing visibility alone closes the \$1577 lane in 14 days, neither is needed.

| ADR | Status | Aufwand | Hebel |
|---|---|---|---|
| ADR-202 JIT-Tier-Reassignment | proposed (conditional) | 1 day skeleton + 1 day wrap + 14d observe | ~5× cost reduction if escalation heuristic holds, BUT latency-doubling risk on hard tasks |
| ADR-203 Anthropic-Alias Adoption | proposed (conditional) | 1 day | Drift-Wartung verschiebt zu Anthropic, BUT silent behavioral drift risk |

Beide ADRs sind bewusst klein (~100 Zeilen) und explizit "trade-off-ehrlich" — Lehre aus ADR-199's drei Iterationen.

## Critical Reading

Both ADRs include honest risk-registers that may make them inadvisable:

- **ADR-202** is anti-pattern in agentic loops (first call defines a path the second can't reproduce). Heuristics for "uncertainty" are regex-fragile. Latency doubles on 20% of calls.
- **ADR-203** trades dead-string-loud-fail for behavioral-silent-drift. Pricing tracking becomes inaccurate. Reproducibility breaks. Includes an OOB internal-alias alternative (`iil/sonnet-current`) that keeps drift control internal.

PR may be rejected after reviewer applies advocatus-diaboli — see companion review document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)