### PR TITLE
fix(adr-review): Default-Modelle vom deprecating qwen-3-235b weg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   Schwelle (`ADR_REVIEW_ESCALATE_BELOW`, default 6). Kommentar nennt Modell +
   Grund. Schließt die Frontier-Lücke bewusst **nicht** (README-Disclaimer).
   Reine Konfig-/Routing-Ergänzung — kein ADR (internes CI-Tool, Muster-Folge).
+- `adr-review`: Default-Modelle umgestellt — `ADR_REVIEW_MODEL`
+  `cerebras/qwen-3-235b…` → `groq/llama-3.3-70b-versatile` (Cerebras-EOL des
+  qwen-Modells 2026-05-27), `ADR_REVIEW_FALLBACK` → `cerebras/llama3.1-8b`
+  (Cross-Provider-Failover, Policy-Tier-1b). Deckt sich mit ADR-208-Resolver
+  (`iil/adr-review`). Kein ADR (Daten-/Default-Fix, Muster-Folge).
 
 ---
 

--- a/packages/adr-review/README.md
+++ b/packages/adr-review/README.md
@@ -24,8 +24,8 @@ optional rot unter Score N.
 | `GITHUB_TOKEN` | ja | — |
 | `CEREBRAS_API_KEY` | eine LLM-Quelle nötig | — |
 | `GROQ_API_KEY` | (für Fallback) | — |
-| `ADR_REVIEW_MODEL` | nein | `cerebras/qwen-3-235b-a22b-instruct-2507` |
-| `ADR_REVIEW_FALLBACK` | nein | `groq/llama-3.3-70b-versatile` |
+| `ADR_REVIEW_MODEL` | nein | `groq/llama-3.3-70b-versatile` |
+| `ADR_REVIEW_FALLBACK` | nein | `cerebras/llama3.1-8b` |
 | `ADR_REVIEW_DEEP_MODEL` | nein | `cerebras/zai-glm-4.7` |
 | `ADR_REVIEW_ESCALATE_BELOW` | nein | `6` |
 | `ADR_REVIEW_DEEP_LABEL` | nein | `adr-deep-review` |

--- a/packages/adr-review/adr_review/cli.py
+++ b/packages/adr-review/adr_review/cli.py
@@ -11,8 +11,8 @@ Env:
   GITHUB_TOKEN        (required) — PR read + comment/label write
   CEREBRAS_API_KEY    — for cerebras/* models   (one LLM key required)
   GROQ_API_KEY        — for groq/* models       (used for fallback)
-  ADR_REVIEW_MODEL          (optional) default 'cerebras/qwen-3-235b-a22b-instruct-2507'
-  ADR_REVIEW_FALLBACK       (optional) default 'groq/llama-3.3-70b-versatile'
+  ADR_REVIEW_MODEL          (optional) default 'groq/llama-3.3-70b-versatile'
+  ADR_REVIEW_FALLBACK       (optional) default 'cerebras/llama3.1-8b'
   ADR_REVIEW_DEEP_MODEL     (optional) default 'cerebras/zai-glm-4.7' (Eskalation)
   ADR_REVIEW_ESCALATE_BELOW (optional) default 6  (Score-Schwelle)
   ADR_REVIEW_DEEP_LABEL     (optional) default 'adr-deep-review'
@@ -38,9 +38,11 @@ MARKER = "<!-- adr-review -->"
 
 # Tier-1a (policy: user-visible prose), Flatrate Cerebras/Groq — kein Anthropic.
 PRIMARY = os.environ.get("ADR_REVIEW_MODEL",
-                         "cerebras/qwen-3-235b-a22b-instruct-2507")
+                         "groq/llama-3.3-70b-versatile")
+# Cross-Provider-Failover (Policy): Primary groq -> Fallback cerebras.
+# Beide nicht deprecating; löst qwen-3-235b ab (Cerebras-EOL 2026-05-27).
 FALLBACK = os.environ.get("ADR_REVIEW_FALLBACK",
-                          "groq/llama-3.3-70b-versatile").strip()
+                          "cerebras/llama3.1-8b").strip()
 # Eskalations-Modell (stärker, weiter Flatrate, KEIN Anthropic).
 DEEP_MODEL = os.environ.get("ADR_REVIEW_DEEP_MODEL",
                             "cerebras/zai-glm-4.7").strip()


### PR DESCRIPTION
Schließt den Cross-Consumer-Caveat aus mcp-hub #55. Die adr-review-CLI trug ihren *eigenen* hartcodierten Default `cerebras/qwen-3-235b…` — Cerebras schaltet das Modell **2026-05-27** ab.

- `ADR_REVIEW_MODEL` → `groq/llama-3.3-70b-versatile` (Policy-kanonischer Tier-1a, nicht deprecating; deckt sich mit ADR-208-Resolver `iil/adr-review`).
- `ADR_REVIEW_FALLBACK` → `cerebras/llama3.1-8b` (Cross-Provider-Failover groq→cerebras, Policy-Tier-1b; vermeidet primary==fallback).
- `ADR_REVIEW_DEEP_MODEL` unverändert (`cerebras/zai-glm-4.7`, nicht deprecating).

Docstring/README/CHANGELOG aktualisiert, 7 Tests grün. Kein neues ADR (Default-/Daten-Fix, Muster-Folge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
