### PR TITLE
fix(ci): add pull-requests: read permission to gitleaks secrets-scan job

### DIFF
--- a/.github/workflows/_ci-python.yml
+++ b/.github/workflows/_ci-python.yml
@@ -122,6 +122,9 @@ jobs:
     name: "Secret Detection (gitleaks)"
     runs-on: ${{ inputs.runs_on }}
     continue-on-error: true
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Isolate TMPDIR per run (self-hosted race fix)
         run: |


### PR DESCRIPTION
## Root Cause

`gitleaks-action@v2` in PR-scan mode calls `GET /repos/{owner}/{repo}/pulls/{PR}/commits` via the GitHub API. This requires `pull-requests: read` in the GITHUB_TOKEN.

The `secrets-scan` job had no `permissions:` block, so it inherited the caller's restricted token (`contents: read` only) → HTTP 403 on every PR across all consumer repos.

## Fix

Add `permissions: pull-requests: read` to the `secrets-scan` job. Consumer repos must also grant this permission in their calling workflows (separate PRs: dev-hub, bfagent, weltenhub already updated on their PR branches).

## Scope

Cross-repo: affected dev-hub, bfagent, weltenhub (and all future consumers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)