### PR TITLE
feat(workflows): /adr-curator + /adr-challenger skills

### DIFF
--- a/.github/workflows/skill-mcp-signatures.yml
+++ b/.github/workflows/skill-mcp-signatures.yml
@@ -1,0 +1,25 @@
+name: Skill MCP Signature Lint
+
+on:
+  push:
+    paths:
+      - ".windsurf/workflows/**.md"
+      - "scripts/lint_skill_mcp_signatures.py"
+      - ".github/workflows/skill-mcp-signatures.yml"
+  pull_request:
+    paths:
+      - ".windsurf/workflows/**.md"
+      - "scripts/lint_skill_mcp_signatures.py"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Lint MCP signatures in skill files
+        run: python scripts/lint_skill_mcp_signatures.py

--- a/.windsurf/workflows/adr-challenger.md
+++ b/.windsurf/workflows/adr-challenger.md
@@ -1,0 +1,202 @@
+---
+description: Adversarial review of a proposed ADR — find conflicts, right-size, surface 1-2 strong counter-arguments. Read-only. Does NOT write or modify ADRs.
+mode: read-only
+---
+
+# /adr-challenger — Adversarial ADR Stress-Test
+
+> **Wann:** Bevor ein Draft als Accepted markiert wird, oder wenn ein bestehender ADR auf "ist das noch tragfähig?" geprüft werden soll.
+> **Wann NICHT:** Disambiguation existierender ADRs → `/adr-curator`. Schema/Format-Check → `/adr-review`. Vollständigen Audit → `/adr-health`.
+
+## Verwendung
+
+```
+/adr-challenger <ADR-NNN | path/to/draft.md>
+```
+
+Beispiele:
+- `/adr-challenger ADR-204`
+- `/adr-challenger ~/github/platform/docs/adr/ADR-DRAFT-routing.md`
+
+---
+
+## Step 0: Repo-Kontext aus project-facts.md (PFLICHT)
+
+```
+Aus project-facts.md entnehmen:
+- ADR_PATH
+- ORC_PREFIX
+- ADRFW_PREFIX
+```
+
+> NIEMALS Pfade/Prefixe hardcoden.
+
+---
+
+## Step 1: Draft laden + Threshold-Reality-Check
+
+Read den Draft komplett.
+
+Gegen `~/.claude/policies/adr-threshold.md` prüfen:
+- Folgt das einem bestehenden Pattern (z.B. "noch ein Platform Agent")? → kein ADR nötig
+- Reversibel durch Entfernen einer App / eines Tasks? → kein ADR nötig
+- Lokal in einem Repo ohne Cross-Cutting-Impact? → kein ADR nötig
+- Code-Style oder Refactor? → kein ADR nötig
+
+**Wenn Threshold nicht überschritten:** Report endet hier mit "CHANGELOG + PR-Beschreibung reicht, kein ADR".
+
+---
+
+## Step 2: Drift-Memory laden (operationalisiert 🌀-Lehren)
+
+```
+MCP: {ORC_PREFIX}agent_memory_search(query="drift:adr OR iteration_count", limit=5)
+MCP: {ORC_PREFIX}agent_memory_search(query="feedback:adr smallest-viable", limit=3)
+```
+
+Zitiere relevante Lehren im Report. Insbesondere:
+- "3+ Architektur-Iterationen ohne Konvergenz = falsches Framing" (🌀 ADR-199 → ADR-201)
+- Smallest-viable-ADR ~120 Zeilen Pattern
+
+---
+
+## Step 3: Schema-Validation (deterministisch)
+
+```
+MCP: {ADRFW_PREFIX}adr_validate(req={"adr_dir": "<ADR_PATH absolute>"})
+→ erwartet: passed=true für ALLE ADRs im Korpus (kein per-file Modus)
+```
+
+**Achtung:** `adr_validate` validiert das **gesamte Verzeichnis**, nicht einen einzelnen Draft. Filtere im Output auf den Draft-Namen. Wenn Draft noch nicht im Verzeichnis liegt: Draft temporär dorthin kopieren ODER Frontmatter manuell gegen Schema v3 prüfen (lieber zweites — keine Side-Effects).
+
+Bei Schema-Fehlern: hart abbrechen mit Liste der Verstöße. Adversarial Review macht nur Sinn auf strukturell gültigen Drafts.
+
+---
+
+## Step 4: Conflict-Detection gegen Korpus
+
+```
+MCP: {ADRFW_PREFIX}adr_query(req={"question": "<draft.decision_summary as natural question>"})
+→ liefert: {primary_answer, citations[], open_questions[], confidence, routing}
+```
+
+Für Top-3-5 Citations: **direkten File-Read** der zitierten ADRs + manuell vergleichen (Decision-Verb, Scope, Status). `adr_diff` ist **nicht** das richtige Tool dafür — es vergleicht Constitution-Sets (temporal oder zwischen Repos), keine ADR-Paare.
+
+Identifiziere:
+- **Hard conflict:** beide accepted, widersprüchliche Decision-Verbs
+- **Soft conflict:** überlappender Scope, aber andere Concerns
+- **Implicit supersession:** Draft macht ADR-X obsolet, nennt es aber nicht in `supersedes:`
+
+---
+
+## Step 5: Cross-Repo-Impact
+
+⚠️ **Direction-Note:** `adr_impact(file_path=...)` gibt zurück welche ADRs für eine Datei gelten — **Gegenteil** von "welche Files referenzieren diesen ADR".
+
+Für letzteres direkter Grep auf Draft-ID:
+```bash
+grep -rn "<DRAFT-ID>" ~/github/ --include="*.py" --include="*.md" --include="*.toml" -l 2>/dev/null | wc -l
+```
+
+Bei neuen Drafts ohne ID gibt es noch keine Refs — stattdessen Scope-Abschätzung über `scope.repos` im Frontmatter. Wenn Impact > 3 Repos und Draft hat keinen Migrations-Plan im Body → Challenge raisen.
+
+---
+
+## Step 6: Right-Sizing-Check (🌀 ADR-201-Lehre)
+
+Heuristiken:
+- **Line-Count:** Body > 180 Zeilen → "smallest-viable cut nötig"
+- **Decision-Verb-Count:** mehr als 1 Verb im Title ("introduce X **and** standardize Y") → Split in 2 ADRs
+- **Concern-Count:** mehr als 1 abgegrenzte Problem-Domain im Body → Split-Vorschlag
+- **Iteration-History:** Wenn Draft Version v3+ oder mehrfach rejected in Memory → "falsches Framing"-Verdacht zitieren
+
+---
+
+## Step 7: Adversarial-Counter-Arguments (LLM-Judgment)
+
+Generiere **1-2 stärkste Gegenargumente** als Steel-Man, nicht Stroh-Mann:
+- Welcher rational Stakeholder könnte begründet widersprechen?
+- Welche Annahme im Draft ist unausgesprochen und falsifizierbar?
+- Welche Alternative im "Considered Options"-Abschnitt verdient mehr Gewicht?
+
+Format pro Counter:
+```
+**Challenger #N (Confidence: 0-100):**
+Argument: <1-2 Sätze>
+Konsequenz wenn ignoriert: <1 Satz>
+Was würde diesen Counter widerlegen: <1 Satz>
+```
+
+---
+
+## Step 8: Open-Question-Aging
+
+```
+MCP: {ADRFW_PREFIX}adr_audit(req={"auditors": ["open_question_aging"]})
+→ liefert: aggregierte Findings über ALLE ADRs (kein per-draft Filter)
+```
+
+Output post-process: filtere `findings[]` auf `adr_id == "<DRAFT-ID>"`. Wenn Draft Open Questions > 7 Tage alt enthält ohne Update → Challenge: "Decide or close before merging Accepted".
+
+---
+
+## Output-Format
+
+```
+## ADR Challenger Report — <ADR-ID or Draft-Filename>
+
+### Threshold Verdict
+✅ ADR-worthy / ❌ CHANGELOG reicht / ⚠️ borderline (Grund)
+
+### Schema
+✅ Passed / ❌ <list violations>
+
+### Conflict-Map
+- ADR-XXX: hard conflict on <verb> — Draft muss `supersedes: ADR-XXX` setzen oder Scope abgrenzen
+- ADR-YYY: soft conflict on <scope> — Erwähnung im "Considered Options" erwartet
+
+### Right-Sizing
+- Line count: NNN (Ziel: ≤180)
+- Decision verbs: N
+- Concerns: N
+- Iteration history: <count> prior versions (Memory)
+- Verdict: ✅ smallest-viable / ⚠️ split-candidate / ❌ smallest-viable cut required
+
+### Cross-Repo Impact
+N repos touched. Migration plan: present / **missing — challenge raised**.
+
+### Steel-Man Challengers
+**#1 (Confidence 75):** <Argument>
+   Folge: <…>
+   Falsifizierbar durch: <…>
+
+**#2 (Confidence 60):** <Argument>
+   ...
+
+### Drift-Memory Citations
+- 🌀 ADR-199 → ADR-201: "3+ Iterationen = falsches Framing"
+- [andere relevante Memories]
+
+### Recommendation
+- [ ] Adress Challenger #1 in Decision rationale
+- [ ] Split into ADR-A (verb-1) + ADR-B (verb-2)
+- [ ] Add `supersedes: ADR-XXX`
+- [ ] Trim to ~120 lines before merging Accepted
+```
+
+---
+
+## Anti-Patterns
+
+- ❌ Stroh-Mann-Argumente (immer Steel-Man)
+- ❌ Niedrige Confidence-Counter aufblähen — wenn unter 50, weglassen
+- ❌ ADR-Text **schreiben** oder **editieren** — read-only Workflow
+- ❌ Threshold-Check überspringen, wenn User "ich will einen ADR" sagt
+- ❌ Path/Repo hardcoden — alles via project-facts.md
+- ❌ Mehr als 2 Counter generieren — Signal-to-Noise ruinieren
+
+---
+
+## Changelog
+
+- 2026-05-15: Initial. Adressiert 🌀-Drift-Klassen ADR-199 (Iteration-Count) und ADR-201 (Smallest-Viable). Read-only, SSoT in platform-workflows.

