### PR TITLE
feat(policies): vendor org-wide policy files (SSoT → platform) — Phase 2a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [2026.05.18] — 2026-05-18
+
+### Added
+- `policies/`: Org-weite Policy-Dateien (`llm-routing`, `session-routing`,
+  `adr-threshold`, `platform-agents`, `claude-skills`, `orchestrator` + README)
+  von der unversionierten `~/.claude/policies/` hierher vendored — **SSoT jetzt
+  versioniert**. Lokale Anbindung via Symlink in den pinned platform-Worktree
+  (Muster wie `~/.claude/commands`→`platform-workflows`); `inject_policies.py`
+  + `claude-policy` lesen den Pfad unverändert. Phase 2a von dev-hub#51 —
+  CI-Auto-Sync nach Orchestrator-Memory folgt als Phase 2b (eigenes ADR).
+  Kein ADR für 2a (Datei-Vendoring, folgt etabliertem Muster — `adr-threshold`).
+
+---
+
 ## [2026.05.17] — 2026-05-17
 
 ### Changed

--- a/policies/README.md
+++ b/policies/README.md
@@ -1,0 +1,56 @@
+# Org-Wide Policies
+
+These files codify cross-repo defaults for the Achim Dehnert / iil.gmbh org
+landscape (achimdehnert, ttz-lif, meiki-lra). They are loaded by Claude Code
+on every session via `~/.claude/CLAUDE.md`.
+
+**SSoT = this directory** (`platform/policies/`, versioned). `~/.claude/policies/`
+is a symlink into a pinned platform worktree (`~/github/platform-pinned/policies/`)
+— same pattern as `~/.claude/commands` → `platform-workflows`. The
+`inject_policies.py` hook and `claude-policy` CLI read that path unchanged.
+
+## Files
+
+| Policy | What it answers |
+|---|---|
+| `llm-routing.md` | Which LLM provider/model for a given task? (Groq/Cerebras first) |
+| `session-routing.md` | Which Claude Code session model? (tier-discipline) |
+| `adr-threshold.md` | Does this work require an ADR? |
+| `platform-agents.md` | Where does a new cross-cutting agent live? (dev-hub) |
+| `claude-skills.md` | When to build a CC slash-command skill, and how |
+| `orchestrator.md` | When to query orchestrator MCP, and how it relates to these files |
+
+## Override pattern (per-repo)
+
+If a repo needs to deviate from an org policy, add a `## Policy Overrides`
+section to that repo's `CLAUDE.md`:
+
+```markdown
+## Policy Overrides
+
+- **llm-routing**: only local Ollama (`mistral:7b-instruct`) — data must not
+  leave the perimeter. Reason: ttz-lif compliance. Approved 2026-05-11.
+- **platform-agents**: use this repo's `apps/` instead of dev-hub —
+  reason: …
+```
+
+Repo overrides take precedence over org defaults.
+
+## Updating a policy
+
+1. Edit the relevant `<topic>.md` file here, in a **platform PR**
+2. Bump the `## Changelog` section at the bottom of that file
+3. Merge → the pinned worktree picks it up on next refresh; CI mirrors the
+   change to orchestrator-side memory (Phase 2b — see dev-hub#51). Until 2b
+   lands: run `claude-policy push` from a session with prod SSH access.
+4. Communicate the change to the team (e.g. dev-hub TechDocs page)
+
+## Conflict resolution
+
+Highest precedence wins (top of list):
+
+1. `<repo>/CLAUDE.md` `## Policy Overrides:` (git-tracked)
+2. Orchestrator MCP memory (live, where loaded)
+3. `platform/policies/<topic>.md` (versioned file-based default)
+
+`claude-policy pull` can detect drift between 2 and 3.

--- a/policies/adr-threshold.md
+++ b/policies/adr-threshold.md
@@ -1,0 +1,41 @@
+# Policy: ADR Threshold
+
+**Trigger words:** ADR, architecture decision, adr-record, adr nötig
+
+## Rule
+
+Do **not** propose writing an ADR for work that is purely an *addition*
+following an existing pattern. ADRs are reserved for genuine architecture
+decisions.
+
+## ADR is required when *any* of these is true
+
+- New external dependency or service boundary (new DB, new API, new MCP, new SaaS)
+- Reverses or replaces an existing architectural decision
+- Cross-cutting impact across multiple apps/teams/repos
+- Non-trivial trade-off worth recording for a future challenger
+- Anything that touches data sovereignty, security perimeter, or licensing
+
+## ADR is NOT required when
+
+- A new app/feature **follows an existing pattern** (e.g. "another Platform
+  Agent in dev-hub like Drift Detector / TechDocs")
+- Reversible by removing one app or one Celery task
+- Local to one repo with no public surface
+- Dependency bump within the same major version
+- Code-style or refactor work
+
+For these → **CHANGELOG entry + PR description** is enough.
+
+## Where ADRs live
+
+`~/github/platform/docs/adr/ADR-NNN-*.md`. Get next number:
+
+```bash
+ls ~/github/platform/docs/adr/ | sort | tail -1
+```
+
+## Changelog
+
+- 2026-05-11: Initial. Promoted after user feedback ("Ergänzung keine
+  Architektur-Entscheidung") on repo_health agent.

--- a/policies/claude-skills.md
+++ b/policies/claude-skills.md
@@ -1,0 +1,115 @@
+# Policy: Claude-Code Skills (Slash-Commands)
+
+**Trigger words:** skill, slash command, /command, workflow, cc-skill
+
+## Was ist eine CC-Skill?
+
+Markdown-Workflow mit YAML-Frontmatter, im Verzeichnis `platform-workflows/.windsurf/workflows/`. Verfügbar als Slash-Command in **beiden** Tools:
+- Claude Code via Symlink `~/.claude/commands/` → `~/github/platform-workflows/.windsurf/workflows/`
+- Windsurf Cascade nativ
+
+Abgrenzung zu anderen Konzepten:
+- **Django Platform-Agents** (`dev-hub/apps/<agent>/`, siehe `platform-agents.md`) — Headless, scheduled, lange Laufzeit
+- **CC-Sub-Agents** (`~/.claude/agents/`) — Claude-only, isolierter Context, kein Cross-Tool
+
+## Wann eine neue Skill bauen?
+
+CC-Skill ist die **Default-Antwort** bei:
+- Wiederkehrender Workflow >3× pro Woche manuell ausgeführt
+- Kombination aus 2+ MCP-Calls + Output-Aggregation
+- Bedarf für Cross-Tool-Verfügbarkeit (CC + Windsurf)
+- Read-only-Analyse oder Reporting
+
+**Nicht** als Skill:
+- Single-MCP-Wrapper (direkter MCP-Call genügt)
+- Einmaliges Skript (Bash-Snippet in PR-Beschreibung)
+- Anything-Write ohne klare Gates (Skill darf write, aber muss Gate explizit machen)
+
+## Pflicht-Strukturelemente
+
+```markdown
+---
+description: <1-line, action-orientiert, ≤120 Zeichen>
+mode: read-only | write
+---
+
+# /skill-name — <Tagline>
+
+> **Wann:** ...
+> **Wann NICHT:** Verweis auf abgrenzende Skills
+
+## Verwendung
+\`\`\`
+/skill-name <args>
+\`\`\`
+
+## Step 0: Repo-Kontext aus project-facts.md
+... (NIEMALS hardcoden)
+
+## Step N: <Schritte>
+
+## Output-Format
+\`\`\`
+<Schema des Outputs>
+\`\`\`
+
+## Anti-Patterns
+- ❌ ...
+
+## Changelog
+- YYYY-MM-DD: ...
+```
+
+## MCP-Signaturen — Pflicht-Verifikation
+
+**Vor Commit:** Jeden im Skill genannten MCP-Call mit dem aktuellen Schema verifizieren. Wrong-Signature-Bugs sind häufig und CI-relevant.
+
+Verifikations-Optionen:
+1. `ToolSearch` mit `select:<mcp-tool-name>` und Argument-Schema gegen Skill abgleichen
+2. Dry-Run mit echtem MCP-Call im Dogfood-Test
+3. (Future) CI-Smoke-Test gegen Schema-Snapshot
+
+## Read-Only Default
+
+Skills sind by-default **read-only**. Write-Modus erfordert:
+- Explizites `mode: write` im Frontmatter
+- Anti-Pattern-Sektion mit konkreten "darf NICHT" Aufzählungen
+- Idempotenz-Garantie ODER explizites "non-idempotent — confirm before re-run"
+
+## Hardcoding-Verbot
+
+**NIEMALS** in Skills:
+- Repo-Pfade (`~/github/platform/docs/adr/`)
+- MCP-Prefixes (`mcp2_`)
+- Owner/Org-Namen (`achimdehnert`)
+- Server-IPs
+
+Quelle: **project-facts.md** (always_on rule im Ziel-Repo). Skill liest Werte zur Laufzeit aus.
+
+## 🌀-Memory-Zitate
+
+Skills die auf Drift-Lehren verweisen sollen **echte Memory-IDs** zitieren, nicht erfundene Namespaces. Beispiel:
+- ✅ `agent_memory_search(query="ADR-141 vs 179 canonical numbers")` (semantic)
+- ❌ `agent_memory_search(query="drift:adr-canonical-numbers")` (kein realer Namespace)
+
+Drift-Lehren leben in lokaler CC-Memory bis sie via `agent_memory_upsert` in Orchestrator promoted werden. Skill darf beide Quellen ansprechen, aber muss den **Discovery-Pfad** beschreiben (CC-Memory zuerst, Fallback Orchestrator).
+
+## Pflicht-Review-Gate
+
+PR der eine neue Skill enthält oder eine bestehende ändert:
+1. Mindestens **1 Dogfood-Test** im PR-Body dokumentiert (Tool-Output zitiert)
+2. MCP-Signaturen verifiziert (siehe oben)
+3. Anti-Patterns-Sektion vollständig
+4. Output-Format als Code-Block exemplifiziert
+5. CHANGELOG-Eintrag in der Skill-Datei
+
+## Verteilung
+
+`~/.claude/commands` Symlink ist **single-machine**. Cross-Machine-Sync für CC-Sessions auf Dev-Server/Prod:
+- Plan: zukünftig Plugin-basiertes Distribution (Backlog)
+- Aktuell: `git pull` in `~/github/platform-workflows` auf jeder Maschine
+
+## Changelog
+
+- 2026-05-15: Initial. Geschrieben nach Dogfood-Findings der ersten 2 CC-Skills (`/adr-curator`, `/adr-challenger`, PR #168). Schließt Policy-Lücke die `platform-agents.md` offen ließ.
+- 2026-05-15: Pushed to orchestrator memory (`entry_key: policy:claude-skills`).

--- a/policies/llm-routing.md
+++ b/policies/llm-routing.md
@@ -1,0 +1,120 @@
+# Policy: LLM Routing
+
+**Trigger words:** welches modell, which model, günstig, cheap, free, kosten,
+cost, llm, provider, haiku, opus, sonnet, groq, llama, cerebras, qwen,
+mistral, together, openai
+
+## Rule
+
+For routine background and summarization tasks, **default to a fast-inference
+provider (Cerebras / Groq)** before suggesting any frontier model from
+Anthropic / OpenAI. The user has paid accounts for Cerebras and Groq —
+free-tier rate limits are not the binding constraint, but **cost-per-token
+on these providers is roughly 1-2 orders of magnitude lower** than frontier
+models for equivalent quality on mechanical tasks.
+
+## Available providers (keys in `~/shared/secrets-inbox/`)
+
+| Provider | Key file | aifw prefix | Notes |
+|---|---|---|---|
+| **Cerebras** | `cerebras_api_key` | `cerebras/` | ~1000+ tok/s, paid tier available |
+| **Groq** | `groq_api_key` | `groq/` | ~500+ tok/s, paid tier available |
+| **Anthropic** | `anthropic_api_key` | `anthropic/` | Frontier reasoning + tool use |
+| **OpenAI** | `openai_api_key` | `openai/` | GPT-4o / o-series |
+| **Mistral** | `mistral_api_key` | `mistral/` | EU-hosted alternative |
+| **Together** | `together_api_key` | `together_ai/` | Long-tail open models |
+
+## Tier list
+
+| Tier | Default model | Use case |
+|---|---|---|
+| **1a** | `groq/llama-3.3-70b-versatile` *or* `cerebras/gpt-oss-120b` | Background jobs, summaries, classification, reports — prefer when output is user-visible prose |
+| **1b** | `cerebras/llama3.1-8b` *or* `groq/llama-3.1-8b-instant` | Same tier, when 8B is sufficient and you want lower spend |
+| **2** | `anthropic/claude-haiku-4-5` | If 1a/1b fail on instruction following or nuance |
+| **3** | `anthropic/claude-sonnet-4-6` | Code review, planning, multi-step reasoning |
+| **4** | `anthropic/claude-opus-4-7` | Only with explicit justification — agentic flows, complex synthesis |
+
+**Verified available** as of 2026-05-13 (via `GET /v1/models`):
+- Cerebras account: `gpt-oss-120b`, `zai-glm-4.7`, `llama3.1-8b`
+  (`qwen-3-235b-a22b-instruct-2507` **DEPRECATED 2026-05-27** — nicht mehr nutzen)
+  (no Llama-3.3-70b on this Cerebras account — use Groq for the 70B Llama instead)
+- Groq Llama family: `llama-3.1-8b-instant`, `llama-3.3-70b-versatile`,
+  `meta-llama/llama-4-scout-17b-16e-instruct`
+
+EU-/data-sovereignty workloads → `mistral/mistral-large-latest` instead of any
+US-hosted provider. For `ttz-lif` / `meiki-lra` repos see per-repo overrides.
+
+## Choosing between Cerebras and Groq (Tier 1)
+
+- **Cerebras**: ultra-fast on its hosted models; Llama family currently 8B only,
+  high-quality option is `gpt-oss-120b` (qwen-3-235b deprecated 2026-05-27)
+- **Groq**: broader Llama catalogue (incl. 70B), `llama-3.1-8b-instant` for cheap fast paths
+- **Round-robin / fallback**: configure both in aifw with one as `default_model`
+  and the other as `fallback_model` — automatic failover on rate-limit or 5xx
+
+## How to apply
+
+Before recommending an LLM target for a new `action_code`, present the tier
+list above. Default = Tier 1a. Skip a tier only with a stated reason.
+
+When seeding an aifw action code (single provider, Tier 1a on Groq):
+
+```python
+from aifw.models import Provider, Model, ActionType
+groq, _ = Provider.objects.get_or_create(
+    name="groq",
+    defaults={"api_key_env_var": "GROQ_API_KEY"},
+)
+m, _ = Model.objects.get_or_create(
+    provider=groq, name="llama-3.3-70b-versatile",
+    defaults={"display_name": "Groq Llama 3.3 70B Versatile"},
+)
+ActionType.objects.update_or_create(
+    code="<your_action_code>",
+    defaults={"default_model": m, "fallback_model": m},
+)
+```
+
+With Groq→Cerebras failover (70B → 8B fallback):
+
+```python
+cerebras, _ = Provider.objects.get_or_create(
+    name="cerebras", defaults={"api_key_env_var": "CEREBRAS_API_KEY"},
+)
+m_cb, _ = Model.objects.get_or_create(
+    provider=cerebras, name="llama3.1-8b",
+)
+ActionType.objects.update_or_create(
+    code="<your_action_code>",
+    defaults={"default_model": m, "fallback_model": m_cb},
+)
+```
+
+`CEREBRAS_API_KEY` / `GROQ_API_KEY` need to be in the host project's `.env`.
+Source values from `~/shared/secrets-inbox/cerebras_api_key` and
+`~/shared/secrets-inbox/groq_api_key` (never echo to stdout).
+
+Cerebras quickstart reference: https://inference-docs.cerebras.ai/quickstart
+
+## Per-repo override examples
+
+- **ttz-hub** (ttz-lif org): compliance requires no external LLM — only Ollama
+  local. Override in `ttz-hub/CLAUDE.md` `## Policy Overrides`.
+- **meiki-hub** (meiki-lra): citizen-data — same applies if PII touched.
+
+## Changelog
+
+- 2026-05-11: Initial. Promoted from meiki-hub local memory after user feedback
+  ("wieso nicht Groq free of cost?") during repo_health agent design.
+- 2026-05-11: Added Cerebras as Tier 1a peer to Groq, noted paid Groq access,
+  documented Cerebras→Groq failover pattern, listed all available provider
+  keys in `~/shared/secrets-inbox/`.
+- 2026-05-13: Reality-check via `/v1/models` — `cerebras/llama-3.3-70b` is
+  not on this account; Tier 1a defaults switched to `groq/llama-3.3-70b-versatile`
+  (or `cerebras/qwen-3-235b-a22b-instruct-2507`). Tier 1b Cerebras model ID
+  fixed to `cerebras/llama3.1-8b` (no dash). Seed examples updated.
+- 2026-05-17: `cerebras/qwen-3-235b-a22b-instruct-2507` von Cerebras zum
+  **2026-05-27 abgekündigt**. Tier-1a Cerebras-Slot → `cerebras/gpt-oss-120b`;
+  qwen aus „Verified available" entfernt. Konsumenten umgestellt: ADR-208
+  Resolver (mcp-hub #55), adr-review-CLI (platform #185), Orchestrator-Routing
+  (mcp-hub #56), aifw-Migration 0003 (dev-hub #48, **DB-Apply ausstehend**).

--- a/policies/orchestrator.md
+++ b/policies/orchestrator.md
@@ -1,0 +1,75 @@
+# Policy: Orchestrator MCP
+
+**Trigger words:** orchestrator, mcp, memory, routing, headless
+
+## What it is
+
+The orchestrator is an MCP server at `https://orchestrator.iil.pet/sse`
+hosted by `~/github/mcp-hub/orchestrator_mcp/`. It provides:
+
+- **Routing**: which LLM/model for a given action_code (DB-driven, via `aifw`)
+- **Memory**: cross-session shared state — current API is
+  `agent_memory_search/upsert/context` (pgvector + temporal decay, ADR-113).
+  The legacy `memory_get/set/list` key-value tools no longer exist.
+- **LLM-Calls**: dispatch via aifw with usage tracking
+- **Headless runs**: long-running Claude Code agents in containers
+
+Tool-prefix when loaded: `orchestrator__*`.
+
+## When to query it
+
+**Before** suggesting an org-specific default, check whether the orchestrator
+has a live policy that overrides the file-based default in
+`~/.claude/policies/`. Specifically: any `policy:*` or `convention:*` entry.
+
+Pseudocode:
+
+```
+if orchestrator MCP available:
+    hits = orchestrator__agent_memory_search(query="policy:<topic>")
+    if hits: use top hit
+    else: fall back to ~/.claude/policies/<topic>.md
+else:
+    use ~/.claude/policies/<topic>.md
+    explicitly tell user "orchestrator not loaded in this session"
+```
+
+## Where it is NOT loaded
+
+- Sessions started outside of dev-hub/bfagent/mcp-hub workspaces may not have
+  the MCP bound. Check tool list at session start.
+- Headless/CI runs always have it (that's its main consumer).
+- The `meiki-hub` workspace currently does **not** bind it (as of 2026-05-11).
+
+## Syncing files ↔ orchestrator
+
+`~/.claude/bin/claude-policy` (`push`/`pull`/`diff`/`list`) is the sync CLI
+and is **functional standalone** since 2026-05-17. Transport: SSH +
+`docker exec` against the prod container `mcp_hub_orchestrator_http`, which
+shares the Postgres backend with the MCP tools; it calls
+`orchestrator_mcp.memory.store.upsert/search` directly. Idempotent
+(content_hash dedup). `push` writes `entry_key=policy:<topic>`,
+`entry_type=decision`, tag `synced-from-file`.
+
+- Standalone: `claude-policy push` from any shell with SSH access to prod.
+- In a Claude session with `orchestrator__*`: set `CLAUDE_POLICY_STUB=1` and
+  Claude substitutes the stubs with native `agent_memory_upsert` calls.
+- Env overrides: `ORCH_PROD_HOST` / `ORCH_CONTAINER` / `ORCH_SSH_USER`.
+
+Versioning home of the CLI: `platform/tools/claude-policy/` (canonical,
+merged via platform#190; `~/.claude/bin/claude-policy` should symlink there).
+The legacy `memory_get/set/list` API it once stubbed no longer exists —
+irrelevant now, the CLI targets `agent_memory_*`/`store`. See dev-hub#51.
+
+## Changelog
+
+- 2026-05-11: Initial reference. Documented after session miss where I should
+  have queried orchestrator for LLM-routing default but didn't.
+- 2026-05-12: Updated to reflect current Memory API (`agent_memory_*`, ADR-113);
+  noted CLI/API mismatch. Pushed from `~/.claude/policies/orchestrator.md` to
+  orchestrator memory.
+- 2026-05-17: claude-policy rewritten stub→functional (SSH/docker-exec
+  transport, base64-inline, idempotent). "Known limitation" removed.
+- 2026-05-18: Versioning home corrected to `platform/tools/claude-policy/`
+  (merged platform#190; supersedes the briefly-recommended `mcp-hub/scripts/`
+  which collided with platform#186). Double-vendor reconciliation, dev-hub#51.

--- a/policies/platform-agents.md
+++ b/policies/platform-agents.md
@@ -1,0 +1,49 @@
+# Policy: Where do Platform Agents live?
+
+**Trigger words:** platform agent, wo soll, which hub, welcher hub, where
+should this live, host für, agent, drift, scribe, guardian
+
+## Rule
+
+Cross-cutting agents that scan, monitor, or report on the **platform itself**
+(not a business domain) live in **`dev-hub/apps/<agent_name>/`**.
+
+## Examples
+
+| Agent | Lives in | Why dev-hub |
+|---|---|---|
+| `agents_dashboard` | dev-hub | exists already, root of "Platform Agents" concept |
+| `adr_lifecycle` (ADR Scribe + Drift) | dev-hub | platform-wide ADR state |
+| `techdocs` | dev-hub | doc sync from 10 repos |
+| `health` | dev-hub | endpoint polling across hubs |
+| `repo_health` *(2026-05-11, new)* | dev-hub | git status across all repos |
+
+## Anti-pattern
+
+> "risk-hub already has aifw installed → host repo-health there"
+
+Wrong. Domain hubs (risk-hub for ARBSCHUTZ, weltenhub for storytelling,
+travel-beat for trips) host **business logic only**. Cross-cutting
+platform-aware code is in dev-hub or `platform` package.
+
+## Where dev-hub provides
+
+- `django-celery-beat` (scheduling) already configured
+- `aifw` available for LLM routing (add to deps + INSTALLED_APPS once)
+- `techdocs.DocSite/DocPage` available for report rendering
+- `apps/core` with TenantAwareModel, audit, outbox
+- Postgres + Redis infra in prod (devhub.iil.pet)
+
+## Decision flow
+
+```
+New cross-cutting feature?
+├── About the platform/codebase itself? → dev-hub
+├── About a business domain (Arbeitsschutz, Reisen, …)? → domain hub
+└── Shared library / convention? → platform package
+```
+
+## Changelog
+
+- 2026-05-11: Initial. Promoted after user feedback ("wieso nicht dev-hub —
+  das wäre eine logische Basis") on repo_health agent host choice.

--- a/policies/session-routing.md
+++ b/policies/session-routing.md
@@ -1,0 +1,73 @@
+# Policy: Claude Code Session Routing
+
+**Trigger words:** session, opus, sonnet, /fast, /model, session model,
+welcher modus, which mode, claude code modus
+
+## Rule
+
+Claude Code session-level model choice should follow the same tier-discipline
+as the action-level `llm-routing.md` policy. The current default — running
+every session on Opus 4.7 — is **Tier 4** in policy terms and meant for
+"agentic flows, complex synthesis, only with explicit justification".
+Most day-to-day work (lint cleanup, model-string sweeps, drift workflows,
+log inspections, deploy checks) is Tier 3 at most.
+
+Concrete spend evidence — 2026-05-13 in this repo's `llm_calls` table:
+
+| Date | Calls | Cost (USD) | Model |
+|---|---|---|---|
+| 2026-05-13 | 1554 | **$608** | claude-opus-4-7 |
+| 2026-05-12 | 2233 | **$969** | claude-opus-4-7 |
+
+At Sonnet pricing ($3/$15 vs Opus $15/$75) those two days would have been
+~$120 + ~$190 = ~$310 instead of $1577. The work product would be
+indistinguishable for the kinds of tasks that ran.
+
+## Tier map for Claude Code sessions
+
+| Task type | Recommended | Why |
+|---|---|---|
+| ADR drafting / architectural reasoning | **Opus 4.7** | Real Tier-4 work — synthesis across many ADRs and policies |
+| Multi-repo refactor with cross-file implications | **Opus 4.7** | Tier-4 reasoning load |
+| Code review of someone else's PR | **Sonnet 4.6** | Tier 3 — sufficient for review depth |
+| Single-PR implementation (bug fix, feature) | **Sonnet 4.6** | Tier 3 |
+| Lint cleanup / mass rename / mechanical edits | **Sonnet 4.6** or `/fast` | Tier 3 or Tier 2 |
+| Log inspection / DB queries / deploy babysitting | `/fast` (Opus 4.6) | Same model family, faster output |
+| Quick "what does this do" / status checks | `/fast` | Cache-friendly, low complexity |
+
+## How to apply
+
+- **At session start**: choose the appropriate model via `/model` based on the
+  intended work for that session. Do not start on Opus 4.7 and stay there by
+  default.
+- **Mid-session**: if the workload changes (e.g. finished the architectural
+  part, now doing mechanical follow-up edits), call `/model` to step down.
+- **`/fast` toggle**: stays on the Opus 4.X family but with faster output —
+  useful when you want Opus reasoning depth on a long context but reduced
+  per-turn latency. Same cost class as regular Opus.
+
+## What the assistant should do
+
+When the assistant notices a session running on Opus 4.7 doing predominantly
+Tier-3-or-below work, it should mention this once early in the session —
+not every turn — with a concrete recommendation. Example:
+
+> "This session is on Opus 4.7. The work I see queued is lint cleanup +
+> running a couple of deploys — Tier 3/2 in `llm-routing.md` terms. A `/model`
+> swap to Sonnet 4.6 would cut spend by ~5× without affecting outcome quality
+> on this kind of work. Want me to remind once or never?"
+
+Do not nag.
+
+## Per-repo / org overrides
+
+- ttz-lif / meiki-lra: same logic but choice is constrained to what's available
+  via Ollama-local — see the per-repo CLAUDE.md.
+- Sessions that run *over* CI (headless_runs, ultrareview) follow `llm-routing.md`
+  for the agent / action_code, not this policy.
+
+## Changelog
+
+- 2026-05-13: Initial. Promoted after observing $1577 / 5969 Opus calls in
+  24 hours of Claude Code session work that was almost entirely Tier-3 in
+  scope (PR drafting, lint cleanup, drift sweeps). See dev-hub#39.


### PR DESCRIPTION
**Phase 2a von dev-hub#51.** Schließt die zweite Hälfte des „unversioniert"-Befunds: nicht nur das `claude-policy`-Tool (platform#190, gemergt), sondern auch die **Policy-Dateien selbst** lagen nur lokal in `~/.claude/policies/`.

## Was

`policies/` mit den 6 Org-Policies + README aus der unversionierten `~/.claude/policies/` hierher vendored — **SSoT ist jetzt versioniert**.

| Datei | beantwortet |
|---|---|
| `llm-routing.md` | LLM-Provider/Modell-Wahl (Groq/Cerebras first) |
| `session-routing.md` | Claude-Code-Session-Modell (Tier-Disziplin) |
| `adr-threshold.md` | Braucht es ein ADR? |
| `platform-agents.md` | Wo lebt ein neuer Cross-Cutting-Agent? |
| `claude-skills.md` | Wann eine CC-Slash-Command-Skill bauen? |
| `orchestrator.md` | Wann Orchestrator-MCP abfragen |

## Lokale Anbindung (Post-Merge, **kein** Code-Change)

`~/.claude/policies/` → Symlink in den pinned platform-Worktree (`~/github/platform-pinned/policies/`) — exakt das Muster `~/.claude/commands`→`platform-workflows`. Verifiziert: `inject_policies.py` und `claude-policy` lesen `POLICIES_DIR` per `glob("*.md")` → ein Verzeichnis-Symlink funktioniert unverändert. `~/.claude/CLAUDE.md`-Pfade bleiben gültig.

> Der Hook lädt Policies in **jede** Session (hohe Blast-Radius) — daher Rewire bewusst erst **nach** Merge, nicht jetzt.

## README angepasst

War unvollständig (nur 4 von 6 Policies, alter lokaler Workflow). Jetzt: vollständige Tabelle + SSoT/Sourcing + „Updating a policy" via platform-PR.

## Scope / ADR

- **Kein ADR für 2a**: reines Datei-Vendoring, folgt etabliertem Muster (`adr-threshold`: „follows an existing pattern" → kein ADR).
- **Phase 2b** (CI-Auto-Sync `policies/**` → Orchestrator-Memory auf self-hosted Hetzner-Runner) = **eigener PR mit leichtgewichtigem ADR** — dort sitzt der echte Trade-off (Auto-Propagation bei jedem Merge). Bewusst nicht hier gebündelt.
- Branch vom **sauberen** `origin/main` (isolierter Worktree); 6 Policy-Dateien byte-identisch zur Live-Quelle (nur README bewusst editiert).

Refs dev-hub#51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)