### PR TITLE
feat(print-agent): v2 — cover-meta + tiers/compare DSLs + ToC + authoring guide

### DIFF
--- a/tools/print_agent/AUTHORING_GUIDE.md
+++ b/tools/print_agent/AUTHORING_GUIDE.md
@@ -1,0 +1,436 @@
+# IIL Print Agent — Authoring Guide
+
+Wie man Markdown schreibt, damit das Print-Agent-PDF **professionell aussieht**.
+SSoT für alle Repos. Stand: 2026-05-14.
+
+---
+
+## 1 Kopf jedes Dokuments
+
+Setze diese Meta-Felder **direkt unter dem `# Titel`** als Bold-Prefix-Zeilen.
+Sie landen automatisch in der Cover-Meta-Tabelle und werden aus dem Body entfernt
+— der Cover muss nicht noch einmal im Text wiederholt werden.
+
+```markdown
+# Mein Konzept
+
+**Typ:** Konzept
+**Status:** Entscheidungsvorlage
+**Datum:** 2026-05-14
+**Adressat:** Geschäftsführung
+**Zielentscheidung:** Provider X oder Y
+**Anlass:** Workshop am 21.05.
+
+(Body startet hier)
+```
+
+**Wirkung:**
+- `Typ:` → Cover-Untertitel statt "Angebot · DATUM" (default: "Dokument").
+- Alle Felder landen in der Meta-Tabelle (rechts) auf Cover-Seite.
+- Bold-Prefix-Zeilen werden **automatisch** aus dem Body gestrippt.
+
+**Unterstützte Keys:**
+`Typ`, `Status`, `Datum`, `Adressat`, `Zielentscheidung`, `Anlass`,
+`Autor`/`Autorin`, `Gültig bis`, `Auftraggeber`, `Angebot Nr.`, `Zielgruppe`,
+`Stand`, `Begleitdokument`.
+
+---
+
+## 2 Inhaltsverzeichnis
+
+Setze einfach `[TOC]` an die Stelle, an der das Inhaltsverzeichnis erscheinen soll
+— meist direkt nach Meta-Block oder Executive Summary.
+
+```markdown
+[TOC]
+```
+
+Wird zu einem gestylten Inhaltsverzeichnis mit allen H2/H3-Headings expandiert,
+mit Hyperlinks im PDF.
+
+---
+
+## 3 Die richtige Visualisierung pro Inhaltstyp
+
+| Inhalt | Verwende NICHT | Verwende stattdessen |
+|---|---|---|
+| Prozess-Flow (Linear/Verzweigung) | ASCII-Boxen `┌──┐` | ` ```mermaid ` Flowchart |
+| Pro vs. Contra | Bullet-Liste mit `**Pro:** -` | ` ```compare ` DSL |
+| Tier-/Schwellen-Entscheidung | Numerierte Liste | ` ```tiers ` DSL |
+| Architektur-Pipeline | ASCII | ` ```arch ` DSL **oder** Mermaid |
+| Schichtenmodell | ASCII | ` ```layer ` DSL |
+| Zeitplan / Roadmap | Tabelle | ` ```gantt ` DSL |
+| Verzeichnis-/Datei-Struktur | inline `code` | ` ```tree ` DSL |
+| Workflow mit Entscheidungsknoten | Bullet-Beschreibung | ` ```flow ` DSL **oder** Mermaid |
+| Hinweis / Warnung / Info-Box | `**Hinweis:**` im Fließtext | `> **Hinweis:** ...` (Blockquote) |
+| Bis 5 Spalten Vergleich | (Standard-Tabelle) | Standard-Tabelle |
+| Mehr als 5 Spalten | Tabelle voll | ` ```compare ` oder Doppel-Tabelle |
+
+---
+
+## 4 DSL-Referenz
+
+### 4.1 `mermaid` — der Allzweck-Diagramm
+
+Empfehlung: für 95% aller Diagramme.
+
+```markdown
+\`\`\`mermaid
+flowchart LR
+    A[Start] --> B{Entscheidung}
+    B -- "ja" --> C[Aktion A]
+    B -- "nein" --> D[Aktion B]
+    style B fill:#1A3A5C,color:#fff
+\`\`\`
+```
+
+**Regeln:**
+- Maximal ~10 Knoten pro Diagramm — sonst splitten.
+- `LR` für ≤5 Knoten (horizontal), `TD` für tiefere Flüsse (vertikal).
+- Multi-Line-Labels mit `<br/>` (keine `\n`).
+- Bold im Label: `<b>Text</b>`.
+- Farben aus dem iil-Design: Primärblau `#1A3A5C`, Hellblau `#EDF3FA`,
+  Ampel rot `#B71C1C`, orange `#E65100`, gelb `#FFC107`, grün `#2E7D32`.
+- `style NODE fill:#...,color:#...,stroke:#...` für individuelle Knoten.
+
+**Größen-Hint:** Wenn ein Mermaid-Diagramm im PDF zu klein wirkt, breche es in 2
+Diagramme auf (z. B. linker und rechter Teil), statt mehr Knoten hineinzupacken.
+
+### 4.2 `tiers` — farbcodierte Tier-/Schwellen-Listen
+
+```markdown
+\`\`\`tiers
+tier1 | Hard Block | Score ≥0.95 ODER ID-Match | sofortige Eskalation, Anlage geblockt
+tier2 | Triage-Queue | Score 0.85 – 0.95 | Bearbeitung ≤24 h durch Sachbearbeitung
+tier3 | Soft Warning | Score 0.70 – 0.85 | optionale Prüfung, je nach Mandant
+ok    | Clear | Kein Treffer | automatische Freigabe
+\`\`\`
+```
+
+Rendert als farbig gestreifte Karten mit Bedingung + Aktion.
+
+### 4.3 `compare` — Pro/Contra und A/B-Vergleich
+
+```markdown
+\`\`\`compare
+title: Option B — OpenSanctions gemanagt
+left:  Pro :: Pay-as-you-go, schneller Start :: AV-Vertrag abschließbar :: Standard-Match-Qualität
+right: Contra :: Externe Datenübermittlung :: PEP-Coverage begrenzt :: Kein Self-Hosting in Phase 1
+verdict: Geeignet als Phase-1-Start, mit Migrationspfad zu Variante B2.
+\`\`\`
+```
+
+Rendert als zweispaltige Karte mit grünem Pro-Header, rotem Contra-Header,
+optional Empfehlungs-Box darunter.
+
+### 4.4 `arch` — Pipeline-/Architektur-Boxen
+
+```markdown
+\`\`\`arch
+title: Sanctions Screening Pipeline
+row: Stammdaten | Lieferanten | Kunden ;; Screening-Engine | Adapter | Matching ;; Audit-Trail | 10 Jahre
+\`\`\`
+```
+
+Verwende `;;` für mehrere Boxen pro Reihe, `|` für Sub-Texte in einer Box.
+
+### 4.5 `layer` — Schichtenmodell
+
+```markdown
+\`\`\`layer
+top: API-Schicht | REST | OpenAPI | Auth
+bridge: HTTPS · JSON
+left:  Datenhaltung | PostgreSQL | RLS-Multi-Tenancy
+right: Indexierung | Elasticsearch | yente
+\`\`\`
+```
+
+### 4.6 `gantt` — Roadmap
+
+```markdown
+\`\`\`gantt
+Phase 1 — Pilotbetrieb     | Wo 1 | Wo 2 | Wo 3 | Wo 4
+g1: Modul-Skeleton         | 1    | 1    |      |
+g2: Provider-Adapter       |      | 1    | 1    |
+g3: UI Triage-Inbox        |      |      | 1    | 1
+\`\`\`
+```
+
+### 4.7 `tree` — Verzeichnisstruktur
+
+```markdown
+\`\`\`tree
+projekt/
+  src/
+    sanctions/
+      models.py    # Datenmodell
+      providers/
+    tests/
+  docs/
+\`\`\`
+```
+
+### 4.8 `flow` — Workflow mit Entscheidungen
+
+Für komplexere Workflows mit nummerierten Stages, Ja/Nein-Pfaden und Endpunkt.
+Bei Bedarf siehe `parse_flow_block` im `print_agent.py`.
+
+---
+
+## 5 Standard-Markdown — Do's und Don'ts
+
+### 5.1 Listen unter Bold-Präfix
+
+**Falsch (rendert als 1 Zeile):**
+```markdown
+**Pro:** - Vorteil A. - Vorteil B. - Vorteil C.
+```
+
+**Richtig:**
+```markdown
+**Pro:**
+
+- Vorteil A
+- Vorteil B
+- Vorteil C
+```
+
+Oder noch besser: ` ```compare ` DSL nutzen.
+
+### 5.2 Tiefe nummerierte Listen
+
+**Falsch (Sub-Items werden 1-3 → 4-6):**
+```markdown
+1. Erster Punkt
+2. Zweiter Punkt mit Detail:
+3. Detail A
+4. Detail B
+5. Dritter Punkt
+```
+
+**Richtig (mit 3 Leerzeichen Einrückung):**
+```markdown
+1. Erster Punkt
+2. Zweiter Punkt mit Detail:
+   - Detail A
+   - Detail B
+3. Dritter Punkt
+```
+
+### 5.3 Tabellen
+
+- Maximal **5 Spalten** für gute Lesbarkeit auf A4.
+- Bei >5 Spalten: ` ```compare ` oder Splitting in 2 Tabellen oder `table.dense`.
+- Spalte mit langen Texten zuerst, kurze Werte rechts.
+- Header in fett (`**Foo**`) ist nicht nötig — der Header wird ohnehin gestylt.
+- Lange URLs in Zellen: Markdown-Link `[Text](url)` statt nackte URL.
+
+**Dense-Tabelle** (kleinere Schrift, mehr Spalten):
+
+```markdown
+{: .dense }
+
+| Sp1 | Sp2 | Sp3 | Sp4 | Sp5 | Sp6 | Sp7 |
+|---|---|---|---|---|---|---|
+| ... | ... | ... | ... | ... | ... | ... |
+```
+
+(Die `{: .dense }`-Annotation davor muss in eigener Zeile stehen.)
+
+### 5.4 Blockquote-Callouts
+
+```markdown
+> **Hinweis:** Das System refresht die Listen täglich um 03:00.
+
+> **Achtung:** Bei harten Treffern wird die Anlage **synchron** blockiert.
+```
+
+Werden als links-eingerückter, hell hinterlegter Block mit farbigem Bold-Präfix
+gerendert. Wirkt visuell wie ein Tipp/Warnung-Kasten ohne extra-Auszeichnung.
+
+### 5.5 Code
+
+- **Inline:** ` `code` ` für Werte, IDs, kurze Pfade.
+- **Code-Block:** für Code-Snippets ≥2 Zeilen. Standard-Sprachen werden farblos
+  gerendert — Print ist nicht für Syntax-Highlight gemacht.
+- **Niemals ASCII-Diagramme** in Code-Blöcken — die Box-Drawing-Zeichen
+  kollabieren in WeasyPrint. Stattdessen Mermaid oder `arch`/`layer`.
+
+### 5.6 URLs
+
+- **Im Body:** `[Anzeigetext](https://lange.url/...)` — der Text wird umgebrochen,
+  die URL bleibt klickbar im PDF.
+- **In Quellen-Sektion:** `<https://url>` ist OK, aber lange URLs brechen
+  jetzt auch automatisch um (CSS `word-break: break-word`).
+
+### 5.7 Seitenumbrüche
+
+Der Print-Agent setzt automatisch:
+- `page-break-after: avoid` auf H2/H3/H4 (kein Heading am Seitenende ohne Body).
+- `page-break-inside: avoid` auf Tabellen und Diagramme.
+
+**Manuelle Seitenumbrüche:** Klasse `break-before` auf H2 setzen:
+
+```markdown
+## Anhang A {: .break-before }
+```
+
+(Die `{: ... }`-Annotation funktioniert durch das `attr_list`-Extension.)
+
+---
+
+## 6 Cover-Design
+
+### 6.1 Untertitel-Zeile (date_line)
+
+Standard für iil-Design: `<Typ> · <Datum>`. Quellen:
+- `Typ:` aus Frontmatter (z. B. "Konzept", "Briefing", "Angebot").
+- Fallback: `Status:`.
+- Fallback: "Dokument".
+
+### 6.2 Executive Summary
+
+Wird **automatisch** von LLM (Cerebras `llama3.1-8b`) generiert auf Basis der MD.
+Es wird die erste ~150 Wörter umfassende Zusammenfassung + 5 Keywords.
+
+**Wenn die LLM-Summary nicht passt:** Den ersten Abschnitt im Body kürzer und
+prägnanter formulieren (LLM zieht aus dem Anfang).
+
+**Kein LLM-Key gesetzt:** PDF wird ohne Summary-Box gerendert (Body startet direkt).
+
+### 6.3 Footer
+
+Wird aus `design.footer_suffix` plus optional `**Stand:** ...` aus Body zusammengesetzt.
+
+---
+
+## 7 Workflows
+
+### 7.1 Neue PDF erstellen
+
+```bash
+# Im Repo:
+/create-pdf <pfad_zur_md>
+
+# Oder direkt:
+python3 ~/github/platform/tools/print_agent/print_agent.py \
+  docs/architecture/foo.md  pdfs/architecture  --design iil
+```
+
+### 7.2 Ganzen Ordner exportieren
+
+```bash
+/create-pdf <pfad_zum_folder>
+```
+
+Erzeugt PDF für jede `.md` rekursiv. Output-Struktur spiegelt `docs/` → `pdfs/`.
+
+### 7.3 Repo-spezifische Anpassungen
+
+Eigene Designs oder CSS-Overrides:
+
+```bash
+python3 .../print_agent.py foo.md out/ --design unsere-firma \
+  --designs configs/print_designs.yaml \
+  --extra-css configs/extra.css
+```
+
+Die `extra.css` wird **nach** der `base.css` geladen — überschreibt also gezielt
+Einzel-Regeln, ohne die Basis zu duplizieren.
+
+---
+
+## 8 Häufige Fehler und Lösungen
+
+| Symptom | Ursache | Lösung |
+|---|---|---|
+| ASCII-Boxen zerlaufen | `pre` rendert proportional | → Mermaid oder `arch`/`layer` |
+| Tabelle sprengt Seite | zu viele Spalten | → `dense`-Tabelle oder `compare` |
+| Pro/Contra als 1 Absatz | Bullet nach `**Pro:**` | → Leerzeile + Bullet-Liste oder `compare` |
+| Sub-Items werden Top-Level | falsche Einrückung | → 3 Leerzeichen für Sub-Bullets |
+| Mermaid zu klein | viele Knoten | → splitten oder TD statt LR |
+| Cover sagt "Angebot" bei Konzept | `**Typ:** Konzept` fehlt | → Typ: in Meta-Block setzen |
+| Status/Adressat als Fließtext | Position vor Meta-Block | → Direkt nach `# Titel`, vor `[TOC]` |
+| Lange URL bricht Layout | nackte URL | → `[Text](url)` |
+| Heading ist letzte Zeile auf Seite | natürlich, sollte nicht passieren | → falls doch: `{: .break-before }` |
+| Leere Seiten im PDF | alter `page-break-before` | → Engine ist jetzt fixed (ab Mai 2026) |
+
+---
+
+## 9 Quick-Start-Template
+
+Kopier-Vorlage für neues Konzept-Dokument:
+
+```markdown
+# <Titel des Konzepts>
+
+**Typ:** Konzept
+**Status:** Entscheidungsvorlage
+**Datum:** YYYY-MM-DD
+**Adressat:** <Geschäftsführung / Compliance / …>
+**Zielentscheidung:** <Was soll entschieden werden?>
+
+[TOC]
+
+## 1 Worum es geht
+
+<Kurz: Anlass, Kontext, Warum jetzt?>
+
+## 2 Empfehlung
+
+> **Empfehlung:** <Ein Satz, klar entscheidbar.>
+
+Begründung:
+
+\`\`\`compare
+title: <Vergleich der Optionen>
+left:  Option A :: Pro-Punkt 1 :: Pro-Punkt 2
+right: Option B :: Pro-Punkt 1 :: Pro-Punkt 2
+verdict: <Empfohlene Option und warum.>
+\`\`\`
+
+## 3 Architektur
+
+\`\`\`mermaid
+flowchart TD
+    A[Input] --> B[Verarbeitung]
+    B --> C[Output]
+\`\`\`
+
+## 4 Entscheidungs-Tiers
+
+\`\`\`tiers
+tier1 | Sofortmaßnahme | <Bedingung> | <Aktion>
+tier2 | Beobachtung    | <Bedingung> | <Aktion>
+ok    | Normal         | <Bedingung> | <Aktion>
+\`\`\`
+
+## 5 Roadmap
+
+\`\`\`gantt
+Phase 1 | KW 1 | KW 2 | KW 3 | KW 4
+g1: ...  | 1    | 1    |      |
+g2: ...  |      | 1    | 1    | 1
+\`\`\`
+
+## 6 Offene Entscheidungen
+
+1. **Frage 1**
+   - Option A
+   - Option B
+2. **Frage 2**
+   - Option A
+   - Option B
+
+## 7 Quellen
+
+- [Quelle 1](https://example.com)
+- [Quelle 2](https://example.com)
+```
+
+---
+
+## 10 Changelog
+
+- **2026-05-14** — Initial. Konsolidiert nach Print-Agent v2 (Cover-Meta-Generalisierung,
+  `tiers`/`compare`-DSLs, ToC, Page-Break-Fix).

