### PR TITLE
DRAFT docs(registry): weltenhub staging OIDC (ADR-210 R6, #221)

### DIFF
--- a/registry/repos.yaml
+++ b/registry/repos.yaml
@@ -118,6 +118,12 @@ domains:
         dockerfile: Dockerfile
         compose: docker-compose.prod.yml
         coverage_threshold: 80
+        # ADR-210 R6 SSoT — staging OIDC (only evidence-backed field; DNS
+        # staging-weltenhub.iil.pet verified resolving, Authentik provider
+        # aligned 2026-05-19). prod_* intentionally omitted (no evidence).
+        oidc:
+          staging_app_slug: weltenhub-staging
+          staging_redirect: https://staging-weltenhub.iil.pet/oidc/callback/
 
       - name: travel-beat
         repo: travel-beat


### PR DESCRIPTION
Records the now-true staging OIDC mapping for weltenhub per ratified ADR-210 R6 (registry=SSoT).

- DNS `staging-weltenhub.iil.pet` verified resolving (188.114.96.3)
- Authentik provider `weltenhub-staging` redirect aligned 2026-05-19 (was `welten-staging.iil.pet` → NXDOMAIN)
- Only evidence-backed `oidc.staging_*` added; no fabricated staging infra (port/host/path) — none verifiable

DRAFT, no auto-merge. Part of #221 closeout. billing/coach/wedding-hub deliberately untouched (no staging DNS in any form → orphan, owner cleanup decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)