### PR TITLE
feat(ci): minimales adr-review CLI-Paket

### DIFF
--- a/.github/workflows/adr-review.yml
+++ b/.github/workflows/adr-review.yml
@@ -3,10 +3,11 @@
 # Uses the adr-review package for clean, testable reviews
 #
 # Setup:
-#   1. Add ANTHROPIC_API_KEY secret to repository
+#   1. Add CEREBRAS_API_KEY (+ optional GROQ_API_KEY) secret to repository
 #   2. Ensure packages/adr-review is available
 #
-# Cost: ~$0.03-0.05 per review
+# LLM: Flatrate via litellm → Cerebras/Groq (Plattform llm-routing Policy).
+#      KEIN Anthropic / ANTHROPIC_API_KEY.
 
 name: "📋 ADR Review"
 
@@ -67,7 +68,8 @@ jobs:
       - name: Run ADR Review
         if: steps.check-pkg.outputs.found == 'true'
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER="${{ github.event.pull_request.number || inputs.pr_number }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - `packages/adr-review/` — minimales CLI für KI-gestützte ADR-Reviews auf PRs
   (konsumiert von `.github/workflows/adr-review.yml`; das Paket fehlte bisher,
-  der Workflow-Guard überspringt nur). Reviewt geänderte ADR-Dateien via Claude
-  (System-Prompt ge-cached), upsertet einen PR-Kommentar, setzt Score-Label.
-  Informativ/non-blocking by default; `--fail-under N` optional. Tests +
-  README dabei. Kein ADR nötig (internes CI-Tool, ein Repo, kein Public-Surface).
+  der Workflow-Guard überspringt nur). Reviewt geänderte ADR-Dateien, upsertet
+  einen PR-Kommentar, setzt Score-Label. Informativ/non-blocking by default;
+  `--fail-under N` optional. Tests + README dabei. Kein ADR nötig (internes
+  CI-Tool, ein Repo, kein Public-Surface).
+
+### Changed
+- adr-review LLM-Pfad: **Flatrate via litellm → Cerebras/Groq** statt Anthropic
+  (Plattform-`llm-routing`-Policy). `ANTHROPIC_API_KEY` entfernt — aus
+  Paket-Deps, CLI, Workflow-Env *und* als GitHub-Secret gelöscht. Default
+  `cerebras/qwen-3-235b-a22b-instruct-2507` + Groq-Fallback, env-übersteuerbar.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [2026.05.16] — 2026-05-16
+
+### Added
+- `packages/adr-review/` — minimales CLI für KI-gestützte ADR-Reviews auf PRs
+  (konsumiert von `.github/workflows/adr-review.yml`; das Paket fehlte bisher,
+  der Workflow-Guard überspringt nur). Reviewt geänderte ADR-Dateien via Claude
+  (System-Prompt ge-cached), upsertet einen PR-Kommentar, setzt Score-Label.
+  Informativ/non-blocking by default; `--fail-under N` optional. Tests +
+  README dabei. Kein ADR nötig (internes CI-Tool, ein Repo, kein Public-Surface).
+
+---
+
 ## [2026.04.28] — 2026-04-28
 
 ### Added