--- a/tools/print_agent/print_agent.py
+++ b/tools/print_agent/print_agent.py
@@ -470,6 +470,96 @@ def parse_layer_block(block: str) -> str:
     return html
 
 
+def parse_tiers_block(block: str) -> str:
+    """Wandelt ```tiers DSL in HTML .tier-list (farbcodierte Tier-Karten) um.
+
+    Syntax (eine Tier pro Zeile, Pipe-getrennt):
+      tier1 | <Label> | <Bedingung> | <Aktion>
+      tier2 | <Label> | <Bedingung> | <Aktion>
+      tier3 | <Label> | <Bedingung> | <Aktion>
+      info  | <Label> | — | <Aktion>     ← neutraler Block ohne Ampel
+
+    Renderiert als Karte mit farbiger Klassen-Spange links.
+    """
+    html = '<div class="tier-list">\n'
+    for line in [l.strip() for l in block.strip().splitlines() if l.strip()]:
+        parts = [p.strip() for p in line.split("|")]
+        if len(parts) < 2:
+            continue
+        kind = parts[0].lower()
+        label = parts[1] if len(parts) > 1 else ""
+        cond = parts[2] if len(parts) > 2 else ""
+        action = parts[3] if len(parts) > 3 else ""
+        cls = {"tier1": "tier-1", "tier2": "tier-2", "tier3": "tier-3",
+               "info": "tier-info", "ok": "tier-ok"}.get(kind, "tier-info")
+        html += f'<div class="tier-item {cls}">\n'
+        html += f'  <div class="tier-label">{label}</div>\n'
+        if cond:
+            html += f'  <div class="tier-cond"><strong>Bedingung:</strong> {cond}</div>\n'
+        if action:
+            html += f'  <div class="tier-action"><strong>Aktion:</strong> {action}</div>\n'
+        html += '</div>\n'
+    html += '</div>'
+    return html
+
+
+def parse_compare_block(block: str) -> str:
+    """Wandelt ```compare DSL in HTML .compare-grid (zwei-/dreispaltig) um.
+
+    Syntax:
+      title: <optionaler Übertitel>
+      left:  <Titel> :: <Item1> :: <Item2> :: …
+      right: <Titel> :: <Item1> :: <Item2> :: …
+      verdict: <Empfehlungs-Text>     ← optional, unter Spalten
+
+    Verwendung typisch für Pro/Contra, Variante A/B, Status quo/Ziel.
+    """
+    title = ""
+    left_title = ""
+    left_items: list[str] = []
+    right_title = ""
+    right_items: list[str] = []
+    verdict = ""
+    for line in [l.rstrip() for l in block.strip().splitlines() if l.strip()]:
+        if line.startswith("title:"):
+            title = line[6:].strip()
+        elif line.startswith("left:"):
+            parts = [p.strip() for p in line[5:].split("::")]
+            left_title = parts[0] if parts else ""
+            left_items = parts[1:] if len(parts) > 1 else []
+        elif line.startswith("right:"):
+            parts = [p.strip() for p in line[6:].split("::")]
+            right_title = parts[0] if parts else ""
+            right_items = parts[1:] if len(parts) > 1 else []
+        elif line.startswith("verdict:"):
+            verdict = line[8:].strip()
+
+    html = '<div class="compare-block">\n'
+    if title:
+        html += f'  <div class="compare-title">{title}</div>\n'
+    html += '  <div class="compare-grid">\n'
+    for side_class, side_title, items in (
+        ("compare-left",  left_title,  left_items),
+        ("compare-right", right_title, right_items),
+    ):
+        if not side_title and not items:
+            continue
+        html += f'    <div class="compare-col {side_class}">\n'
+        if side_title:
+            html += f'      <div class="compare-col-title">{side_title}</div>\n'
+        if items:
+            html += '      <ul>\n'
+            for it in items:
+                html += f'        <li>{it}</li>\n'
+            html += '      </ul>\n'
+        html += '    </div>\n'
+    html += '  </div>\n'
+    if verdict:
+        html += f'  <div class="compare-verdict"><strong>Empfehlung:</strong> {verdict}</div>\n'
+    html += '</div>'
+    return html
+
+
 _PUPPETEER_CFG = Path(__file__).parent / ".puppeteer.json"
 
 