--- a/.windsurf/workflows/adr-challenger.md
+++ b/.windsurf/workflows/adr-challenger.md
@@ -186,6 +186,22 @@ N repos touched. Migration plan: present / **missing — challenge raised**.
 
 ---
 
+## Action-Output (statt nur Report)
+
+Pro Finding **executable Artefakte** vorschlagen, nicht nur Text:
+
+| Finding | Action-Output |
+|---|---|
+| Split-Vorschlag (z.B. 7 Concerns → 4 ADRs) | Frontmatter-Stubs für jeden Sub-ADR (status: draft, supersedes: <parent>, scope, decision_summary-Stub) — ready für `/adr` |
+| Hard-Conflict ohne `supersedes:` | Diff-Block: `--- supersedes: []` `+++ supersedes: [ADR-XXX]` für PR-Amendment |
+| Cross-Repo-Impact ohne Migrations-Plan | `gh issue create` Snippet mit Migration-Phasen-Template |
+| Open Questions > 7 Tage alt | TODO-Liste mit ADR-Section-Verweis + Decide-or-Close-Snippet |
+| Memory-Drift (File-Status ≠ Orchestrator-Memory) | `agent_memory_upsert`-Call ready zum Aufruf |
+
+Format: pro Finding 1 Code-Block (`bash` / `yaml` / `python`), copy-paste-ready. User entscheidet was angewandt wird — Skill bleibt read-only.
+
+---
+
 ## Anti-Patterns
 
 - ❌ Stroh-Mann-Argumente (immer Steel-Man)

