### PR TITLE
feat(pr-review): declare typed args schema (T2 #3 example)

### DIFF
--- a/.windsurf/workflows/pr-review.md
+++ b/.windsurf/workflows/pr-review.md
@@ -1,5 +1,21 @@
 ---
 description: Review and address PR comments using GitHub MCP
+mode: write
+args:
+  - name: pr_number
+    type: integer
+    required: true
+    description: GitHub PR number to review (e.g. 51).
+  - name: repo
+    type: string
+    required: false
+    default: mcp-hub
+    description: Target repo slug under achimdehnert/. Defaults to mcp-hub.
+  - name: include_diff
+    type: boolean
+    required: false
+    default: true
+    description: Whether the reviewer should pull the full diff before commenting.
 ---
 
 # PR Review Workflow


### PR DESCRIPTION
## Summary

Tags `pr-review.md` with the new `args:` frontmatter convention shipped
in mcp-hub's T2 #3 PR. Demonstrates the schema for a real workflow so
downstream consumers (Discord bot, headless agents, CC sessions) have a
concrete example to point at.

## Schema

```yaml
args:
  - name: pr_number
    type: integer
    required: true
    description: GitHub PR number to review (e.g. 51).
  - name: repo
    type: string
    required: false
    default: mcp-hub
    description: Target repo slug under achimdehnert/. Defaults to mcp-hub.
  - name: include_diff
    type: boolean
    required: false
    default: true
    description: Whether the reviewer should pull the full diff before commenting.
---
```

Calling pattern:

```
orchestrator.workflow_execute(
  name="pr-review",
  args={"pr_number": 51, "include_diff": true},
  confirm=true,  # mode: write
)
```

## Out of scope

- Upgrading the body to use `{{pr_number}}` etc. — the existing
  `{REPO_OWNER}` / `{ADR_PATH}` placeholders are LLM-facing
  instructions; double-brace placeholders are reserved for caller
  substitution and can be introduced workflow-by-workflow.
- Tagging the remaining ~58 workflows — one example is enough to
  demonstrate the convention; the rest can spread incrementally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)