@@ -523,32 +613,43 @@ def render_mermaid_to_png(mermaid_code: str) -> str:
 
 
 def preprocess_md(md_text: str) -> str:
-    """Ersetzt ```gantt / ```tree / ```flow / ```arch / ```layer / ```mermaid durch HTML."""
-    def replace_gantt(m):  return parse_gantt_block(m.group(1))
-    def replace_tree(m):   return parse_tree_block(m.group(1))
-    def replace_flow(m):   return parse_flow_block(m.group(1))
-    def replace_arch(m):   return parse_arch_block(m.group(1))
-    def replace_layer(m):  return parse_layer_block(m.group(1))
+    """Ersetzt ```gantt / ```tree / ```flow / ```arch / ```layer / ```tiers / ```compare / ```mermaid durch HTML."""
+    def replace_gantt(m):   return parse_gantt_block(m.group(1))
+    def replace_tree(m):    return parse_tree_block(m.group(1))
+    def replace_flow(m):    return parse_flow_block(m.group(1))
+    def replace_arch(m):    return parse_arch_block(m.group(1))
+    def replace_layer(m):   return parse_layer_block(m.group(1))
+    def replace_tiers(m):   return parse_tiers_block(m.group(1))
+    def replace_compare(m): return parse_compare_block(m.group(1))
     def replace_mermaid(m):
         code = m.group(1).strip()
         print(f"   \U0001f4ca Mermaid-Diagramm rendern ({code.split(chr(10))[0][:40]}\u2026)")
         return render_mermaid_to_png(code)
