### PR TITLE
ADR-208 Model-Resolver + Amendments ADR-201/203 (advocatus-diabolus)

### DIFF
--- a/docs/adr/ADR-201-claude-code-pricing-visibility.md
+++ b/docs/adr/ADR-201-claude-code-pricing-visibility.md
@@ -3,14 +3,46 @@ status: accepted
 date: 2026-05-14
 decision-makers: [Achim Dehnert]
 implementation_status: in-progress
-related: [ADR-199-rejected, dev-hub#39]
+related: [ADR-199-rejected, ADR-203, ADR-208, dev-hub#39]
 ---
 
 # ADR-201: Claude Code Pricing Visibility — Statusline + Stop-Summary
 
 ## Status
 
-Accepted — direkter Folge-ADR der ADR-199-Rejection. Adressiert das konkrete Symptom ($1577/48h Opus-Spend in dev-hub#39) am User-Touchpoint statt über eine Routing-Authority.
+Accepted — **Umsetzung präzisiert, siehe Amendment 2026-05-16.**
+
+## Amendment 2026-05-16 (Advocatus-Diabolus-Review)
+
+Beschluss bleibt (Cost-Sichtbarkeit am Touchpoint), aber vier Korrekturen
+**bindend für die Umsetzung**:
+
+1. **Abnahmekriterium ist technisch, nicht behavioral.** Pass/Fail von
+   ADR-201 = *Zahl korrekt, p95 < 100 ms, Abweichung ≤ 1 % zu
+   `llm_calls.cost_usd`*. Das alte Kriterium „>30 % Reduktion
+   `opus_per_session_ratio` in 14 Tagen" ist unkontrolliert
+   (Hawthorne, $1577-Vorfall selbst, ADR-202 parallel) und wird in ein
+   **separates Experiment mit Baseline/Kontrolle** ausgelagert — kein
+   Pass/Fail-Gate eines Anzeige-Features. Metrik dort = $/Outcome, nicht der
+   gamebare Modell-Mix-Proxy.
+2. **Per-Turn-Quelle = lokales Session-Ledger, nicht Prod-DB.** Der Stop-Hook
+   schreibt `~/.claude/state/<session>.jsonl` (append, eine Zeile/Turn). Die
+   Statusline liest ausschließlich diese Datei (Sub-ms, kein SSH-Tunnel, kein
+   Prod-Hop im Editor-Innerloop). Prod-DB nur für „today across sessions" als
+   gecachter Refresh alle N Turns. Damit entfällt Open Question 2
+   (Tunnel vs. Replica) und der Latenz-Negativpunkt.
+3. **Pricing aus dem Resolver (ADR-208), nicht aus dem Dict.** Kein
+   eigenständiges Pricing-Wissen in der Statusline; `PRICING_USD_PER_MTOK`
+   wird durch die Resolver-SSoT abgelöst (sonst dieselbe Drift wie ADR-203
+   Risiko #2). Tier-Mismatch-Heuristik wird über die Rolle aus dem Resolver
+   trivial (Open Question 1 dort gelöst).
+4. **Hook-API-Spike vor Phase 1.** Phase 2 (`/model`-Pre-Prompt-Vergleich)
+   ist der einzige Touchpoint am *Entscheidungspunkt* — die ambienten
+   Phasen 1+2 wirken nur ergänzend. 30-min-Spike zur SlashCommand-Pre-Hook-
+   Verfügbarkeit **zuerst**; ist Phase 2 machbar, Hebelreihenfolge umkehren.
+
+Die folgenden Original-Abschnitte gelten unverändert, soweit nicht oben
+präzisiert.
 
 ## Context
 

--- a/docs/adr/ADR-203-anthropic-model-alias-adoption.md
+++ b/docs/adr/ADR-203-anthropic-model-alias-adoption.md
@@ -1,5 +1,6 @@
 ---
-status: proposed
+status: superseded
+superseded-by: ADR-208
 date: 2026-05-14
 decision-makers: [Achim Dehnert]
 implementation_status: none
@@ -10,7 +11,8 @@ related: [ADR-199-rejected, ADR-201, ADR-208, mcp-hub#37, mcp-hub#41]
 
 ## Status
 
-Proposed — **Richtung revidiert, siehe Amendment 2026-05-16.**
+Superseded by ADR-208 (2026-05-16) — Provider-`-latest` verworfen, siehe
+Amendment unten. Original als Kontext erhalten.
 
 ## Amendment 2026-05-16 (Advocatus-Diabolus-Review)
 

--- a/docs/adr/ADR-203-anthropic-model-alias-adoption.md
+++ b/docs/adr/ADR-203-anthropic-model-alias-adoption.md
@@ -3,14 +3,41 @@ status: proposed
 date: 2026-05-14
 decision-makers: [Achim Dehnert]
 implementation_status: none
-related: [ADR-199-rejected, ADR-201, mcp-hub#37, mcp-hub#41]
+related: [ADR-199-rejected, ADR-201, ADR-208, mcp-hub#37, mcp-hub#41]
 ---
 
 # ADR-203: Anthropic Model-Alias Adoption — Drift-Wartung zu Anthropic verschieben
 
 ## Status
 
-Proposed — optional Folge-ADR von ADR-199 (rejected). 1-Tag-Aufwand mit hohem Hebel, falls die Trade-offs akzeptabel sind.
+Proposed — **Richtung revidiert, siehe Amendment 2026-05-16.**
+
+## Amendment 2026-05-16 (Advocatus-Diabolus-Review)
+
+Der ursprüngliche Beschluss (Provider-Rolling-Aliase `claude-*-latest`) wird
+**nicht** umgesetzt. Begründung:
+
+1. **Selbstwiderspruch zum eigenen Risiko #4.** Reproduzierbarkeit für
+   ADR-Reviews/Audits/Evals geht verloren. Diese Org betreibt externes
+   ADR-Review — Provider-`-latest` auf audit-erzeugenden Surfaces ist damit
+   ausgeschlossen, nicht nur „riskant".
+2. **Die „Out-of-the-Box-Alternative" ist die Entscheidung.** Interne Aliase
+   liefern jeden genannten Vorteil (eine Update-Stelle, Provider-Unabhängig,
+   einheitliches Naming) und eliminieren **jedes** gelistete Vendor-Risiko.
+   Die einzige Last (Update bei Modell-Retirement = 1 PR) ist der mcp-hub#37-
+   Fall — vernachlässigbar gegenüber dem Verlust von Kontrolle/Observability.
+3. **Cost-Tracking-Konflikt mit ADR-201 aufgelöst:** ein aufgelöster Pin hält
+   `llm_calls.cost_usd` exakt; die Mitigation „Anthropics Usage-Reporting
+   außerhalb unseres Stacks" entfällt.
+
+**Revidierter Beschluss:** Modell-Identität wird über einen **internen,
+versionierten Resolver** geführt (→ **ADR-208**), nicht über Provider-Aliase.
+Provider-`-latest` ist auf Routing-/Review-/Eval-/Audit-Surfaces untersagt.
+Die Kopplung „conditional auf ADR-201-Messung" wird gestrichen (kausal
+unverbunden: 203 = Drift, 201 = Cost-Awareness).
+
+Die folgenden Original-Abschnitte bleiben als Kontext/Begründung erhalten,
+sind aber durch dieses Amendment + ADR-208 überschrieben.
 
 ## Context
 

--- a/docs/adr/ADR-208-internal-model-resolver.md
+++ b/docs/adr/ADR-208-internal-model-resolver.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-05-16
 decision-makers: [Achim Dehnert]
 implementation_status: none
@@ -10,8 +10,9 @@ related: [ADR-199-rejected, ADR-201, ADR-203, mcp-hub#37, mcp-hub#41]
 
 ## Status
 
-Proposed — entstanden aus dem Advocatus-Diabolus-Review von ADR-201 + ADR-203
-(2026-05-16). Schließt die Lücke, die beide bisher separat umgehen.
+Accepted (2026-05-16) — ratifiziert aus dem Advocatus-Diabolus-Review von
+ADR-201 + ADR-203. Ersetzt die Richtung von ADR-203 (dort `superseded`).
+Implementierung gemäß Skizze offen (`implementation_status: none`).
 
 ## Context
 

--- a/docs/adr/ADR-208-internal-model-resolver.md
+++ b/docs/adr/ADR-208-internal-model-resolver.md
@@ -1,0 +1,107 @@
+---
+status: proposed
+date: 2026-05-16
+decision-makers: [Achim Dehnert]
+implementation_status: none
+related: [ADR-199-rejected, ADR-201, ADR-203, mcp-hub#37, mcp-hub#41]
+---
+
+# ADR-208: Interner Model-Resolver — versionierte Alias→Pin+Preis-Map (ohne Service)
+
+## Status
+
+Proposed — entstanden aus dem Advocatus-Diabolus-Review von ADR-201 + ADR-203
+(2026-05-16). Schließt die Lücke, die beide bisher separat umgehen.
+
+## Context
+
+Drei ADRs umkreisen dieselbe fehlende Schicht:
+
+- **ADR-199** wollte eine Model-Routing-*Authority* und wurde nach 4 Review-
+  Runden als **over-engineered** abgelehnt (Service/GitOps-Routing zu schwer).
+- **ADR-203** versucht Drift-Wartung über Provider-`-latest` zu lösen →
+  silent vendor drift, Reproduzierbarkeit/Cost-Tracking kaputt (dort Amendment).
+- **ADR-201** dupliziert Pricing-Wissen (`PRICING_USD_PER_MTOK`) und liest
+  Session-Kosten pro Turn aus der Prod-DB.
+
+Nicht-offensichtlicher Befund: ADR-199 wurde zu Recht als *schwere* Variante
+verworfen — aber „kein 199" ≠ „die leichte Essenz von 199". 201 und 203 kaufen
+diese Essenz jeweils teuer und unvollständig ein. **Es fehlt genau ein
+Primitiv: Model-Identität + Pricing als eine versionierte Quelle.**
+
+## Decision
+
+Ein **interner Resolver** als *Daten*-Artefakt, **kein Service, keine
+Routing-Logik** (bewusste Abgrenzung zum verworfenen ADR-199):
+
+- Eine versionierte Datei (`iil_routing/model_resolver.yaml`, GitOps):
+
+  ```yaml
+  aliases:
+    iil/opus-current:   { model: anthropic/claude-opus-4-7,    price_in: 15.0, price_out: 75.0 }
+    iil/sonnet-current: { model: anthropic/claude-sonnet-4-6,  price_in: 3.0,  price_out: 15.0 }
+    iil/haiku-current:  { model: anthropic/claude-haiku-4-5,   price_in: 0.8,  price_out: 4.0 }
+    iil/fast-current:   { model: groq/llama-3.3-70b-versatile, price_in: 0.59, price_out: 0.79 }
+  ```
+
+- **Genau drei Konsumenten lesen daraus**, keiner hält eigenes Wissen:
+  1. Routing-Surfaces (mcp-hub `model_selector`/`model_registry`/`review_adr`)
+     referenzieren `iil/<rolle>-current` statt Pin oder Provider-`-latest`.
+  2. `~/.claude/hooks/log_llm_call.py` zieht Pricing **nur** hieraus
+     (`PRICING_USD_PER_MTOK` entfällt).
+  3. ADR-201-Statusline liest Pricing + Rolle hieraus.
+- **Update bei Modell-Retirement = 1 PR an dieser Datei** (mcp-hub#37-Fall),
+  reviewbar, versioniert.
+- **Reproduzierbarkeit:** jeder Call/Run loggt den *aufgelösten* Pin + die
+  Resolver-Version (git sha). Audits/ADR-Reviews bleiben exakt nachvollziehbar.
+- **Provider-`-latest` ist verboten** auf Routing-/Review-/Eval-/Audit-
+  Surfaces (löst ADR-203 Risiko #1–#4 strukturell).
+
+## Consequences
+
+### Positiv
+
+- Eine SSoT für Model-Identität *und* Pricing → ADR-201-Dict-Drift und
+  ADR-203-Vendor-Drift fallen beide weg.
+- ADR-203 ↔ ADR-201-Konflikt aufgelöst: aufgelöster Pin ⇒ `cost_usd` exakt.
+- Keine neue Laufzeit-Abhängigkeit, kein Service — reversibel durch Löschen
+  der Datei + Zurück-auf-Pin. Bewusst *kleiner* als das verworfene ADR-199.
+- ADR-201 Open Questions 1+2 werden trivial (Rolle bekannt; keine Prod-DB
+  im Per-Turn-Pfad nötig).
+
+### Negativ / offen
+
+- Die Update-Last bleibt intern (1 PR pro Retirement) — akzeptiert, weil
+  Kontrolle/Observability/Reproduzierbarkeit das überwiegen.
+- Migrationsaufwand: Routing-Surfaces + `log_llm_call.py` einmalig auf
+  Resolver umstellen (~0.5 Tag). SQL-Rows analog ADR-203 §Implementations-
+  Skizze, aber mit Alias→Pin statt Provider-Alias.
+- Andere Provider (`groq/*`, `openai/*`) bleiben zunächst gepinnt im Resolver;
+  einheitliches Naming ja, aber keine provider-übergreifende Auto-Drift
+  (gewollt).
+
+## Abgrenzung zu ADR-199 (warum das kein 199-Reboot ist)
+
+| | ADR-199 (rejected) | ADR-208 |
+|---|---|---|
+| Form | Service / Routing-Authority | eine YAML-Datei |
+| Logik | Routing-Entscheidung | nur Auflösung Alias→Pin+Preis |
+| Laufzeit-Dep | ja | nein |
+| Reversibel | schwer | Datei löschen |
+
+ADR-199 wurde wegen *Schwere* verworfen — ADR-208 nimmt nur dessen
+unstrittigen Kern (eine versionierte Identitäts-/Preis-Quelle) und lässt die
+Routing-Authority bewusst weg.
+
+## Acceptance Criteria
+
+- [ ] `model_resolver.yaml` existiert, GitOps-versioniert, CI-validiert (Schema + jeder `model` ist ein real auflösbarer litellm-String)
+- [ ] mcp-hub Routing-Surfaces referenzieren `iil/<rolle>-current`, kein Provider-`-latest`, keine verstreuten Pins
+- [ ] `log_llm_call.py` zieht Pricing aus dem Resolver; `PRICING_USD_PER_MTOK` entfernt; `cost_usd` unverändert akkurat (Regressionstest gegen 30 historische Calls)
+- [ ] Jeder geloggte Call enthält aufgelösten Pin + Resolver-git-sha
+- [ ] ADR-203-Amendment + ADR-201-Amendment referenzieren ADR-208
+
+## Changelog
+
+- 2026-05-16: Initial. Proposed. Konsolidiert die in ADR-201/203 verstreuten
+  Workarounds zur leichten Essenz des verworfenen ADR-199.

--- a/docs/adr/ADR-208-internal-model-resolver.md
+++ b/docs/adr/ADR-208-internal-model-resolver.md
@@ -93,6 +93,78 @@ ADR-199 wurde wegen *Schwere* verworfen — ADR-208 nimmt nur dessen
 unstrittigen Kern (eine versionierte Identitäts-/Preis-Quelle) und lässt die
 Routing-Authority bewusst weg.
 
+## Implementierungs-Skizze (konkret)
+
+### Ablage & Konsumweg (cross-repo)
+
+Kanonisch in **mcp-hub** (dort leben die Routing-Surfaces), von `~/.claude`
+mitbenutzt — Pointer/Vendor statt zweiter Wahrheit (gleiche Anti-Drift-Linie
+wie ADR-018 Doku-Strategie):
+
+```
+mcp-hub/orchestrator_mcp/iil_routing/
+  model_resolver.yaml          # SSoT (GitOps, reviewbar)
+  model_resolver.schema.json   # Schema
+  resolver.py                  # resolve(alias) -> {model, price_in, price_out, sha}
+~/.claude/hooks/log_llm_call.py  # importiert resolver.py, sonst vendored Fallback-Copy
+```
+
+### Schema (Auszug, `model_resolver.schema.json`)
+
+```json
+{ "type":"object","required":["aliases"],
+  "properties":{"aliases":{"type":"object","minProperties":1,
+    "additionalProperties":{"type":"object",
+      "required":["model","price_in","price_out"],
+      "properties":{
+        "model":{"type":"string","pattern":"^[a-z0-9_-]+/[A-Za-z0-9._-]+$"},
+        "price_in":{"type":"number","exclusiveMinimum":0},
+        "price_out":{"type":"number","exclusiveMinimum":0}}}}}}
+```
+
+### CI-Validator (deterministisch, analog meiki manifest-check)
+
+`scripts/check-model-resolver.py`, Workflow on PR-paths:
+
+1. Schema-Validierung.
+2. Jeder `model` ist ein real auflösbarer litellm-String
+   (`litellm.get_model_info(model)` ohne Exception) — **kein** `*-latest`
+   erlaubt (Regex-Block `-latest$`).
+3. Kein verwaister Alias: jeder in Surfaces referenzierte `iil/<rolle>-current`
+   existiert in `aliases` (grep über mcp-hub + policies).
+4. Exit≠0 bricht den PR — „Resolver konsistent == Routing konsistent".
+
+### Migration je Surface (idempotent, ein PR)
+
+| Surface | Heute | Nachher |
+|---|---|---|
+| `orchestrator_mcp/model_selector.py` `_ROUTE_TABLE` | Pins | `iil/<rolle>-current` via `resolver.resolve()` |
+| `orchestrator_mcp/model_registry.py` `_FALLBACK` | Pins | dito |
+| `orchestrator_mcp/skills/review_adr.py` `_DEFAULT_REVIEW_MODEL` | Pin | `iil/opus-current` |
+| `dev-hub aifw_llm_models` / `aifw_action_types.default_model_id` | Pin-Rows | Alias-Rows + UPDATE (SQL analog ADR-203 §Skizze, aber Alias→Pin) |
+| `~/.claude/policies/llm-routing.md` | Tier-Liste mit Pins | Alias-Namen |
+| `~/.claude/hooks/log_llm_call.py` | `PRICING_USD_PER_MTOK` | `resolver.resolve()`; loggt `resolved_model` + `resolver_sha` |
+
+### Phasen
+
+| Phase | Aufwand | Lieferung |
+|---|---|---|
+| 1 | 30 min | `model_resolver.yaml` + Schema + `resolver.py` + CI-Validator (grün) |
+| 2 | 1 h | `log_llm_call.py` auf Resolver; Regressionstest gegen 30 historische Calls (`cost_usd` ≤ 1 % Abweichung) |
+| 3 | 1 h | mcp-hub Surfaces + `review_adr` umstellen; `*-latest`-Grep = 0 |
+| 4 | 1 h | dev-hub SQL-Migration (`0047_aifw_alias_rows.sql`) + policies-Update |
+| 5 | 30 min | ADR-201-Statusline liest `resolver.resolve()`; Rollback-Test |
+
+### Rollback
+
+Eine Datei + Loader entfernen, Surfaces zurück auf Pin (git revert des
+Migrations-PR). Keine Laufzeit-Dependency, kein Datenverlust — der Resolver
+ist Daten, kein Service.
+
+### Mapping Phasen → Acceptance
+
+Phase 1→AC1, Phase 3→AC2, Phase 2→AC3, Phase 2/5→AC4, ADR-Amendments→AC5.
+
 ## Acceptance Criteria
 
 - [ ] `model_resolver.yaml` existiert, GitOps-versioniert, CI-validiert (Schema + jeder `model` ist ein real auflösbarer litellm-String)


### PR DESCRIPTION
Ergebnis des tiefen Reviews von ADR-201 + ADR-203.

**ADR-203 (Amendment):** Provider-`-latest` verworfen — Selbstwiderspruch zu eigenem Risiko #4 (Audit-/Review-Reproduzierbarkeit). Richtung → interne Aliase (ADR-208). "Conditional auf ADR-201" gestrichen (kausal unverbunden).

**ADR-201 (Amendment):** (1) Abnahmekriterium technisch (Korrektheit/Latenz) statt unkontrollierter Verhaltensmetrik → separates Experiment. (2) Per-Turn-Quelle = lokales Session-Ledger statt Prod-DB/SSH-Tunnel. (3) Pricing aus Resolver, nicht dupliziertes Dict. (4) Hook-API-Spike vor Phase 1.

**ADR-208 (neu, Proposed):** Die leichte Essenz des als over-engineered verworfenen ADR-199 — *eine* versionierte Alias→Pin+Preis-Map, kein Service. Löst ADR-201-Dict-Drift und ADR-203-Vendor-Drift gemeinsam; ADR-201↔203-Cost-Konflikt aufgelöst.

Base = `adr/201-pricing-visibility` (Workstream-Branch mit 199/201/203). Genuine Architektur (kehrt 203-Richtung um, cross-cutting SSoT) → ADR-Schwelle erfüllt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)