### PR TITLE
feat(policies): auto-sync to orchestrator on merge (ADR-209) — Phase 2b, schließt dev-hub#51

### DIFF
--- a/.github/workflows/sync-policies-to-orchestrator.yml
+++ b/.github/workflows/sync-policies-to-orchestrator.yml
@@ -1,0 +1,46 @@
+name: Sync Policies to Orchestrator
+
+# ADR-209: on merge to main touching policies/**, mirror the org policy
+# files into the orchestrator pgvector memory (ADR-113) so headless/CI
+# agents see the approved change immediately. Idempotent (content_hash).
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "policies/**"
+  workflow_dispatch:
+
+jobs:
+  sync:
+    name: claude-policy push (local, idempotent)
+    # Prod-Server: orchestrator container is local → no SSH, no key.
+    runs-on: [self-hosted, prod]
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout platform
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.PROJECT_PAT }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Push org policies → orchestrator memory
+        env:
+          ORCH_LOCAL: "1"
+          CLAUDE_POLICY_DIR: ${{ github.workspace }}/policies
+        run: |
+          python3 tools/claude-policy/claude-policy push
+
+      - name: Verify convergence
+        env:
+          ORCH_LOCAL: "1"
+          CLAUDE_POLICY_DIR: ${{ github.workspace }}/policies
+        run: |
+          python3 tools/claude-policy/claude-policy diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   + `claude-policy` lesen den Pfad unverändert. Phase 2a von dev-hub#51 —
   CI-Auto-Sync nach Orchestrator-Memory folgt als Phase 2b (eigenes ADR).
   Kein ADR für 2a (Datei-Vendoring, folgt etabliertem Muster — `adr-threshold`).
+- **ADR-209** + `.github/workflows/sync-policies-to-orchestrator.yml`: Phase 2b
+  von dev-hub#51 — bei Merge auf `main` mit `policies/**` synct ein Workflow
+  auf dem `[self-hosted, prod]`-Runner die Policies via `claude-policy push`
+  automatisch in den Orchestrator-Memory (ADR-113). Idempotent (content_hash).
+  `tools/claude-policy`: zwei rückwärtskompatible Env-Vars — `ORCH_LOCAL=1`
+  (docker exec lokal, kein SSH/Key auf dem prod-Runner) und `CLAUDE_POLICY_DIR`
+  (Policy-Quelle = Checkout statt `~/.claude/policies`). Behebt die manuelle
+  Push-Drift (gemergte Policy ≠ was Agenten sehen) — letztes Stück dev-hub#51.
 
 ---
 