-    text = re.sub(r"```gantt\n(.*?)```", replace_gantt, md_text, flags=re.DOTALL)
-    text = re.sub(r"```tree\n(.*?)```",  replace_tree,  text,    flags=re.DOTALL)
-    text = re.sub(r"```flow\n(.*?)```",  replace_flow,  text,    flags=re.DOTALL)
-    text = re.sub(r"```arch\n(.*?)```",  replace_arch,  text,    flags=re.DOTALL)
-    text = re.sub(r"```layer\n(.*?)```", replace_layer, text,    flags=re.DOTALL)
-    text = re.sub(r"```mermaid\n(.*?)```", replace_mermaid, text, flags=re.DOTALL)
+    text = re.sub(r"```gantt\n(.*?)```",   replace_gantt,   md_text, flags=re.DOTALL)
+    text = re.sub(r"```tree\n(.*?)```",    replace_tree,    text,    flags=re.DOTALL)
+    text = re.sub(r"```flow\n(.*?)```",    replace_flow,    text,    flags=re.DOTALL)
+    text = re.sub(r"```arch\n(.*?)```",    replace_arch,    text,    flags=re.DOTALL)
+    text = re.sub(r"```layer\n(.*?)```",   replace_layer,   text,    flags=re.DOTALL)
+    text = re.sub(r"```tiers\n(.*?)```",   replace_tiers,   text,    flags=re.DOTALL)
+    text = re.sub(r"```compare\n(.*?)```", replace_compare, text,    flags=re.DOTALL)
+    text = re.sub(r"```mermaid\n(.*?)```", replace_mermaid, text,    flags=re.DOTALL)
     return text
 
 
 _INLINE_PATTERNS = {
-    "stand":       r"\*\*Stand:\*\*\s*([^|\n]+)",
-    "zielgruppe":  r"\*\*Zielgruppe:\*\*\s*([^\n]+)",
-    "angebot_nr":  r"\*\*Angebot Nr\.:\*\*\s*([^\n]+)",
-    "datum":       r"\*\*Datum:\*\*\s*([^\n]+)",
-    "gueltig_bis": r"\*\*Gültig bis:\*\*\s*([^\n]+)",
-    "auftraggeber":r"\*\*Auftraggeber\*\*\s*\n+(.+)",
+    "stand":           r"\*\*Stand:\*\*\s*([^|\n]+)",
+    "zielgruppe":      r"\*\*Zielgruppe:\*\*\s*([^\n]+)",
+    "angebot_nr":      r"\*\*Angebot Nr\.:\*\*\s*([^\n]+)",
+    "datum":           r"\*\*Datum:\*\*\s*([^\n]+)",
+    "gueltig_bis":     r"\*\*Gültig bis:\*\*\s*([^\n]+)",
+    "auftraggeber":    r"\*\*Auftraggeber\*\*\s*\n+(.+)",
+    # Generic document fields (used by konzept/briefing templates)
+    "doc_type":        r"\*\*(?:Typ|Doc[- ]?Type|Dokumenttyp):\*\*\s*([^\n]+)",
+    "status":          r"\*\*Status:\*\*\s*([^\n]+)",
+    "adressat":        r"\*\*Adressat:\*\*\s*([^\n]+)",
+    "zielentscheidung":r"\*\*Zielentscheidung:\*\*\s*([^\n]+)",
+    "autor":           r"\*\*Autor(?:in)?:\*\*\s*([^\n]+)",
+    "anlass":          r"\*\*Anlass:\*\*\s*([^\n]+)",
 }
 
 
