### PR TITLE
fix(deploy): staging compose-sync uses dir target; deploy.sh detects staging compose

### DIFF
--- a/.github/workflows/_deploy-unified.yml
+++ b/.github/workflows/_deploy-unified.yml
@@ -204,8 +204,10 @@ jobs:
           key: ${{ secrets.STAGING_SSH_KEY }}
           fingerprint: ${{ secrets.STAGING_SSH_FINGERPRINT }}
           source: "docker-compose.staging.yml"
-          # deploy.sh on staging uses docker-compose.yml (no env-specific suffix)
-          target: "${{ inputs.app_path }}/docker-compose.yml"
+          # scp-action treats `target` as a directory and creates the file
+          # inside it. deploy.sh detects `docker-compose.staging.yml` for the
+          # staging environment automatically (see ADR-022).
+          target: "${{ inputs.app_path }}"
           overwrite: true
 
       - name: Deploy to staging

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -33,10 +33,15 @@ if [[ -f "$APP_PATH/.env" ]]; then
   PREVIOUS_TAG=$(grep "^IMAGE_TAG=" "$APP_PATH/.env" | cut -d= -f2 || true)
 fi
 
-# Compose-File nach Umgebung wählen (ADR-022: docker-compose.prod.yml für Production)
+# Compose-File nach Umgebung wählen (ADR-022)
+# Production: docker-compose.prod.yml
+# Staging:    docker-compose.staging.yml
+# Fallback:   docker-compose.yml
 COMPOSE_FILE="docker-compose.yml"
 if [[ "$ENVIRONMENT" == "production" && -f "$APP_PATH/docker-compose.prod.yml" ]]; then
   COMPOSE_FILE="docker-compose.prod.yml"
+elif [[ "$ENVIRONMENT" == "staging" && -f "$APP_PATH/docker-compose.staging.yml" ]]; then
+  COMPOSE_FILE="docker-compose.staging.yml"
 fi
 
 # Staging: eigenes Compose-Projekt um DEV-Container nicht zu überschreiben


### PR DESCRIPTION
Tiny follow-up to #143/#145.

Previous PR's staging compose-sync set scp-action's `target` to the full file path. scp-action treats that as a directory and creates it as a folder → copy fails → staging deploy aborts.

Fix: target is now the directory; deploy.sh prefers `docker-compose.staging.yml` for ENVIRONMENT=staging (mirroring the prod-side `docker-compose.prod.yml` preference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)