--- a/packages/adr-review/README.md
+++ b/packages/adr-review/README.md
@@ -7,8 +7,9 @@ Konsumiert von `.github/workflows/adr-review.yml` (`pip install ./packages/adr-r
 ## Verhalten
 
 1. Lädt geänderte ADR-Dateien des PR (Trigger-Pfade wie im Workflow).
-2. Reviewt sie via Claude gegen eine MADR-/Advocatus-Diabolus-Checkliste
-   (System-Prompt ge-cached).
+2. Reviewt sie via **litellm → Flatrate Cerebras/Groq** gegen eine
+   MADR-/Advocatus-Diabolus-Checkliste. **Kein Anthropic, kein
+   ANTHROPIC_API_KEY** (Plattform-`llm-routing`-Policy: Cerebras/Groq first).
 3. Upsertet **einen** PR-Kommentar (Marker `<!-- adr-review -->`, kein Spam).
 4. Setzt Score-Label: `adr-review-passed` (≥7) · `-concerns` (5–6) · `-failed` (<5).
 
@@ -21,11 +22,19 @@ optional rot unter Score N.
 | Var | Pflicht | Default |
 |---|---|---|
 | `GITHUB_TOKEN` | ja | — |
-| `ANTHROPIC_API_KEY` | ja | — |
-| `ADR_REVIEW_MODEL` | nein | `claude-sonnet-4-6` |
+| `CEREBRAS_API_KEY` | eine LLM-Quelle nötig | — |
+| `GROQ_API_KEY` | (für Fallback) | — |
+| `ADR_REVIEW_MODEL` | nein | `cerebras/qwen-3-235b-a22b-instruct-2507` |
+| `ADR_REVIEW_FALLBACK` | nein | `groq/llama-3.3-70b-versatile` |
 
-Fehlt ein Pflicht-Secret oder enthält der PR keine ADR-Datei → sauberer
-Exit 0 mit Hinweis (kein false-rot, konsistent mit dem Workflow-Guard).
+Keys werden wie bei `print_agent` aufgelöst: env-Var **oder**
+`~/shared/secrets-inbox/<provider>_api_key`. Fehlt `GITHUB_TOKEN`, jeder
+LLM-Key oder enthält der PR keine ADR-Datei → sauberer Exit 0 mit Hinweis
+(kein false-rot, konsistent mit dem Workflow-Guard).
+
+Default-Modell = Policy-Tier-1a (user-visible Prosa), Flatrate, kein Frontier.
+Override jederzeit via Env. ADR-208-Resolver als künftige Auflösung vorgesehen,
+bewusst noch nicht hart gekoppelt (Paket bleibt minimal).
 
 ## Lokal
 
@@ -34,6 +43,3 @@ pip install ./packages/adr-review
 adr-review --pr 175 --repo achimdehnert/platform --dry-run
 pytest packages/adr-review/tests
 ```
-
-Künftig: Modellauflösung über den internen Resolver (ADR-208) statt
-hartem Default — bewusst noch nicht hart gekoppelt (Paket bleibt minimal).

--- a/packages/adr-review/README.md
+++ b/packages/adr-review/README.md
@@ -1,0 +1,39 @@
+# adr-review
+
+Minimales CLI für KI-gestützte ADR-Architektur-Reviews auf Pull Requests.
+Konsumiert von `.github/workflows/adr-review.yml` (`pip install ./packages/adr-review`
+→ `adr-review --pr <n> --repo <owner/name>`).
+
+## Verhalten
+
+1. Lädt geänderte ADR-Dateien des PR (Trigger-Pfade wie im Workflow).
+2. Reviewt sie via Claude gegen eine MADR-/Advocatus-Diabolus-Checkliste
+   (System-Prompt ge-cached).
+3. Upsertet **einen** PR-Kommentar (Marker `<!-- adr-review -->`, kein Spam).
+4. Setzt Score-Label: `adr-review-passed` (≥7) · `-concerns` (5–6) · `-failed` (<5).
+
+**Informativ, nicht blockierend.** Default Exit 0 (auch bei niedrigem Score) —
+bewusst kein Enforcement-Gate (ADR-199-Lehre). `--fail-under N` macht CI
+optional rot unter Score N.
+
+## Env
+
+| Var | Pflicht | Default |
+|---|---|---|
+| `GITHUB_TOKEN` | ja | — |
+| `ANTHROPIC_API_KEY` | ja | — |
+| `ADR_REVIEW_MODEL` | nein | `claude-sonnet-4-6` |
+
+Fehlt ein Pflicht-Secret oder enthält der PR keine ADR-Datei → sauberer
+Exit 0 mit Hinweis (kein false-rot, konsistent mit dem Workflow-Guard).
+
+## Lokal
+
+```bash
+pip install ./packages/adr-review
+adr-review --pr 175 --repo achimdehnert/platform --dry-run
+pytest packages/adr-review/tests
+```
+
+Künftig: Modellauflösung über den internen Resolver (ADR-208) statt
+hartem Default — bewusst noch nicht hart gekoppelt (Paket bleibt minimal).

--- a/packages/adr-review/adr_review/__init__.py
+++ b/packages/adr-review/adr_review/__init__.py
@@ -1,0 +1,3 @@
+"""Minimal AI architecture-review CLI for ADR pull requests."""
+
+__version__ = "0.1.0"

--- a/packages/adr-review/adr_review/cli.py
+++ b/packages/adr-review/adr_review/cli.py
@@ -1,13 +1,18 @@
 """adr-review — minimal AI architecture review for ADR pull requests.
 
+Flatrate-only: routes via litellm to Cerebras/Groq (platform llm-routing
+policy). NO Anthropic, no ANTHROPIC_API_KEY.
+
 Non-blocking by default: posts a review comment + sets a score label.
 Use --fail-under N to make CI red below a score (off by default — informing,
 not enforcing; the ADR-199 lesson).
 
 Env:
-  GITHUB_TOKEN       (required) — PR read + comment/label write
-  ANTHROPIC_API_KEY  (required) — the review model
-  ADR_REVIEW_MODEL   (optional) — default 'claude-sonnet-4-6'
+  GITHUB_TOKEN        (required) — PR read + comment/label write
+  CEREBRAS_API_KEY    — for cerebras/* models   (one LLM key required)
+  GROQ_API_KEY        — for groq/* models       (used for fallback)
+  ADR_REVIEW_MODEL    (optional) default 'cerebras/qwen-3-235b-a22b-instruct-2507'
+  ADR_REVIEW_FALLBACK (optional) default 'groq/llama-3.3-70b-versatile'
 """
 from __future__ import annotations
 
@@ -15,13 +20,20 @@ import argparse
 import os
 import re
 import sys
+from pathlib import Path
 
 import requests
 
 GH = "https://api.github.com"
 MARKER = "<!-- adr-review -->"
-# Default cost-conscious (ADR-201 spirit). Future: resolve via ADR-208 resolver.
-MODEL = os.environ.get("ADR_REVIEW_MODEL", "claude-sonnet-4-6")
+
+# Tier-1a (policy: user-visible prose), Flatrate Cerebras/Groq — kein Anthropic.
+PRIMARY = os.environ.get("ADR_REVIEW_MODEL",
+                         "cerebras/qwen-3-235b-a22b-instruct-2507")
+FALLBACK = os.environ.get("ADR_REVIEW_FALLBACK",
+                          "groq/llama-3.3-70b-versatile").strip()
+_SECRET_DIRS = [Path.home() / "shared" / "secrets-inbox",
+                Path.home() / ".secrets"]
 
 CHECKLIST = """Du bist ADR-Architektur-Reviewer für die iil/achimdehnert-Plattform.
 Bewerte den/die geänderten ADR(s) gegen:
@@ -48,6 +60,26 @@ def is_adr_file(path: str) -> bool:
         or bool(re.match(r"ADR-.*\.md$", base))
         or (path.startswith("concepts/") and path.endswith(".md"))
     )
+
+
+def _secret(model: str) -> str | None:
+    """litellm-Modellstring → API-Key (env ODER ~/shared/secrets-inbox/, wie print_agent)."""
+    m = model.lower()
+    name = ("cerebras_api_key" if m.startswith("cerebras/")
+            else "groq_api_key" if m.startswith("groq/")
+            else "mistral_api_key" if m.startswith("mistral/")
+            else "openai_api_key" if m.startswith(("openai/", "gpt-"))
+            else None)
+    if not name:
+        return None
+    val = os.environ.get(name.upper())
+    if val:
+        return val
+    for d in _SECRET_DIRS:
+        p = d / name
+        if p.exists():
+            return p.read_text().strip()
+    return None
 
 
 def _gh(method: str, url: str, token: str, **kw):
@@ -81,26 +113,44 @@ def fetch_text(raw_url: str, token: str) -> str:
         return f"(konnte Inhalt nicht laden: {e})"
 
 
-def review(files: list[dict], token: str) -> tuple[int, str]:
-    import anthropic
+def _complete(model: str, system: str, user: str) -> str | None:
+    """Ein litellm-Versuch; None bei fehlendem Key oder Fehler."""
+    key = _secret(model)
+    if not key:
+        print(f"adr-review: kein Key für {model} — übersprungen")
+        return None
+    try:
+        import litellm
+        resp = litellm.completion(
+            model=model,
+            messages=[{"role": "system", "content": system},
+                      {"role": "user", "content": user}],
+            max_tokens=1600,
+            temperature=0.2,
+            api_key=key,
+            timeout=60,
+        )
+        return (resp.choices[0].message.content or "").strip()
+    except Exception as e:  # noqa: BLE001
+        print(f"adr-review: {model} fehlgeschlagen: {e}")
+        return None
 
-    parts = []
-    for f in files:
-        parts.append(f"### {f['filename']}\n\n{fetch_text(f['raw_url'], token)}")
+
+def review(files: list[dict], token: str) -> tuple[int, str] | None:
+    parts = [f"### {f['filename']}\n\n{fetch_text(f['raw_url'], token)}"
+             for f in files]
     user = "Geänderte ADR-Dateien:\n\n" + "\n\n---\n\n".join(parts)
 
-    client = anthropic.Anthropic()
-    msg = client.messages.create(
-        model=MODEL,
-        max_tokens=1600,
-        system=[{"type": "text", "text": CHECKLIST,
-                 "cache_control": {"type": "ephemeral"}}],
-        messages=[{"role": "user", "content": user}],
-    )
-    text = "".join(b.text for b in msg.content if b.type == "text").strip()
+    text = _complete(PRIMARY, CHECKLIST, user)
+    used = PRIMARY
+    if text is None and FALLBACK:
+        text = _complete(FALLBACK, CHECKLIST, user)
+        used = FALLBACK
+    if text is None:
+        return None
     m = re.search(r"SCORE:\s*(\d{1,2})", text)
     score = max(1, min(10, int(m.group(1)))) if m else 5
-    return score, text
+    return score, f"{text}\n\n<sub>via {used}</sub>"
 
 
 def label_for(score: int) -> str:
@@ -150,8 +200,9 @@ def main(argv: list[str] | None = None) -> int:
     if not token:
         print("adr-review: GITHUB_TOKEN fehlt — übersprungen.")
         return 0
-    if not os.environ.get("ANTHROPIC_API_KEY"):
-        print("adr-review: ANTHROPIC_API_KEY fehlt — übersprungen.")
+    if not (_secret(PRIMARY) or (FALLBACK and _secret(FALLBACK))):
+        print("adr-review: kein LLM-Key (CEREBRAS_API_KEY/GROQ_API_KEY) "
+              "— übersprungen.")
         return 0
 
     files = changed_adrs(a.repo, a.pr, token)
@@ -159,11 +210,15 @@ def main(argv: list[str] | None = None) -> int:
         print("adr-review: keine ADR-Dateien im PR — nichts zu tun.")
         return 0
 
-    score, text = review(files, token)
+    res = review(files, token)
+    if res is None:
+        print("adr-review: Review nicht möglich (LLM) — übersprungen.")
+        return 0
+    score, text = res
     label = label_for(score)
     body = (f"## 🤖 ADR Review — Score {score}/10 (`{label}`)\n\n"
-            f"{text}\n\n<sub>Modell: {MODEL} · {len(files)} ADR-Datei(en) · "
-            f"informativ, nicht blockierend</sub>")
+            f"{text}\n\n<sub>{len(files)} ADR-Datei(en) · Flatrate "
+            f"(Cerebras/Groq) · informativ, nicht blockierend</sub>")
 
     if a.dry_run:
         print(body)

--- a/packages/adr-review/adr_review/cli.py
+++ b/packages/adr-review/adr_review/cli.py
@@ -1,0 +1,186 @@
+"""adr-review — minimal AI architecture review for ADR pull requests.
+
+Non-blocking by default: posts a review comment + sets a score label.
+Use --fail-under N to make CI red below a score (off by default — informing,
+not enforcing; the ADR-199 lesson).
+
+Env:
+  GITHUB_TOKEN       (required) — PR read + comment/label write
+  ANTHROPIC_API_KEY  (required) — the review model
+  ADR_REVIEW_MODEL   (optional) — default 'claude-sonnet-4-6'
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+import requests
+
+GH = "https://api.github.com"
+MARKER = "<!-- adr-review -->"
+# Default cost-conscious (ADR-201 spirit). Future: resolve via ADR-208 resolver.
+MODEL = os.environ.get("ADR_REVIEW_MODEL", "claude-sonnet-4-6")
+
+CHECKLIST = """Du bist ADR-Architektur-Reviewer für die iil/achimdehnert-Plattform.
+Bewerte den/die geänderten ADR(s) gegen:
+- MADR-Struktur: Kontext/Problem, Entscheidung, Konsequenzen, Alternativen.
+- Wird eine echte Architekturentscheidung getroffen (nicht bloße Ergänzung)?
+- Trade-offs explizit & für künftige Herausforderer nachvollziehbar?
+- Reversibilität, Blast-Radius, Daten-/Sicherheits-/Lizenz-Berührung benannt?
+- Selbstwidersprüche zwischen Decision und Risiken?
+- Status/Frontmatter konsistent (proposed/accepted/superseded).
+
+Antworte AUF DEUTSCH, knapp, als Advocatus Diabolus. Format EXAKT:
+Erste Zeile: `SCORE: <ganzzahl 1-10>`
+Dann `---`
+Dann Markdown: **Verdikt** (1 Satz), **Stärken** (max 3 Bullets),
+**Schwächen/Risiken** (max 5 Bullets), **Konkrete Nachbesserung** (max 3)."""
+
+
+def is_adr_file(path: str) -> bool:
+    """Mirror der adr-review.yml Trigger-Pfade."""
+    base = path.rsplit("/", 1)[-1]
+    return (
+        path.startswith("docs/adr/")
+        or path.startswith("adr/")
+        or bool(re.match(r"ADR-.*\.md$", base))
+        or (path.startswith("concepts/") and path.endswith(".md"))
+    )
+
+
+def _gh(method: str, url: str, token: str, **kw):
+    h = {"Authorization": f"Bearer {token}",
+         "Accept": "application/vnd.github+json"}
+    r = requests.request(method, url, headers=h, timeout=30, **kw)
+    r.raise_for_status()
+    return r
+
+
+def changed_adrs(repo: str, pr: int, token: str) -> list[dict]:
+    out, page = [], 1
+    while True:
+        r = _gh("GET", f"{GH}/repos/{repo}/pulls/{pr}/files"
+                f"?per_page=100&page={page}", token)
+        batch = r.json()
+        if not batch:
+            break
+        out += [f for f in batch if is_adr_file(f["filename"])
+                and f["status"] != "removed"]
+        if len(batch) < 100:
+            break
+        page += 1
+    return out
+
+
+def fetch_text(raw_url: str, token: str) -> str:
+    try:
+        return _gh("GET", raw_url, token).text
+    except Exception as e:  # noqa: BLE001
+        return f"(konnte Inhalt nicht laden: {e})"
+
+
+def review(files: list[dict], token: str) -> tuple[int, str]:
+    import anthropic
+
+    parts = []
+    for f in files:
+        parts.append(f"### {f['filename']}\n\n{fetch_text(f['raw_url'], token)}")
+    user = "Geänderte ADR-Dateien:\n\n" + "\n\n---\n\n".join(parts)
+
+    client = anthropic.Anthropic()
+    msg = client.messages.create(
+        model=MODEL,
+        max_tokens=1600,
+        system=[{"type": "text", "text": CHECKLIST,
+                 "cache_control": {"type": "ephemeral"}}],
+        messages=[{"role": "user", "content": user}],
+    )
+    text = "".join(b.text for b in msg.content if b.type == "text").strip()
+    m = re.search(r"SCORE:\s*(\d{1,2})", text)
+    score = max(1, min(10, int(m.group(1)))) if m else 5
+    return score, text
+
+
+def label_for(score: int) -> str:
+    if score >= 7:
+        return "adr-review-passed"
+    if score >= 5:
+        return "adr-review-concerns"
+    return "adr-review-failed"
+
+
+def upsert_comment(repo: str, pr: int, body: str, token: str) -> None:
+    body = f"{MARKER}\n{body}"
+    existing = _gh("GET", f"{GH}/repos/{repo}/issues/{pr}/comments?per_page=100",
+                   token).json()
+    for c in existing:
+        if MARKER in (c.get("body") or ""):
+            _gh("PATCH", f"{GH}/repos/{repo}/issues/comments/{c['id']}",
+                token, json={"body": body})
+            return
+    _gh("POST", f"{GH}/repos/{repo}/issues/{pr}/comments", token,
+        json={"body": body})
+
+
+def set_label(repo: str, pr: int, label: str, token: str) -> None:
+    for stale in ("adr-review-passed", "adr-review-concerns",
+                  "adr-review-failed"):
+        if stale != label:
+            try:
+                _gh("DELETE",
+                    f"{GH}/repos/{repo}/issues/{pr}/labels/{stale}", token)
+            except Exception:  # noqa: BLE001
+                pass
+    _gh("POST", f"{GH}/repos/{repo}/issues/{pr}/labels", token,
+        json={"labels": [label]})
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="adr-review")
+    ap.add_argument("--pr", type=int, required=True)
+    ap.add_argument("--repo", required=True, help="owner/name")
+    ap.add_argument("--fail-under", type=int, default=0,
+                    help="Exit 1 wenn Score < N (default 0 = nie blockieren)")
+    ap.add_argument("--dry-run", action="store_true")
+    a = ap.parse_args(argv)
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if not token:
+        print("adr-review: GITHUB_TOKEN fehlt — übersprungen.")
+        return 0
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        print("adr-review: ANTHROPIC_API_KEY fehlt — übersprungen.")
+        return 0
+
+    files = changed_adrs(a.repo, a.pr, token)
+    if not files:
+        print("adr-review: keine ADR-Dateien im PR — nichts zu tun.")
+        return 0
+
+    score, text = review(files, token)
+    label = label_for(score)
+    body = (f"## 🤖 ADR Review — Score {score}/10 (`{label}`)\n\n"
+            f"{text}\n\n<sub>Modell: {MODEL} · {len(files)} ADR-Datei(en) · "
+            f"informativ, nicht blockierend</sub>")
+
+    if a.dry_run:
+        print(body)
+        return 0
+
+    upsert_comment(a.repo, a.pr, body, token)
+    try:
+        set_label(a.repo, a.pr, label, token)
+    except Exception as e:  # noqa: BLE001
+        print(f"adr-review: Label konnte nicht gesetzt werden: {e}")
+
+    print(f"adr-review: Score {score} ({label}) gepostet.")
+    if a.fail_under and score < a.fail_under:
+        print(f"adr-review: Score {score} < --fail-under {a.fail_under} → exit 1")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/adr-review/pyproject.toml
+++ b/packages/adr-review/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Minimal CLI: AI architecture review for ADR pull requests"
 requires-python = ">=3.11"
 dependencies = [
-    "anthropic>=0.40",
+    "litellm>=1.50",
     "requests>=2.31",
 ]
 