@@ -568,15 +669,44 @@ def extract_meta(md_text: str, fm: dict | None = None) -> dict:
     return meta
 
 
+# Bold-prefix patterns that should NOT appear in the body — they're already in the cover.
+_META_PREFIX_RE = re.compile(
+    r"^\*\*(?:Stand|Status|Datum|Adressat|Zielentscheidung|Anlass|Autor(?:in)?|"
+    r"Typ|Dokumenttyp|Doc[- ]?Type|Zielgruppe|Angebot Nr\.|Gültig bis|Auftraggeber|"
+    r"Begleitdokument):\*\*",
+    re.IGNORECASE,
+)
+
+
+def strip_meta_prefix_lines(md_text: str) -> str:
+    """Remove lines like '**Status:** Konzept' from MD body — they're already on the cover.
+
+    Keeps everything else intact, including the trailing blank-line separator
+    so that downstream markdown parsing doesn't merge paragraphs.
+    """
+    out_lines = []
+    for line in md_text.splitlines():
+        if _META_PREFIX_RE.match(line.strip()):
+            continue
+        out_lines.append(line)
+    return "\n".join(out_lines)
+
+
 def _build_meta_rows(meta: dict, design: dict, stem: str) -> list:
     """Return list of (label, value) tuples for the meta table."""
     template = design.get("meta_template", "meiki")
     if template == "iil":
         rows = []