--- a/.windsurf/workflows/adr-curator.md
+++ b/.windsurf/workflows/adr-curator.md
@@ -126,6 +126,21 @@ Verwende **ADR-NNN** als Referenz. Bei "<conflict-claim>" prüfe ob ADR-XXX/YYY 
 
 ---
 
+## Action-Output (statt nur Report)
+
+Pro Finding **executable Artefakte** vorschlagen, nicht nur Text:
+
+| Finding | Action-Output |
+|---|---|
+| Body-Heading-Drift (z.B. ADR-179 file zeigt "ADR-141" im H1) | `sed -i 's\|^# ADR-141:\|# ADR-179:\|' <file>` (User reviewt + applied) |
+| Stale Orchestrator-Memory | Code-Block mit `agent_memory_upsert(entry_key="adr:platform:ADR-NNN", ...)` aufruf-fertig |
+| Cross-Repo-Reference-Audit | `grep -rln "ADR-NNN" ~/github/ --include="*.py"` + Pipe-Snippet für Repo-Aggregation |
+| Constitution-Load-Gap (adr_explain "Rule not found") | `gh issue create` Snippet im iil-adrfw-Repo mit Reproduce-Steps |
+
+Format: pro Finding 1 `bash`-Code-Block ODER 1 MCP-Call-Block, klar abgegrenzt. User entscheidet was angewandt wird — Skill bleibt read-only, aber Output ist copy-paste-ready.
+
+---
+
 ## Anti-Patterns (was dieser Workflow NICHT tut)
 
 - ❌ Neue ADRs schreiben — das macht `/adr`