--- a/packages/adr-review/pyproject.toml
+++ b/packages/adr-review/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "adr-review"
+version = "0.1.0"
+description = "Minimal CLI: AI architecture review for ADR pull requests"
+requires-python = ">=3.11"
+dependencies = [
+    "anthropic>=0.40",
+    "requests>=2.31",
+]
+
+[project.scripts]
+adr-review = "adr_review.cli:main"
+
+[tool.setuptools]
+packages = ["adr_review"]

--- a/packages/adr-review/tests/test_filter.py
+++ b/packages/adr-review/tests/test_filter.py
@@ -1,0 +1,24 @@
+from adr_review.cli import is_adr_file, label_for
+
+
+def test_should_match_adr_paths():
+    assert is_adr_file("docs/adr/ADR-208-foo.md")
+    assert is_adr_file("adr/ADR-001.md")
+    assert is_adr_file("some/nested/ADR-042-bar.md")
+    assert is_adr_file("concepts/adr-actions/note.md")
+
+
+def test_should_reject_non_adr_paths():
+    assert not is_adr_file("README.md")
+    assert not is_adr_file("docs/guides/setup.md")
+    assert not is_adr_file("concepts/adr-actions/install.sh")
+    assert not is_adr_file("src/app.py")
+
+
+def test_should_map_score_to_label():
+    assert label_for(9) == "adr-review-passed"
+    assert label_for(7) == "adr-review-passed"
+    assert label_for(6) == "adr-review-concerns"
+    assert label_for(5) == "adr-review-concerns"
+    assert label_for(4) == "adr-review-failed"
+    assert label_for(1) == "adr-review-failed"


### PR DESCRIPTION
Schließt die Lücke: `.github/workflows/adr-review.yml` erwartet `packages/adr-review` — existierte nie, der Guard überspringt nur. Dieses Paket macht `AI Review` real lauffähig.

**Verhalten:** geänderte ADR-Dateien → Claude-Review (MADR/Advocatus-Diabolus, System-Prompt ge-cached) → **ein** upsertender PR-Kommentar + Score-Label (passed/concerns/failed). **Informativ, nicht blockierend** (Default Exit 0; `--fail-under N` optional) — bewusst kein Enforcement-Gate (ADR-199-Lehre). Fehlt Secret/ADR-Datei → sauberer Exit 0 (kein false-rot).

**Validiert:** pip-install + Entrypoint + 3 Tests grün + Skip-Verhalten.

**Governance:** kein ADR — internes CI-Tool, ein Repo, kein Public-Surface, folgt erwartetem Muster → CHANGELOG-Eintrag + diese PR-Beschreibung (Policy-konform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)