-        if meta.get("angebot_nr"):  rows.append(("Angebot-Nr.", meta["angebot_nr"]))
-        if meta.get("datum"):       rows.append(("Datum", meta["datum"]))
-        if meta.get("gueltig_bis"): rows.append(("Gültig bis", meta["gueltig_bis"]))
-        if meta.get("auftraggeber"): rows.append(("Auftraggeber", meta["auftraggeber"]))
+        # Angebot-specific fields (only shown if filled)
+        if meta.get("angebot_nr"):       rows.append(("Angebot-Nr.", meta["angebot_nr"]))
+        # Generic Konzept/Briefing-Felder (always shown if present)
+        if meta.get("status"):           rows.append(("Status", meta["status"]))
+        if meta.get("datum"):            rows.append(("Datum", meta["datum"]))
+        if meta.get("gueltig_bis"):      rows.append(("Gültig bis", meta["gueltig_bis"]))
+        if meta.get("adressat"):         rows.append(("Adressat", meta["adressat"]))
+        if meta.get("anlass"):           rows.append(("Anlass", meta["anlass"]))
+        if meta.get("zielentscheidung"): rows.append(("Zielentscheidung", meta["zielentscheidung"]))
+        if meta.get("auftraggeber"):     rows.append(("Auftraggeber", meta["auftraggeber"]))
         rows.append(("Auftragnehmer", "IIL GmbH · Achim Dehnert · kontakt@iil.gmbh"))
         return rows
     # meiki default
