### PR TITLE
Cross-Repo Ingest-/Doku-Konvention (PROPOSED, ADR-207)

### DIFF
--- a/docs/adr/ADR-207-cross-repo-ingest-doku-konvention.md
+++ b/docs/adr/ADR-207-cross-repo-ingest-doku-konvention.md
@@ -52,8 +52,34 @@ Public-Sector-Datensouveränität (ttz/meiki) erfordert je Org Prüfung, ob das
 Provenienz-Archiv auf geteilten Mounts liegen darf; Drift-Check als
 wiederverwendbarer CI-Baustein ist Folge-ADR.
 
+## Reversibilität & Risiken (Amendment 2026-05-17, aus adr-review)
+
+- **Reversibilität:** Rücknahme ist billig und lokal — Pointer-Datei
+  (`docs/_conventions/ingest.md`) + `shared/<repo>/inbox/` je Repo löschen,
+  diese ADR auf `superseded` setzen. Kein Code, kein Service, keine
+  Daten-Migration; Provenienz-Archiv bleibt unberührt. Kosten ≈ N kleine
+  Revert-PRs (N = Tier-A-Repos).
+- **Blast-Radius bei Tier-Fehlzuordnung:** Ein Code-Repo fälschlich in Tier A
+  → leerer, ungenutzter `inbox/`-Ordner (kosmetisch, kein Funktionsbruch).
+  Ein ingest-relevantes Repo fälschlich in Tier C → Rohmaterial landet
+  weiter ad hoc (Status quo ante, kein Regress). Fehlzuordnung ist also
+  **nicht schadhaft, nur suboptimal** und per 1-Zeilen-PR an dieser Datei
+  korrigierbar.
+- **Daten-Souveränität (kritisch, ttz-lif / meiki-lra):** Provenienz mit
+  Klarnamen/Sozialdaten darf **nicht** ungeprüft auf einen org-fremd
+  geteilten Mount. Verbindlich: für `ttz-lif`/`meiki-lra` liegt
+  `_archiv/` auf einem **org-lokalen, nicht quergeteilten** Pfad; die
+  Tier-A-Aufnahme dieser Repos steht unter dem Vorbehalt einer
+  DSFA-/Mount-Prüfung je Org (kein Default-Rollout dorthin).
+- **Lizenz/Compliance:** Drittinhalte im `_archiv/` werden nicht
+  weiterverteilt (außerhalb Git, kein Publish) — kein Lizenz-Transfer.
+
 ## Status / nächste Schritte
 
-- [ ] Ratifizierung dieser ADR (Plattform-Governance)
-- [ ] Tier-A-Repos: je 1 Pointer-PR (`docs/_conventions/ingest.md` + `shared/<repo>/inbox/README.md`)
+**Status: `Proposed`** — die folgenden Schritte sind **bedingt** und werden
+erst nach Ratifizierung ausgelöst (keine impliziten Fakten):
+
+- [ ] Ratifizierung dieser ADR (Plattform-Governance) — Voraussetzung für alles Weitere
+- [ ] *Danach:* Tier-A-Repos: je 1 Pointer-PR (`docs/_conventions/ingest.md` + `shared/<repo>/inbox/README.md`)
+- [ ] *Danach, ttz-lif/meiki-lra nur nach* DSFA-/Mount-Prüfung (siehe Daten-Souveränität)
 - [ ] Folge-ADR: Drift-Check als CI-Baustein

--- a/docs/adr/ADR-207-cross-repo-ingest-doku-konvention.md
+++ b/docs/adr/ADR-207-cross-repo-ingest-doku-konvention.md
@@ -3,7 +3,6 @@ id: ADR-207
 title: "Cross-Repo Ingest- & Doku-Konvention (tiered, opt-in)"
 status: Accepted
 date: 2026-05-16
-accepted: 2026-05-17
 deciders: Plattform-Governance
 ---
 

