### PR TITLE
feat(workflows): tag 10 prominent workflows with mode: read-only|write

### DIFF
--- a/.windsurf/workflows/adr-review.md
+++ b/.windsurf/workflows/adr-review.md
@@ -1,5 +1,6 @@
 ---
 description: Review an ADR against the platform-specific checklist (MADR 4.0 + infrastructure conventions + Modern Platform Patterns)
+mode: read-only
 ---
 
 # ADR Review Workflow

--- a/.windsurf/workflows/adr.md
+++ b/.windsurf/workflows/adr.md
@@ -1,5 +1,6 @@
 ---
 description: Create new ADR with automatic scope detection, proper structure, and pgvector memory storage
+mode: write
 ---
 
 # ADR Creation Workflow

--- a/.windsurf/workflows/agentic-coding.md
+++ b/.windsurf/workflows/agentic-coding.md
@@ -1,5 +1,6 @@
 ---
 description: Fully Agentic Coding — Task definieren, planen, routen, ausführen, bewerten (v6)
+mode: write
 ---
 
 # Agentic Coding Workflow v6

--- a/.windsurf/workflows/deploy.md
+++ b/.windsurf/workflows/deploy.md
@@ -1,5 +1,6 @@
 ---
 description: Deploy any app to production (bfagent, cad-hub, travel-beat, etc.)
+mode: write
 ---
 
 # Deploy Workflow

--- a/.windsurf/workflows/governance-check.md
+++ b/.windsurf/workflows/governance-check.md
@@ -1,5 +1,6 @@
 ---
 description: Check platform governance before implementing new functionality
+mode: read-only
 ---
 
 # Platform Governance Check Workflow

--- a/.windsurf/workflows/infra-health.md
+++ b/.windsurf/workflows/infra-health.md
@@ -1,5 +1,6 @@
 ---
 description: Check health of all deployed services and infrastructure
+mode: read-only
 ---
 
 # /infra-health

--- a/.windsurf/workflows/pre-code.md
+++ b/.windsurf/workflows/pre-code.md
@@ -1,5 +1,6 @@
 ---
 description: Pre-Code Contract Verification — Annahmen verifizieren bevor der erste Keystroke
+mode: read-only
 ---
 
 # /pre-code — Contract Verification (PCV)

--- a/.windsurf/workflows/release.md
+++ b/.windsurf/workflows/release.md
@@ -1,5 +1,6 @@
 ---
 description: Publish a Python package (iil-aifw, promptfw, authoringfw, ...) to PyPI
+mode: write
 ---
 
 # Release Workflow — PyPI Publish

--- a/.windsurf/workflows/ship.md
+++ b/.windsurf/workflows/ship.md
@@ -1,5 +1,6 @@
 ---
 description: App auf Production deployen — verify, push, CI, migrate, health check
+mode: write
 ---
 
 # /ship — Universal Deploy Workflow

--- a/.windsurf/workflows/workflow-index.md
+++ b/.windsurf/workflows/workflow-index.md
@@ -1,5 +1,6 @@
 ---
 description: Alle Workflows auf einen Blick — Trigger-Matrix, Entscheidungsbaum, Agent-Einstieg
+mode: read-only
 ---
 
 # Workflow Index — Platform Coding Agent System


### PR DESCRIPTION
## Summary

Establishes the T2 #4 convention from the workflow-registry build-out:
every workflow declares a `mode` field in its YAML frontmatter so
`orchestrator.workflow_run` can expose whether the prompt performs
side-effectful actions.

| Value | Meaning |
|---|---|
| `read-only` | Analyse / audit / check — no system mutation |
| `write` | Modifies code, deploys, publishes, writes external state |

## What this PR does

Tags 10 high-signal workflows as examples; the rest stay implicit so
authors can upgrade incrementally as they review their flows. The
orchestrator-side parser (mcp-hub follow-up PR) defaults missing
`mode` to `write` (conservative).

```
read-only:  adr-review, governance-check, pre-code,
            infra-health, workflow-index
write:      deploy, release, ship, adr, agentic-coding
```

## Why now

T2 (Workflow Registry) is live. Stage #4 of the buildout is the
read-only/write metadata that future executors (workflow_execute,
dry-run gates, Discord-bot confirmations) will use to decide whether
to require human approval before kicking a workflow off. Landing this
on `main` ahead of the executor work keeps the convention visible and
gives mcp-hub a real signal to parse from day one.

## Out of scope

- Tagging the remaining ~49 workflows — separate PR per author area
- `workflow_execute` / dry-run / approval gates (T2 #2)
- Args templating from frontmatter (T2 #3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)