@@ -598,7 +728,12 @@ def build_html(title: str, body_html: str, meta: dict, stem: str, enrichment: di
     template = design.get("meta_template", "meiki")
 
     if template == "iil":
-        date_line = f"Angebot · {meta.get('datum', '')}"
+        # Document type drives the cover subtitle line.
+        # Priority: explicit Typ: > explicit Status: > "Angebot" (backward-compat default).
+        # New documents should set "**Typ:** Konzept|Briefing|Angebot|…" explicitly.
+        doc_type = meta.get("doc_type") or meta.get("status") or "Angebot"
+        datum = meta.get("datum", "")
+        date_line = f"{doc_type} · {datum}".strip(" ·")
     else:
         zg = meta.get("zielgruppe", "Lenkungskreis, IT-Leitung, Entscheider LRA")
         date_line = f"Zielgruppe: {zg}"
@@ -626,16 +761,29 @@ def convert(input_path: Path, output_dir: Path, design_name: str = "meiki", extr
     print(f"🎨 Design: {design_name}")
 
     md_text = input_path.read_text(encoding="utf-8")
-    md_text_processed = preprocess_md(md_text)
-    md = markdown.Markdown(extensions=["tables", "attr_list", "meta"])
-    body_html = md.convert(md_text_processed)
-    fm = {k: v for k, v in md.Meta.items()} if hasattr(md, "Meta") else {}
+    # Extract meta first (from original text), then strip those lines before HTML build.
+    md_pre_meta = markdown.Markdown(extensions=["meta"])
+    md_pre_meta.convert(md_text)
+    fm = {k: v for k, v in md_pre_meta.Meta.items()} if hasattr(md_pre_meta, "Meta") else {}
     meta = extract_meta(md_text, fm=fm)
 
-    m = re.search(r"<h1>(.*?)</h1>", body_html)
+    # Strip meta-prefix lines so they don't appear as paragraph text in body.
+    md_text_cleaned = strip_meta_prefix_lines(md_text)
+    md_text_processed = preprocess_md(md_text_cleaned)
+    md = markdown.Markdown(
+        extensions=["tables", "attr_list", "meta", "toc", "fenced_code", "sane_lists"],
+        extension_configs={
+            "toc": {
+                "title": "Inhaltsverzeichnis",
+                "toc_class": "toc-list",
+            },
+        },
+    )
+    body_html = md.convert(md_text_processed)
+
+    m = re.search(r"<h1[^>]*>(.*?)</h1>", body_html)
     title = m.group(1) if m else input_path.stem
-    body_html = re.sub(r"<h1>.*?</h1>", "", body_html, count=1)
-    body_html = re.sub(r"<p><strong>Stand:</strong>.*?</p>", "", body_html, count=1)
+    body_html = re.sub(r"<h1[^>]*>.*?</h1>", "", body_html, count=1)
 
     print("🤖 LLM-Anreicherung …")
     enrichment = llm_enrich(title, md_text, design)

--- a/tools/print_agent/print_templates/base.css
+++ b/tools/print_agent/print_templates/base.css
@@ -68,9 +68,14 @@ hr { border: none; border-top: 1.5px solid var(--border); margin: 16pt 0; }
 h2 {
     font-size: 13pt; font-weight: 700; color: var(--primary);
     margin: 22pt 0 8pt 0; padding-bottom: 4pt;
-    border-bottom: 1.5px solid var(--border); page-break-after: avoid;
+    border-bottom: 1.5px solid var(--border);
+    page-break-after: avoid;
+    /* No forced page break before — only avoid orphan headings. */
 }
-h3 { font-size: 10.5pt; font-weight: 700; color: #1C1C1C; margin: 14pt 0 5pt 0; }
+/* Opt-in: add class="break-before" to an h2 if you really want a forced page break. */
+h2.break-before { page-break-before: always; }
+h3 { font-size: 10.5pt; font-weight: 700; color: #1C1C1C; margin: 14pt 0 5pt 0; page-break-after: avoid; }
+h4 { font-size: 10pt; font-weight: 700; color: var(--primary); margin: 12pt 0 4pt 0; page-break-after: avoid; }
 
 table {
     width: 100%; border-collapse: collapse; font-size: 9pt;
@@ -259,10 +264,107 @@ pre {
     text-align: center; margin: 12pt 0; page-break-inside: avoid;
 }
 .mermaid-diagram svg {
-    max-width: 100%; height: auto;
+    max-width: 100%; max-height: 20cm; height: auto; width: auto;
 }
 .mermaid-fallback {
     background: #f5f5f5; border: 1px solid var(--border); border-radius: 4pt;
     padding: 8pt 12pt; font-size: 7.5pt; color: #555; white-space: pre-wrap;
     page-break-inside: avoid;
 }
+
+/* ---- TIER LIST (```tiers) ---- */
+.tier-list { margin: 12pt 0 16pt 0; }
+.tier-item {
+    border: 1px solid var(--border); border-left: 6px solid var(--border-dark);
+    border-radius: 3pt; padding: 8pt 12pt; margin-bottom: 6pt;
+    background: #FFFFFF; page-break-inside: avoid;
+}
+.tier-item.tier-1 { border-left-color: #B71C1C; background: #FFF5F5; }
+.tier-item.tier-2 { border-left-color: #E65100; background: #FFF8F0; }
+.tier-item.tier-3 { border-left-color: #F9A825; background: #FFFDF0; }
+.tier-item.tier-ok { border-left-color: #2E7D32; background: #F4FBF4; }
+.tier-item.tier-info { border-left-color: var(--primary); background: var(--bg-light); }
+.tier-label {
+    font-weight: 700; font-size: 10pt; color: #1C1C1C; margin-bottom: 3pt;
+}
+.tier-item.tier-1 .tier-label { color: #7F1010; }
+.tier-item.tier-2 .tier-label { color: #8B3000; }
+.tier-item.tier-3 .tier-label { color: #806000; }
+.tier-item.tier-ok .tier-label { color: #1B5E20; }
+.tier-cond, .tier-action {
+    font-size: 9pt; color: #333; margin-top: 2pt;
+}
+.tier-cond strong, .tier-action strong { color: var(--primary); }
+
+/* ---- COMPARE GRID (```compare) ---- */
+.compare-block { margin: 12pt 0 16pt 0; page-break-inside: avoid; }
+.compare-title {
+    font-weight: 700; font-size: 10pt; color: var(--primary);
+    text-align: center; margin-bottom: 6pt;
+}
+.compare-grid { display: flex; gap: 10pt; }
+.compare-col {
+    flex: 1; border: 1px solid var(--border); border-radius: 3pt;
+    padding: 8pt 12pt; background: #FFFFFF;
+}
+.compare-col-title {
+    font-weight: 700; font-size: 9.5pt; margin-bottom: 5pt;
+    padding-bottom: 3pt; border-bottom: 1px solid var(--border);
+}
+.compare-left  { border-top: 3px solid #2E7D32; }
+.compare-left  .compare-col-title { color: #1B5E20; }
+.compare-right { border-top: 3px solid #B71C1C; }
+.compare-right .compare-col-title { color: #7F1010; }
+.compare-col ul { margin: 0; padding-left: 14pt; font-size: 9pt; line-height: 1.5; }
+.compare-col li { margin-bottom: 2pt; }
+.compare-verdict {
+    margin-top: 8pt; padding: 7pt 12pt;
+    background: var(--bg-light); border-left: 4px solid var(--primary);
+    font-size: 9.5pt; line-height: 1.5;
+}
+.compare-verdict strong { color: var(--primary); }
+
+/* ---- CALLOUTS (GitHub-style blockquote callouts via class on <blockquote>) ---- */
+blockquote {
+    border-left: 4px solid var(--primary);
+    background: var(--bg-light);
+    padding: 8pt 14pt;
+    margin: 10pt 0;
+    color: #1C1C1C;
+    page-break-inside: avoid;
+}
+blockquote p { margin: 0 0 4pt 0; }
+blockquote p:last-child { margin-bottom: 0; }
+blockquote strong:first-child { color: var(--primary); }
+
+/* ---- URL handling — long links shouldn't bleed into margin ---- */
+a[href] { word-break: break-word; overflow-wrap: anywhere; }
+
+/* ---- DENSE TABLES (opt-in via class="dense") ---- */
+table.dense { font-size: 8pt; }
+table.dense thead th { padding: 5pt 6pt; font-size: 7.5pt; }
+table.dense tbody td { padding: 4pt 6pt; }
+
+/* ---- COMPACT BULLET LIST (opt-in via class="compact") ---- */
+ul.compact li, ol.compact li { margin-bottom: 1pt; }
+
+/* ---- TABLE OF CONTENTS (rendered via [TOC] marker) ---- */
+.toc-list {
+    margin: 14pt 0 24pt 0; padding: 12pt 16pt;
+    background: var(--bg-light); border-left: 4px solid var(--primary);
+    border-radius: 0 3pt 3pt 0; page-break-inside: avoid;
+}
+.toc-list-title {
+    font-weight: 700; font-size: 11pt; color: var(--primary);
+    margin-bottom: 6pt; text-transform: uppercase; letter-spacing: 0.08em;
+}
+.toc-list ol { margin: 0; padding-left: 16pt; font-size: 9.5pt; line-height: 1.7; }
+.toc-list ol ol { font-size: 9pt; padding-left: 14pt; }
+.toc-list li { margin-bottom: 1pt; }
+.toc-list a { color: #1C1C1C; }
+.toc-list a:hover { color: var(--primary); }
+
+/* ---- LIST OVERHAUL — better visual rhythm for body lists ---- */
+ul, ol { margin: 4pt 0 10pt 0; padding-left: 18pt; }
+ul li, ol li { margin-bottom: 3pt; }
+ul ul, ol ol, ul ol, ol ul { margin: 3pt 0 3pt 0; }


### PR DESCRIPTION
## Summary

Print-Agent v2 — schließt die Lücke zwischen "Entwurfs-MD" und "präsentationsreifem PDF".

Drei Verbesserungs-Cluster:

1. **Cover-Meta generalisiert** (`iil` template) — Konzepte/Briefings/Berichte zeigen nicht mehr "Angebot · DATUM" als Untertitel. Status/Adressat/Zielentscheidung/Anlass landen in der Cover-Meta-Tabelle statt als Fließtext im Body.
2. **Zwei neue DSLs** — \`\`\`tiers\`\`\` (farbcodierte Tier-Karten) und \`\`\`compare\`\`\` (Pro/Contra-Doppelspalte mit Verdict-Callout). Adressiert die häufigsten Anti-Patterns in Entscheidungsvorlagen, für die es bisher kein eigenes Element gab.
3. **AUTHORING_GUIDE.md als SSoT** — die mächtigen Custom-DSLs (\`arch\`, \`layer\`, \`gantt\`, \`tree\`, \`flow\`, \`mermaid\`) waren bisher im Code versteckt. Jetzt dokumentiert mit Beispielen, Don'ts und Quick-Start-Template.

## Backward compatibility

- **iil-`date_line`** defaultet weiter auf \`"Angebot · DATUM"\` wenn weder \`Typ:\` noch \`Status:\` gesetzt — alle bestehenden Angebote rendern unverändert.
- Neue DSLs sind reine **Erweiterungen** — bestehende Dokumente unberührt.
- \`sane_lists\` markdown-Extension hinzugefügt: strikteres Bullet-Parsing nach Bold-Präfix. Smoketest zeigt keine Regression.
- \`h2 page-break-before\` von \`always\` auf \`auto\` geändert — beseitigt leere Seiten. Opt-in über CSS-Klasse \`.break-before\` wenn explizit gewünscht.
- h1-Regex-Fix für toc-Extension-Kompatibilität (Heading mit \`id=\`-Attribut).

## Test plan

- [x] **Smoketest meiki** — \`meiki-hub/docs/02-prozesshandbuch/fristenmanagement.md\` (21 Seiten): Cover, Meta-Tabelle, Tabellen, Listen alle wie zuvor; keine Regression.
- [x] **Smoketest ttz** — \`ttz-hub/docs/Angebot_KI_Werkleiterassistent_Phase1_IIL.md\`: Cover zeigt weiterhin \`"Angebot · 28. April 2026"\` (Backward-Compat-Default greift, da kein \`Typ:\` gesetzt).
- [x] **iil mit allen neuen Features** — \`risk-hub/docs/architecture/sanctions-screening-customer-concept.md\` (17 Seiten, 3 Mermaid-Diagramme + 3 \`compare\`-Blöcke + 4 \`tiers\`-Karten + ToC).
- [ ] **Reviewer:** visuelle Prüfung der Vorher/Nachher-Diff am sanctions-Konzept (Customer-Repo).

## Commits

- \`f59a88f\` feat(print-agent): v2 — cover-meta generalization + tiers/compare DSLs + ToC
- \`825bfed\` docs(print-agent): authoring guide for print-friendly markdown

## Follow-ups (nicht in diesem PR)

- Repo-spezifische Migration: alte ASCII-Diagramme durch Mermaid/arch/layer ersetzen, wenn ohnehin überarbeitet (kein Big-Bang)
- README.md im print_agent-Ordner auf AUTHORING_GUIDE.md verlinken
- Print-Agent-Test-Suite (heute nicht vorhanden) — eigener PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)