--- a/docs/adr/ADR-207-cross-repo-ingest-doku-konvention.md
+++ b/docs/adr/ADR-207-cross-repo-ingest-doku-konvention.md
@@ -1,8 +1,9 @@
 ---
 id: ADR-207
 title: "Cross-Repo Ingest- & Doku-Konvention (tiered, opt-in)"
-status: Proposed
+status: Accepted
 date: 2026-05-16
+accepted: 2026-05-17
 deciders: Plattform-Governance
 ---
 
@@ -76,10 +77,11 @@ wiederverwendbarer CI-Baustein ist Folge-ADR.
 
 ## Status / nächste Schritte
 
-**Status: `Proposed`** — die folgenden Schritte sind **bedingt** und werden
-erst nach Ratifizierung ausgelöst (keine impliziten Fakten):
+**Status: `Accepted` (2026-05-17)** — ratifiziert durch Plattform-Governance
+(PR #175). Konvention `docs/governance/cross-repo-ingest-doku.md` ist damit
+verbindlich; Rollout bewusst konservativ (erst SUGGEST):
 
-- [ ] Ratifizierung dieser ADR (Plattform-Governance) — Voraussetzung für alles Weitere
-- [ ] *Danach:* Tier-A-Repos: je 1 Pointer-PR (`docs/_conventions/ingest.md` + `shared/<repo>/inbox/README.md`)
-- [ ] *Danach, ttz-lif/meiki-lra nur nach* DSFA-/Mount-Prüfung (siehe Daten-Souveränität)
+- [x] Ratifizierung dieser ADR (Plattform-Governance)
+- [ ] Tier-A-Repos: je 1 Pointer-PR (`docs/_conventions/ingest.md` + `shared/<repo>/inbox/README.md`)
+- [ ] ttz-lif/meiki-lra **nur nach** DSFA-/Mount-Prüfung (siehe Daten-Souveränität) — kein Default-Rollout
 - [ ] Folge-ADR: Drift-Check als CI-Baustein

--- a/docs/adr/ADR-207-cross-repo-ingest-doku-konvention.md
+++ b/docs/adr/ADR-207-cross-repo-ingest-doku-konvention.md
@@ -1,0 +1,59 @@
+---
+id: ADR-207
+title: "Cross-Repo Ingest- & Doku-Konvention (tiered, opt-in)"
+status: Proposed
+date: 2026-05-16
+deciders: Plattform-Governance
+---
+
+# ADR-207 — Cross-Repo Ingest- & Doku-Konvention
+
+## Kontext
+
+In meiki-hub entstand 2026-05-16 eine validierte Doku-Strategie (eine
+Doku-Wahrheit pro Repo, Format-Hierarchie MD>PDF>docx, ein Ingest-Trichter +
+Provenienz-Archiv). Die Frage: auf andere Repos verallgemeinern? Und in
+welcher Form, ohne die Multi-Repo-Drift zu reproduzieren, die wir gerade
+beseitigt haben?
+
+Risiken einer naiven Verallgemeinerung:
+
+- **Blanket-Rollout** erzeugt leere `inbox/`-Ordner in reinen Code-Repos —
+  Zeremonie ohne Wert.
+- **N-fach kopierter Konventionstext** driftet garantiert (genau das
+  wiederkehrende Anti-Muster: divergierende Zweitstände).
+- **Repo-Identität aus Remote-Namen** abgeleitet → in dieser Session wurde
+  über einen Rename-Redirect versehentlich ein Live-Repo archiviert.
+
+## Entscheidung
+
+1. **Eine SSoT-Konvention im `platform`-Repo:**
+   `docs/governance/cross-repo-ingest-doku.md`. Teilnehmende Repos verlinken
+   per dünnem Pointer, kopieren den Text **nicht**.
+2. **Tiered/opt-in statt blanket.** Tier A (ingest-pflichtig): `meiki-hub`,
+   `risk-hub`, `ttz-hub`. Tier B opt-in. Tier C (reine Code-Repos)
+   ausgenommen. Aufnahme weiterer Repos = PR gegen die Konvention.
+3. **Pfad-Schema** `~/shared/<repo>/inbox/` + `~/shared/<repo>/_archiv/<datum>/`
+   + `~/github/<repo>/docs/` (Ground Truth). Bewusst **nicht**
+   `<repo>/<repo>-inbox` (doppelter Name).
+4. **Rollout-Disziplin:** erst diese ADR ratifizieren, dann pro Tier-A-Repo
+   *ein* Pointer-PR. Kein Massen-Anlegen.
+5. **Pflichtregel:** Repo-Identität vor `archive`/`delete`/`rename` immer per
+   API auflösen (`gh api repos/<o>/<r> --jq .id`).
+
+## Konsequenzen
+
+**Positiv:** eine wartbare Quelle; kein Drift durch Pointer-Modell; Aufwand
+nur dort, wo Rohmaterial real anfällt; die meiki-Drift-Lehren werden
+plattformweit kodifiziert.
+
+**Negativ / offen:** Tier-Zuordnung ist eine fortlaufende Pflegeaufgabe;
+Public-Sector-Datensouveränität (ttz/meiki) erfordert je Org Prüfung, ob das
+Provenienz-Archiv auf geteilten Mounts liegen darf; Drift-Check als
+wiederverwendbarer CI-Baustein ist Folge-ADR.
+
+## Status / nächste Schritte
+
+- [ ] Ratifizierung dieser ADR (Plattform-Governance)
+- [ ] Tier-A-Repos: je 1 Pointer-PR (`docs/_conventions/ingest.md` + `shared/<repo>/inbox/README.md`)
+- [ ] Folge-ADR: Drift-Check als CI-Baustein

--- a/docs/governance/cross-repo-ingest-doku.md
+++ b/docs/governance/cross-repo-ingest-doku.md
@@ -1,0 +1,73 @@
+# Cross-Repo Ingest- & Doku-Konvention
+
+**Status:** PROPOSED (Ratifizierung via ADR-207)
+**Datum:** 2026-05-16
+**Home:** `platform` (Governance-SSoT) — Repos verlinken hierauf, kopieren nicht.
+**Pilot/Herkunft:** meiki-hub `docs/_conventions/doku-strategie.md` (validiert 2026-05-16)
+
+---
+
+## Zweck
+
+Verallgemeinerung der in meiki-hub bewährten Doku-Strategie auf weitere Repos —
+**tiered/opt-in, nicht blanket**. Eine uniforme Ingest-Struktur für reine
+Code-Repos ist leere Zeremonie; der Wert entsteht nur dort, wo **externes
+Rohmaterial** eintrifft (Stakeholder-`.docx`, Prozess-Exporte, Zips,
+Workshop-Transkripte).
+
+## Scope-Tiers
+
+| Tier | Repos (Beispiele) | Verbindlichkeit |
+|---|---|---|
+| **A — ingest-pflichtig** | doc-/public-sector-lastig: `meiki-hub`, `risk-hub`, `ttz-hub` | Konvention gilt |
+| **B — opt-in** | Repos mit gelegentlichem Fremdmaterial | bei Bedarf, gleicher Pfad |
+| **C — ausgenommen** | reine Code-/Lib-Repos ohne Fremd-Ingest | kein Inbox-Ordner |
+
+Tier-Zuordnung wird in ADR-207 ratifiziert; Aufnahme weiterer Repos = PR gegen
+diese Datei, nicht stillschweigend.
+
+## Pfad-Schema (verbindlich für Tier A/B)
+
+```
+~/shared/<repo>/inbox/                      # einziger Eingang für Rohmaterial
+~/shared/<repo>/_archiv/<YYYY-MM-DD>/        # Provenienz, außerhalb Git
+~/github/<repo>/docs/                        # Ground Truth (Markdown, versioniert)
+```
+
+Bewusst **nicht** `~/shared/<repo>/<repo>-inbox` (doppelter Repo-Name).
+Ein Eingang pro Repo — keine zweiten Schatten-Ordner.
+
+## Regeln (identisch über alle Tier-A/B-Repos)
+
+1. **Eine Doku-Wahrheit pro Repo:** `<repo>/docs/`. Repo-Identität vor
+   archive/delete **immer per API auflösen** (`gh api repos/<o>/<r> --jq .id`)
+   — Rename-Redirects sehen wie ein zweites Repo aus (Drift-Lehre meiki).
+2. **Format-Hierarchie:** Markdown = Ground Truth · PDF = generierter Output
+   bzw. regulatorische Ground-Truth (siehe pdf-first-Konvention) · `.docx` =
+   **nie** canonical (nur Ingest/Austausch).
+3. **Ein Ingest-Trichter + Provenienz-Archiv.** Jede Datei in `inbox/`
+   verlässt sie binnen einer Session über genau einen Ausgang:
+   destillieren → `docs/` · archivieren → `_archiv/` · löschen (nur
+   nachweisliche Byte-Duplikate). Nie liegen lassen.
+4. **Pointer statt Kopie.** Teilnehmende Repos legen *eine* dünne
+   `docs/_conventions/ingest.md` an, die **hierher verlinkt** — kein
+   divergierender Zweittext (Anti-Drift).
+5. **Automatisierung statt Disziplin.** Periodischer Drift-Check
+   (CI/Cron bzw. `session-docu`) beantwortet je Repo: „liegt Quelle X schon
+   im Repo, abweichend, oder verwaist?".
+
+## Rollout-Disziplin (bewusst konservativ)
+
+Analog Repo-Health-Regel-Disziplin: **erst SUGGEST, dann verbindlich**.
+Kein Massen-Anlegen von `inbox/`-Ordnern. Reihenfolge:
+1. ADR-207 ratifiziert Schema + Tier-A-Liste.
+2. Pro Tier-A-Repo *ein* PR: dünne `docs/_conventions/ingest.md`-Pointer +
+   `~/shared/<repo>/inbox/README.md`.
+3. Tier-B nach Bedarf, Tier-C nie.
+
+## Offene Punkte
+
+- ttz-hub/meiki-hub: Public-Sector-Datensouveränität — Provenienz-Archiv mit
+  Klarnamen bleibt **außerhalb Git** und ggf. außerhalb geteilter Mounts;
+  je Org prüfen.
+- Drift-Check als wiederverwendbarer CI-Baustein: separater Folge-ADR.

--- a/docs/governance/cross-repo-ingest-doku.md
+++ b/docs/governance/cross-repo-ingest-doku.md
@@ -1,6 +1,6 @@
 # Cross-Repo Ingest- & Doku-Konvention
 
-**Status:** PROPOSED (Ratifizierung via ADR-207)
+**Status:** active (ratifiziert via ADR-207, 2026-05-17)
 **Datum:** 2026-05-16
 **Home:** `platform` (Governance-SSoT) — Repos verlinken hierauf, kopieren nicht.
 **Pilot/Herkunft:** meiki-hub `docs/_conventions/doku-strategie.md` (validiert 2026-05-16)


### PR DESCRIPTION
Verallgemeinert die in meiki-hub validierte Doku-Strategie plattformweit — **tiered/opt-in, Pointer-Modell, kein Blanket-Rollout**.

- `docs/governance/cross-repo-ingest-doku.md` — SSoT-Konvention (Tiers A/B/C, Pfad-Schema `shared/<repo>/inbox`, Regeln)
- `docs/adr/ADR-207-...` — Entscheidungsvorlage (Status **Proposed**, Ratifizierung ausstehend)

Kodifiziert auch die Drift-Lehren der Session (Repo-Identität nie aus Remote-Namen; vor archive/delete API-Auflösung). Kein Repo wird vor Ratifizierung angefasst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)