### PR TITLE
fix(ci): skip adr-review job when packages/adr-review is absent

### DIFF
--- a/.github/workflows/adr-review.yml
+++ b/.github/workflows/adr-review.yml
@@ -43,16 +43,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Check adr-review package presence
+        id: check-pkg
+        run: |
+          if [ -f "./packages/adr-review/pyproject.toml" ] || [ -f "./packages/adr-review/setup.py" ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::packages/adr-review not present — AI Review will be skipped. Add the package to enable."
+          fi
+
       - name: Setup Python
+        if: steps.check-pkg.outputs.found == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'
 
       - name: Install adr-review
+        if: steps.check-pkg.outputs.found == 'true'
         run: pip install ./packages/adr-review
 
       - name: Run ADR Review
+        if: steps.check-pkg.outputs.found == 'true'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The 'AI Review' job in `.github/workflows/adr-review.yml` unconditionally runs `pip install ./packages/adr-review`, but that path has **never** existed in this repo (`git log --all -- packages/adr-review` returns empty).

Effect: every ADR-touching PR has a failing required check, blocking merges. PR #170 (1-line ADR-179 title fix) is currently blocked by this.

## Fix

Add a guard step that checks for `pyproject.toml` or `setup.py` under `./packages/adr-review` and gates the install/run steps on it.

- Package present → job runs unchanged
- Package absent → install/run skipped, job ends success with workflow-warning annotation explaining the missing package

## Test plan

- [x] yaml lint passes locally
- [ ] CI run on this PR: AI Review job ends success with warning annotation
- [ ] After merge: PR #170 mergeable without admin bypass

## Discovery

Surfaced while attempting to merge PR #170 (ADR-179 title-bug fix from `/adr-curator` dogfood-test, PR #168).

🤖 Generated with [Claude Code](https://claude.com/claude-code)