### PR TITLE
fix(ci): run migrate instead of migrate --check on fresh postgres DB

### DIFF
--- a/.github/workflows/_ci-python.yml
+++ b/.github/workflows/_ci-python.yml
@@ -304,17 +304,11 @@ jobs:
           POSTGRES_HOST: localhost
         run: |
           set -euo pipefail
-          DB_ENGINE=$(python -c "from django.conf import settings; print(settings.DATABASES['default']['ENGINE'])" 2>/dev/null || echo "unknown")
-          if echo "$DB_ENGINE" | grep -q "sqlite"; then
-            echo "OK: SQLite detected — running migrate to create test DB schema"
-            python manage.py migrate --run-syncdb 2>&1 || echo "migrate completed (warnings above are non-fatal)"
-          else
-            python manage.py migrate --check 2>&1 && echo "OK: Migration graph consistent" || {
-              echo "FAIL: Migration graph inconsistent — pending or broken migrations detected!"
-              python manage.py showmigrations 2>&1 | grep -E '^\s+\[ \]' || true
-              exit 1
-            }
-          fi
+          python manage.py migrate 2>&1 && echo "OK: Migration graph consistent — all migrations applied" || {
+            echo "FAIL: Migration graph inconsistent — broken or conflicting migrations detected!"
+            python manage.py showmigrations 2>&1 | grep -E '^\s+\[ \]' || true
+            exit 1
+          }
 
       - name: AppConfig Label Check
         working-directory: ${{ inputs.src_dir }}

--- a/.github/workflows/_ci-python.yml
+++ b/.github/workflows/_ci-python.yml
@@ -209,6 +209,20 @@ jobs:
     name: "Unit Tests"
     runs-on: ${{ inputs.runs_on }}
     if: ${{ !inputs.skip_tests }}
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: test_user
+          POSTGRES_PASSWORD: test_pass
+          POSTGRES_DB: test_db
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python
@@ -227,7 +241,7 @@ jobs:
         env:
           DJANGO_SETTINGS_MODULE: ${{ inputs.django_settings_module }}
           SECRET_KEY: test-secret-key-for-ci
-          USE_POSTGRES: "0"
+          POSTGRES_HOST: localhost
         run: |
           WORKERS=${{ inputs.pytest_workers }}
           if [ "$WORKERS" = "1" ] || [ "$WORKERS" = "0" ]; then
@@ -255,6 +269,20 @@ jobs:
     runs-on: ${{ inputs.runs_on }}
     if: ${{ !inputs.skip_tests }}
     continue-on-error: true
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: test_user
+          POSTGRES_PASSWORD: test_pass
+          POSTGRES_DB: test_db
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python
@@ -273,7 +301,7 @@ jobs:
         env:
           DJANGO_SETTINGS_MODULE: ${{ inputs.django_settings_module }}
           SECRET_KEY: test-secret-key-for-ci
-          USE_POSTGRES: "0"
+          POSTGRES_HOST: localhost
         run: |
           set -euo pipefail
           DB_ENGINE=$(python -c "from django.conf import settings; print(settings.DATABASES['default']['ENGINE'])" 2>/dev/null || echo "unknown")
@@ -293,7 +321,7 @@ jobs:
         env:
           DJANGO_SETTINGS_MODULE: ${{ inputs.django_settings_module }}
           SECRET_KEY: test-secret-key-for-ci
-          USE_POSTGRES: "0"
+          POSTGRES_HOST: localhost
         run: |
           set -euo pipefail
           python manage.py check --deploy --fail-level ERROR 2>&1 || {
@@ -307,7 +335,7 @@ jobs:
         env:
           DJANGO_SETTINGS_MODULE: ${{ inputs.django_settings_module }}
           SECRET_KEY: test-secret-key-for-ci
-          USE_POSTGRES: "0"
+          POSTGRES_HOST: localhost
           REDIS_URL: redis://localhost:6379/0
         run: |
           WORKERS=${{ inputs.pytest_workers }}


### PR DESCRIPTION
## Summary

Follow-up to #196: `migrate --check` always exits non-zero on a fresh CI postgres container because ALL migrations are "pending" — none have ever been applied to an empty database. This caused the Migration Graph Check step to fail systematically.

**Fix**: Replace `migrate --check` with plain `migrate`, which:
1. Applies all migrations to the fresh postgres container
2. Fails with a clear error if the migration graph has broken or conflicting migrations  
3. Leaves the DB in a migrated state, ready for integration tests in the next step

Also simplifies the step by removing the SQLite/PostgreSQL branch (both cases now just run `migrate`).

## Test plan

- [ ] weltenhub PR #9 integration test "Migration Graph Check" passes with green postgres service

🤖 Generated with [Claude Code](https://claude.com/claude-code)