--- a/docs/adr/ADR-209-policy-auto-sync-on-merge.md
+++ b/docs/adr/ADR-209-policy-auto-sync-on-merge.md
@@ -1,0 +1,76 @@
+---
+status: accepted
+date: 2026-05-18
+decision-makers: [Achim Dehnert]
+implementation_status: in-progress
+related: [ADR-113, dev-hub#51, platform#190, platform#193]
+---
+
+# ADR-209: Org-Policy Auto-Sync to Orchestrator Memory on Merge
+
+## Status
+
+Accepted.
+
+## Context
+
+Org-wide policies live in `platform/policies/*.md` (SSoT, vendored in
+platform#193). Headless/CI agents do **not** read these files — they read the
+orchestrator pgvector memory (ADR-113) via
+`agent_memory_search(query="policy:<topic>")`. The bridge between the two is
+`tools/claude-policy/claude-policy push` (platform#190).
+
+Today that bridge is **manual**: a human runs `claude-policy push` from a
+session with prod access. Failure mode: a policy change is merged but nobody
+pushes it — agents keep acting on the stale policy until someone remembers.
+This is exactly the drift the whole dev-hub#51 thread set out to remove.
+
+## Decision
+
+A GitHub Action **auto-syncs on merge**:
+
+- `on: push` to `main`, `paths: ["policies/**"]` (+ `workflow_dispatch`).
+- `runs-on: [self-hosted, prod]` — the orchestrator container is local on
+  that host, so the sync uses **local `docker exec`, no SSH, no key**
+  (new `ORCH_LOCAL=1` mode in the CLI; `CLAUDE_POLICY_DIR` points at the
+  checked-out `policies/`).
+- Step = `claude-policy push`. Idempotent: `store.upsert` skips on unchanged
+  `content_hash`, so re-runs and no-op merges cost nothing.
+
+The merge-time **PR review remains the human gate**. The Action only
+propagates what was already approved into git.
+
+## Considered Options
+
+1. **Status quo (manual push)** — drift-prone; the recurring failure above.
+2. **Cron poll** — bounded drift window + still needs the same tool; no
+   advantage over push-triggered, just latency.
+3. **Push-triggered Action (chosen)** — immediate, idempotent, minimal.
+4. **Orchestrator pulls from git** — inverts ownership, new infra in the MCP
+   service; disproportionate for a 6-file mirror.
+
+## Consequences
+
+**Positive**
+
+- No policy drift between git SSoT and the memory agents consume.
+- Single tool (`claude-policy`) for manual *and* automated sync — the
+  `ORCH_LOCAL` / `CLAUDE_POLICY_DIR` additions are backward-compatible.
+
+**Negative / risk** (the trade-off this ADR exists to record)
+
+- An approved-but-wrong policy merge **auto-propagates to all agents**.
+  Mitigations: PR review is the gate; the orchestrator entry is *advisory*
+  while the file stays authoritative (per `policy:orchestrator`); rollback
+  is `git revert` → the Action re-runs and re-converges (idempotent).
+- Hard dependency on the `[self-hosted, prod]` runner being online. Failure
+  is **visible** in the Actions tab and **safe to re-run** (`workflow_dispatch`
+  or re-push); no silent partial state (`upsert` is per-file idempotent).
+
+## Scope
+
+No new external dependency, no new service boundary, reversible (delete the
+workflow). Lightweight per `policy:adr-threshold`, recorded only because it
+introduces an **automated cross-cutting write path** into shared agent memory
+— worth a future challenger's attention. The file-vendoring half (Phase 2a)
+deliberately shipped without an ADR (pure pattern-following, platform#193).

--- a/tools/claude-policy/README.md
+++ b/tools/claude-policy/README.md
@@ -33,7 +33,16 @@ Env-Overrides:
 | `ORCH_PROD_HOST` | `88.198.191.108` |
 | `ORCH_CONTAINER` | `mcp_hub_orchestrator_http` |
 | `ORCH_SSH_USER` | `root` |
+| `ORCH_LOCAL=1` | docker-Befehl auf *diesem* Host ausführen (kein ssh) — für den `[self-hosted, prod]`-CI-Runner, wo der Container lokal ist (ADR-209) |
+| `CLAUDE_POLICY_DIR` | Policy-Quellverzeichnis (default `~/.claude/policies`); CI setzt `$GITHUB_WORKSPACE/policies` |
 | `CLAUDE_POLICY_STUB=1` | altes Stub-Verhalten, für *In-Claude*-Sessions die die `_orch_*`-Stubs durch native `orchestrator__*`-Tool-Calls ersetzen |
+
+## CI-Auto-Sync (ADR-209)
+
+`.github/workflows/sync-policies-to-orchestrator.yml` ruft bei jedem Merge auf
+`main` der `policies/**` dieses Skript auf dem `[self-hosted, prod]`-Runner mit
+`ORCH_LOCAL=1 CLAUDE_POLICY_DIR=$GITHUB_WORKSPACE/policies` auf. Idempotent
+(content_hash), No-Op wenn unverändert.
 
 ## Verwendung
 

--- a/tools/claude-policy/claude-policy
+++ b/tools/claude-policy/claude-policy
@@ -23,6 +23,11 @@ Overridable via env:
     ORCH_PROD_HOST   (default 88.198.191.108)
     ORCH_CONTAINER   (default mcp_hub_orchestrator_http)
     ORCH_SSH_USER    (default root)
+    ORCH_LOCAL=1          — run the docker command on *this* host (no ssh).
+                            Set on the [self-hosted, prod] CI runner where
+                            the orchestrator container is local (ADR-209).
+    CLAUDE_POLICY_DIR     — policy source dir (default ~/.claude/policies).
+                            CI sets it to $GITHUB_WORKSPACE/policies.
     CLAUDE_POLICY_STUB=1  — restore the old stub behaviour, for running
                             *inside* a Claude session that substitutes the
                             stubs with native orchestrator__* MCP calls.
@@ -46,12 +51,20 @@ import subprocess
 import sys
 from pathlib import Path
 
-POLICIES_DIR = Path.home() / ".claude" / "policies"
+# Policy source dir. Default = local Claude config; CI overrides it to the
+# checked-out repo (`CLAUDE_POLICY_DIR=$GITHUB_WORKSPACE/policies`).
+POLICIES_DIR = Path(
+    os.environ.get("CLAUDE_POLICY_DIR")
+    or (Path.home() / ".claude" / "policies")
+)
 
 PROD_HOST = os.environ.get("ORCH_PROD_HOST", "88.198.191.108")
 CONTAINER = os.environ.get("ORCH_CONTAINER", "mcp_hub_orchestrator_http")
 SSH_USER = os.environ.get("ORCH_SSH_USER", "root")
 STUB_MODE = os.environ.get("CLAUDE_POLICY_STUB") == "1"
+# Run the docker command on *this* host (no ssh wrapper). Set on the
+# [self-hosted, prod] runner, where the orchestrator container is local.
+LOCAL_MODE = os.environ.get("ORCH_LOCAL") == "1"
 
 SSH_CONNECT_TIMEOUT = 20
 SSH_RUN_TIMEOUT = 90
@@ -84,25 +97,34 @@ class TransportError(RuntimeError):
 
 
 def _ssh(argv: list[str], *, input_bytes: bytes | None = None) -> bytes:
-    """Run `ssh <user>@<host> <argv...>`; return stdout. Raise
-    TransportError on SSH failure or non-zero exit."""
-    cmd = [
-        "ssh",
-        "-o", "BatchMode=yes",
-        "-o", f"ConnectTimeout={SSH_CONNECT_TIMEOUT}",
-        f"{SSH_USER}@{PROD_HOST}",
-        *argv,
-    ]
+    """Run `argv` against the orchestrator host; return stdout. Raise
+    TransportError on failure or non-zero exit.
+
+    Default: wrap in `ssh <user>@<host>`. With ORCH_LOCAL=1 (the
+    [self-hosted, prod] CI runner, where the container is local) run `argv`
+    directly — no ssh, no key needed."""
+    if LOCAL_MODE:
+        cmd = list(argv)
+        label = "local"
+    else:
+        cmd = [
+            "ssh",
+            "-o", "BatchMode=yes",
+            "-o", f"ConnectTimeout={SSH_CONNECT_TIMEOUT}",
+            f"{SSH_USER}@{PROD_HOST}",
+            *argv,
+        ]
+        label = "ssh"
     try:
         proc = subprocess.run(
             cmd, input=input_bytes, capture_output=True,
             timeout=SSH_RUN_TIMEOUT,
         )
     except (subprocess.TimeoutExpired, OSError) as exc:
-        raise TransportError(f"ssh failed: {exc}") from exc
+        raise TransportError(f"{label} failed: {exc}") from exc
     if proc.returncode != 0:
         err = proc.stderr.decode("utf-8", "replace").strip()
-        raise TransportError(f"ssh exit {proc.returncode}: {err or '(no stderr)'}")
+        raise TransportError(f"{label} exit {proc.returncode}: {err or '(no stderr)'}")
     return proc.stdout
 
 


### PR DESCRIPTION
**Letztes Stück von dev-hub#51.** Behebt die manuelle-Push-Drift: Policies sind SSoT in `platform/policies/` (2a, #193), aber Headless-/CI-Agenten lesen den Orchestrator-Memory (ADR-113). Bisher musste ein Mensch `claude-policy push` ausführen — gemergte Policy ≠ was Agenten sehen, bis jemand dran denkt.

## Inhalt

**`docs/adr/ADR-209-policy-auto-sync-on-merge.md`** (lightweight MADR)
Dokumentiert die Entscheidung **und den Trade-off**, dessentwegen das ADR überhaupt existiert: eine approved-aber-falsche Policy propagiert automatisch zu allen Agenten. Mitigation: PR-Review bleibt das menschliche Gate; Orchestrator-Eintrag ist *advisory* gegenüber der Datei-SSoT; Rollback = `git revert` → Workflow re-konvergiert (idempotent). 4 Optionen abgewogen.

**`.github/workflows/sync-policies-to-orchestrator.yml`**
`on: push main` + `paths: policies/**` (+ `workflow_dispatch`), `runs-on: [self-hosted, prod]` → `claude-policy push` + `diff`-Verify. Auf dem prod-Runner ist der Orchestrator-Container lokal → **kein SSH, kein Key**. Spiegelt das etablierte `sync-adrs-to-devhub.yml`-Muster.

**`tools/claude-policy/claude-policy`** — zwei **rückwärtskompatible** Env-Vars:
| Var | Zweck |
|---|---|
| `ORCH_LOCAL=1` | `docker exec` auf *diesem* Host statt `ssh user@prod docker exec` — für den prod-Runner |
| `CLAUDE_POLICY_DIR` | Policy-Quelle = Checkout (`$GITHUB_WORKSPACE/policies`) statt `~/.claude/policies` |

## Verifiziert (lokal)

```
T1  CLAUDE_POLICY_DIR=…/policies  → diff: 0 policies differ (exit 0)   # Override + SSH-Default intakt
T2  (kein env)                    → default ~/.claude/policies          # rückwärtskompatibel
T3  ORCH_LOCAL=1                  → 'local exit 1: No such container'   # beweist no-ssh lokalen Pfad
py_compile OK · yaml OK
```

> Der Workflow selbst läuft erst beim ersten Merge / `workflow_dispatch` auf dem prod-Runner (E2E dort nicht vorab simulierbar). Die CLI-Pfade sind verifiziert; das Workflow-Muster ist 1:1 von `sync-adrs-to-devhub.yml` übernommen. Empfehlung: nach Merge einmal `workflow_dispatch` triggern + Actions-Log prüfen.

## Scope

Keine neue externe Dependency, reversibel (Workflow löschen). Lightweight-ADR per `policy:adr-threshold` (nur wegen des automatisierten Cross-Cutting-Write-Pfads dokumentiert). Branch vom sauberen `origin/main` (isolierter Worktree).

Schließt dev-hub#51 (Phase 1 + 2a + 2b komplett). Refs ADR-113, platform#190, platform#193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)