### PR TITLE
fix(adr-179): correct body heading from 'ADR-141' to 'ADR-179'

### DIFF
--- a/docs/adr/ADR-179-postgresql-only-testing.md
+++ b/docs/adr/ADR-179-postgresql-only-testing.md
@@ -3,7 +3,7 @@ status: accepted
 date: 2026-03-12
 decision-makers: [Achim Dehnert]
 ---
-# ADR-141: PostgreSQL-Only Testing
+# ADR-179: PostgreSQL-Only Testing
 
 **Status:** ACCEPTED  
 **Datum:** 2026-03-12  


### PR DESCRIPTION
## Summary

The H1 inside `docs/adr/ADR-179-postgresql-only-testing.md` said `# ADR-141: PostgreSQL-Only Testing` — root cause of the 13-repo comment-rot swept on 2026-05-12.

File frontmatter (`status: accepted`, filename) was correct; only the body heading drifted. One-line fix.

## Discovery

Surfaced by `/adr-curator` dogfood-test on topic "SQLite Verbot" (PR #168). The curator's naming-collision-check step grep'd the ADR corpus and the title-bug appeared in the head excerpt.

## Diff

```diff
-# ADR-141: PostgreSQL-Only Testing
+# ADR-179: PostgreSQL-Only Testing
```

## Test plan

- [x] `head -10 docs/adr/ADR-179-postgresql-only-testing.md` shows correct heading
- [x] `grep -c "# ADR-141" docs/adr/ADR-179-postgresql-only-testing.md` returns 0
- [ ] After merge: re-run `/adr-curator "SQLite Verbot"` — no body-heading drift warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)