--- a/.windsurf/workflows/adr-curator.md
+++ b/.windsurf/workflows/adr-curator.md
@@ -1,0 +1,141 @@
+---
+description: Disambiguate which ADR is canonical for a topic — supersession chains, naming collisions, conflict warnings. Read-only.
+mode: read-only
+---
+
+# /adr-curator — ADR Disambiguation Specialist
+
+> **Wann:** Bevor du auf ADR-X verweist, eine bestehende Decision in Frage stellst, oder bei Verdacht auf canonical-number-drift (Lehre aus 🌀 ADR-141 vs 179).
+> **Wann NICHT:** Neuen ADR schreiben → `/adr`. Draft adversarial reviewen → `/adr-challenger`. Vollständigen Audit → `/adr-health`.
+
+## Verwendung
+
+```
+/adr-curator <topic-or-keyword>
+```
+
+Beispiele:
+- `/adr-curator SQLite Verbot`
+- `/adr-curator multi-tenancy strategy`
+- `/adr-curator ADR-141`
+
+---
+
+## Step 0: Repo-Kontext aus project-facts.md (PFLICHT)
+
+```
+Aus project-facts.md (always_on rule) entnehmen:
+- ADR_PATH (z.B. "docs/adr")
+- ORC_PREFIX (orchestrator MCP prefix, aktuell "mcp2_")
+- ADRFW_PREFIX (iil-adrfw MCP prefix, aktuell "mcp2_")
+```
+
+> **NIEMALS** Pfade/Prefixe hardcoden. SSoT ist project-facts.md.
+
+---
+
+## Step 1: Drift-Memory query (operationalisiert 🌀-Lehren)
+
+```
+MCP: {ORC_PREFIX}agent_memory_search(query="drift:adr <topic>", limit=5)
+MCP: {ORC_PREFIX}agent_memory_search(query="policy:adr-canonical-numbers", limit=3)
+```
+
+Wenn Drift-Memory existiert für das Topic → Output **zuerst** zitieren ("Vorsicht: diese Frage hatte bereits einen Drift-Fall bei ADR-X — siehe Memory").
+
+---
+
+## Step 2: Constitution-Query auf ADR-Korpus
+
+```
+MCP: {ADRFW_PREFIX}adr_query(req={"question": "<topic>"})
+→ liefert: {primary_answer, citations[], open_questions[], confidence, routing}
+```
+
+**Wichtig:** `adr_query` ist deterministisch (regel-basiert, kein Vektor). Bei `confidence=0` und leeren `citations` → MCP kennt das Topic nicht. **Nicht** als "Topic existiert nicht" interpretieren — fallback auf Grep in Step 4 ist Pflicht.
+
+Re-rank der `citations`-Liste (LLM-Judgment):
+1. **Status-Priority:** Accepted > Proposed > Superseded > Deprecated
+2. **Recency-Bias:** bei identischem Score jüngeres `decision_date`
+3. **Title-Match:** exakter Keyword-Match im Titel schlägt nur-Body-Match
+
+---
+
+## Step 3: Supersession-Kette + Detail-Read
+
+Für jeden Top-3-Hit aus Citations:
+
+```
+MCP: {ADRFW_PREFIX}adr_explain(req={"rule_id": "<rule_id_from_citation>", "audience": "senior"})
+```
+
+**Achtung Format:** `rule_id` ist nicht `"ADR-179"` allein, sondern `"ADR-NNN/<rule-slug>"` (z.B. `"ADR-099/tenant-id-bigint"`). Plain ADR-Nummern liefern "Rule not found". Wenn `citations` keine vollständigen rule_ids enthalten → **Fallback auf direkten File-Read** des ADR-Files für Supersession-Fields aus Frontmatter (`supersedes`, `superseded_by`, `amends`).
+
+Folge `superseded_by` rekursiv bis zum aktuell gültigen ADR.
+
+---
+
+## Step 4: Naming-Collision-Check (Anti-141/179-Drift)
+
+```
+Grep über ADR_PATH nach allen Titeln mit Top-Topic-Keyword:
+  grep -l "<keyword>" $ADR_PATH/ADR-*.md
+```
+
+Wenn mehrere ADRs **denselben Topic-Claim** machen → explizit als "Konflikt-Kandidat" markieren. Lehre: ADR-141 (=Discord-Bridge) wurde monatelang als "SQLite-Verbot" zitiert, kanonisch war 179.
+
+---
+
+## Step 5: Cross-Repo-Referenzen (optional, bei "wird das woanders zitiert?")
+
+⚠️ **Direction-Note:** `adr_impact` macht das **Gegenteil**: gegeben einen `file_path`, sagt es welche ADRs für die Datei gelten. Für "welche Files referenzieren ADR-X" → direkter Grep:
+
+```bash
+grep -rn "ADR-NNN" ~/github/ --include="*.py" --include="*.md" --include="*.toml" --include="*.yml" -l 2>/dev/null
+```
+
+Output gruppieren nach Repo. Bei >20 Hits: nur Counts pro Repo zeigen, keine vollständige File-Liste.
+
+---
+
+## Output-Format
+
+```
+## ADR Curator Report — "<topic>"
+
+### Canonical ADR
+**ADR-NNN — <Title>** (Status: Accepted, last touched: YYYY-MM-DD)
+
+### Supersession Chain
+ADR-AAA (deprecated) → ADR-BBB (superseded) → **ADR-NNN** (current)
+
+### Conflict Candidates (manuelle Verifikation empfohlen)
+- ADR-XXX touches similar topic — different decision verb
+- ADR-YYY claims topic in title but status=Proposed
+
+### Drift Warning
+[falls Memory-Hit] Diese Frage hatte bereits Drift bei ADR-Z — siehe `drift:adr-canonical-numbers`.
+
+### Cross-Repo Impact (optional)
+- repo-a: 3 references
+- repo-b: 1 reference
+
+### Recommendation
+Verwende **ADR-NNN** als Referenz. Bei "<conflict-claim>" prüfe ob ADR-XXX/YYY denselben Decision-Scope haben oder nur überlappendes Vokabular.
+```
+
+---
+
+## Anti-Patterns (was dieser Workflow NICHT tut)
+
+- ❌ Neue ADRs schreiben — das macht `/adr`
+- ❌ Drafts reviewen — das macht `/adr-challenger`
+- ❌ Cross-ADR-Audit — das macht `/adr-health`
+- ❌ Path/Repo hardcoden — alles via project-facts.md
+- ❌ Annahme "vector-search-top-1 = canonical" — Status + Supersession + Naming-Collision müssen mitgeprüft werden
+
+---
+
+## Changelog
+
+- 2026-05-15: Initial. Adressiert 🌀-Drift-Klasse ADR-141/179. SSoT in platform-workflows, verfügbar in Claude Code (via Symlink) und Windsurf-Cascade.

