### PR TITLE
fix(ci): geguardeten adr-review.yml auf ADR-Workstream backporten

### DIFF
--- a/.github/workflows/adr-review.yml
+++ b/.github/workflows/adr-review.yml
@@ -43,16 +43,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Check adr-review package presence
+        id: check-pkg
+        run: |
+          if [ -f "./packages/adr-review/pyproject.toml" ] || [ -f "./packages/adr-review/setup.py" ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::packages/adr-review not present — AI Review will be skipped. Add the package to enable."
+          fi
+
       - name: Setup Python
+        if: steps.check-pkg.outputs.found == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'
 
       - name: Install adr-review
+        if: steps.check-pkg.outputs.found == 'true'
         run: pip install ./packages/adr-review
 
       - name: Run ADR Review
+        if: steps.check-pkg.outputs.found == 'true'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Problem:** `adr-review.yml` auf `adr/201-pricing-visibility` ist die alte ungeguardete Version (`pip install ./packages/adr-review` — Paket existiert nicht) → `AI Review` failt hart auf jedem ADR-PR (z. B. #176).

**Befund:** `main` ist bereits gefixt (Guard: `check-pkg` → skip + `::warning::`). `sync-workflows-to-repos` zieht aus main → andere Repos self-healing. Kein Fix an main nötig; **keine** Blanket-Aktion über die ~55 vor dem Guard abgezweigten Branches (erben ihn via Merge/Rebase).

**Fix:** genau diese eine Datei von `main` auf den aktiven Workstream backporten (+13 Zeilen, nur der Guard). Stoppt das falsch-rote ❌ ohne History-Rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)