### PR TITLE
chore(ports): risk-hub staging 8090 → 8099 (Realität angleichen, fixt 301-Loop)

### DIFF
--- a/infra/ports.yaml
+++ b/infra/ports.yaml
@@ -186,7 +186,12 @@ services:
 
   risk-hub:
     prod: 8090
-    staging: 8090
+    # Staging-Host (88.99.38.75) bindet risk_hub_staging_web real auf
+    # 127.0.0.1:8099 (docker-compose.staging.yml) — bewiesen frei &
+    # erfolgreich gebunden. ports.yaml spiegelt jetzt die Realität,
+    # damit nginx_gen.py einen korrekten proxy_pass erzeugt (vorher
+    # 8090 → ins Leere → 301-Loop auf staging.schutztat.de).
+    staging: 8099
     dev: 8090
     container_name: risk_hub_web
     domain_prod: schutztat.de


### PR DESCRIPTION
> **Draft — bewusst nicht zum Merge.** Wartet auf Entscheidung/Host-Port-Check.

## Problem
`https://staging.schutztat.de/` läuft in einen **301-Redirect-Loop auf sich selbst**. Root-Cause ist **kein App-Bug** (Django hat kein `SECURE_SSL_REDIRECT`), sondern ein Port-Drift:

- `docker-compose.staging.yml` bindet `risk_hub_staging_web` real auf `127.0.0.1:8099:8000` (bewiesen frei, erfolgreich gebunden, Staging-Deploy grün, internes `:8099/livez/` = 200).
- `infra/ports.yaml` führte `risk-hub.staging: 8090`.
- `nginx_gen.py` baut den Vhost aus ports.yaml → `proxy_pass http://127.0.0.1:8090` zeigt ins Leere → kein funktionierender `:443`-Vhost für `staging.schutztat.de` → Fallback/Catch-all `return 301 https://$host$request_uri;` → Endlos-Loop.

## Fix (niedrigstes Risiko)
ports.yaml an die **laufende Realität** angleichen (`staging: 8099`) statt den Host-Port auf 88.99.38.75 zu reshufflen (8090-Freiheit dort nicht verifizierbar — SSH gesperrt; 8099 ist nachweislich frei & gebunden).

## Nach Merge erforderlich (Host, SSH)
```
python infra/scripts/nginx_gen.py --staging-only   # auf 88.99.38.75
nginx -t && nginx -s reload
```
Hängt mit ADR-198 zusammen (2-Label-Wildcard / ACM-Cert schutztat.de, dns_staging_sync) — Cert muss `staging.schutztat.de` decken.

## Verifikation
Nach nginx-reload: `curl -skL https://staging.schutztat.de/livez/` → 200 (statt 301-Loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)