--- a/scripts/lint_skill_mcp_signatures.py
+++ b/scripts/lint_skill_mcp_signatures.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Static lint for MCP-call signatures in .windsurf/workflows/*.md skills.
+
+Catches common signature-drift bugs discovered during /adr-curator + /adr-challenger
+dogfood-testing (2026-05-15, PR #168):
+
+- adr_query expects `question=`, not `query=`
+- adr_explain expects `rule_id=`, not `adr_id=`
+- adr_validate is directory-wide; `adr_id_or_path=` is wrong
+- adr_diff is set/temporal mode; pair-wise `adr_a=/adr_b=` is wrong
+- adr_impact direction is file -> ADRs (warn if comments imply reverse)
+
+Exits non-zero on any violation. Designed for CI (paths: .windsurf/workflows/**).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+WORKFLOWS_DIR = Path(".windsurf/workflows")
+
+# (regex, message) — match on the MCP call site inside skill markdown
+RULES: list[tuple[re.Pattern[str], str]] = [
+    (
+        re.compile(r"adr_query\([^)]*\bquery\s*="),
+        "adr_query expects `question=`, not `query=`",
+    ),
+    (
+        re.compile(r"adr_explain\([^)]*\badr_id\s*="),
+        "adr_explain expects `rule_id=`, not `adr_id=`",
+    ),
+    (
+        re.compile(r"adr_validate\([^)]*\b(adr_id|adr_id_or_path|path)\s*="),
+        "adr_validate accepts only `adr_dir=` (validates ALL ADRs in directory)",
+    ),
+    (
+        re.compile(r"adr_diff\([^)]*\b(adr_a|adr_b)\s*="),
+        "adr_diff is set/temporal mode — no pair-wise `adr_a=/adr_b=`",
+    ),
+    (
+        re.compile(r"adr_impact\([^)]*\b(adr_id|scope)\s*="),
+        "adr_impact accepts `file_path=` and optional `repo=` — direction is file -> ADRs, NOT reverse",
+    ),
+]
+
+
+def lint_file(path: Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    violations: list[str] = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        # Skip comment lines explaining the rule (look for explicit "NOT" or "wrong" markers)
+        lowered = line.lower()
+        if any(marker in lowered for marker in ("not `", "wrong", "❌", "achtung", "warnung")):
+            continue
+        for pattern, msg in RULES:
+            if pattern.search(line):
+                violations.append(f"{path}:{line_no}: {msg}\n    → {line.strip()}")
+    return violations
+
+
+def main() -> int:
+    if not WORKFLOWS_DIR.exists():
+        print(f"::error::{WORKFLOWS_DIR} not found", file=sys.stderr)
+        return 2
+
+    skill_files = sorted(WORKFLOWS_DIR.glob("*.md"))
+    if not skill_files:
+        print(f"::warning::No skill files in {WORKFLOWS_DIR}", file=sys.stderr)
+        return 0
+
+    all_violations: list[str] = []
+    for f in skill_files:
+        all_violations.extend(lint_file(f))
+
+    if all_violations:
+        print("MCP signature violations found:\n", file=sys.stderr)
+        for v in all_violations:
+            print(v, file=sys.stderr)
+            print("", file=sys.stderr)
+        print(
+            f"::error::Found {len(all_violations)} violation(s) across {len(skill_files)} skill file(s)",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK: {len(skill_files)} skill files clean ({len(RULES)} rules checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds two read-only ADR-governance skills as slash-commands:

- **`/adr-curator`** — disambiguation: supersession chains, naming-collision detection, canonical-number drift warnings. Addresses the ADR-141 vs ADR-179 drift class (16-file comment-rot swept on 2026-05-12).
- **`/adr-challenger`** — adversarial review of proposed/draft ADRs: right-sizing per smallest-viable lesson, conflict-detection against existing corpus, 1-2 steel-man counter-arguments per Confidence-rated.

Both are read-only — they propose, never write. ADR creation stays with `/adr`; review-format stays with `/adr-review`; full audit stays with `/adr-health`.

## Dogfood-test findings

Each skill was dogfood-tested against a real platform ADR before commit:

**`/adr-curator` on "SQLite Verbot / PostgreSQL-only Testing"** revealed:
- Body-heading bug in `ADR-179-postgresql-only-testing.md` — H1 inside the file says `# ADR-141: PostgreSQL-Only Testing` (root cause of the 13-repo comment-rot)
- `adr_explain(rule_id="ADR-179")` returns "Rule not found in constitution" — constitution-load gap in iil-adrfw
- Orchestrator memory missing the drift-knowledge that lives only in local Claude-Code memory

**`/adr-challenger` on ADR-188 (Unified Vector Store)** revealed:
- 426 lines, 7 distinct decisions (E1-E7) — scope-bloat per smallest-viable lesson
- Status drift: orchestrator memory says `Proposed`, file says `Accepted`
- Proposed split into 3-4 smaller ADRs (E1+E6 schema, E2 model, E3+E4 API+naming, E7 DSGVO-policy) — E5 (risk-hub ProjectDocumentLink) belongs in risk-hub ADR

## Tool-signature fixes applied during testing

The first-draft skills used wrong MCP signatures. Corrected to match iil-adrfw schema:

- `adr_explain` uses `rule_id` (not `adr_id`)
- `adr_impact` direction is file→ADRs (NOT ADR→files — for the latter use grep)
- `adr_validate` is directory-wide (no per-file mode)
- `adr_diff` is set/temporal mode (not pair-wise between two ADRs — use File-Read instead)
- `adr_query` uses `question` (not `query`); return shape is `{primary_answer, citations[], open_questions[], confidence, routing}`

## Design rationale

Picked **skills**, not Claude-Code sub-agents:
- Skills work in both Claude Code AND Windsurf-Cascade; sub-agents are CC-only
- Skills already have SSoT via platform-workflows + symlink
- No current need for context-isolation or auto-delegation
- Aligns with platform-agents.md policy (Django headless agents in `dev-hub/apps/` are a different concept)

## Test plan

- [x] `/adr-curator SQLite Verbot` returns canonical ADR-179, surfaces title-bug + memory-drift
- [x] `/adr-challenger ADR-188` returns split proposal + 2 steel-man counters (confidence 85 + 70)
- [ ] User-validation: run `/adr-curator <topic>` on next ADR-disambiguation need
- [ ] User-validation: run `/adr-challenger ADR-NNN` before next ADR is moved Accepted → Implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)