### PR TITLE
ADR-211 Rev 9 (Wahl B) + SF1 i2-Target-Existenz

### DIFF
--- a/docs/adr/ADR-211-klickdummy-benutzeranforderungen-entwicklungsprozess.md
+++ b/docs/adr/ADR-211-klickdummy-benutzeranforderungen-entwicklungsprozess.md
@@ -64,7 +64,7 @@ Drift-Memory (meiki-hub-Auto-Memory, `drift: true`) **und** Followup-Issue
 | # | Invariante | Erzwingung |
 |---|---|---|
 | **I1 Spec-first** | Maschinenlesbares, versioniertes Spec-Artefakt (YAML/JSON/strukturiertes Frontmatter); Markdown-Bullets zählen nicht. Klickdummy rendert es, ist nicht die Quelle. | `make -C <repo> klickdummy-i1` (Exit-Code), CI-verifiziert — keine Frontmatter-Behauptung |
-| **I2 Prod-Sicherheit** | Genau eine Klasse je Klickdummy, **explizit deklariert**: **Mock-Prototyp** (kein Backend; Systemgrenzen als Target-Mock) ODER **Demo-Render** (env-gegated; in Prod nicht erreichbar). „Keine Klasse deklariert" ist I2-Verstoß (kein vacuous pass). | repo-definierter Check `make -C <repo> klickdummy-i2`; Plattform prüft nur, **dass** er existiert und Exit 0 liefert (R3 — kein plattformweiter String-Grep) |
+| **I2 Prod-Sicherheit** | Genau eine Klasse je Klickdummy, **explizit deklariert**: **Mock-Prototyp** (kein Backend; Systemgrenzen als Target-Mock) ODER **Demo-Render** (env-gegated; in Prod nicht erreichbar). „Keine Klasse deklariert" ist I2-Verstoß (kein vacuous pass). **Kanonische Token (Rev 9):** `klickdummy_class: mock-prototyp` oder `klickdummy_class: demo-render` im Klickdummy-Spec/Manifest-Root (alternativ `class:` für neue Specs). Token bewusst gemischtsprachig — `mock-prototyp` (de) und `demo-render` (en, wegen `?demo=`-Konsistenz). | repo-definierter Check `make -C <repo> klickdummy-i2`; Plattform prüft nur, **dass** das Target existiert und Exit 0 liefert (R3 — kein plattformweiter String-Grep) |
 | **I3 Lebenszyklus** | **A ohne Zielsystem:** endet bei dok. Fachabteilungs-Review → ADR `accepted-frozen`/`superseded`, Spec eingefroren, Pfad `klickdummy/archive/`. **B Transition:** ab erstem Screen mit Impl-Route greift I3 je Screen. **C mit Zielsystem:** Parity-grün/Screen ⇒ statische Quelle weg. **Staging ist ausdrücklich erlaubter Doppelquell-Raum** (dort läuft der Parity-Vergleich); verbotene Grenze = **prod-Deploy** (Tag/Container-Push nach prod), nicht staging (R4). | `make -C <repo> klickdummy-i3`: assert für jeden Screen mit Impl-Route + grünem Parity + **prod-Release** ⇒ statische Quelle abwesend |
 | **I4 Namensraum** | Repo-Klickdummy-ADR mit reserviertem Titel-Präfix; Cross-Repo-Refs **nur** `repo:ADR-NNN` (inkl. des `conforms_to:`-Feldes → `conforms_to: platform:ADR-211`). | `platform/scripts/checks/adr_cross_repo_refs.sh` |
 
@@ -173,6 +173,7 @@ Drei Cascade-Adversarial-Pässe + Schema-/YAML-Härtung:
 - **Rev 6** — C1-Geltungsbereich präzisiert (nur registry-Repos); `conforms_to` I4-qualifiziert; SF1-Regex + SF5
 - **Rev 7** — C6 auf Script `klickdummy_policy_sync.sh` umgestellt; SF6
 - **Rev 8** — Frontmatter schema-konform: `review_history`/`acceptance_trigger` aus Frontmatter in den Body verschoben (iil-adrfw `validate` lehnt Additional Properties ab; vorher zudem YAML-ScannerError durch `date:`-Mapping-Fehlinterpretation)
+- **Rev 9** — Wahl-B kanonisiert: `klickdummy_class` lebt im Klickdummy-Spec/Manifest-Root (kanonische Token `mock-prototyp` / `demo-render`); SF1 prüft zusätzlich Existenz des `make klickdummy-i2`-Targets (anti-vacuous-pass plattformseitig verstärkt). Auslöser: meiki-hub-WIP hat klickdummy_class bereits in `module-manifest.json` umgesetzt + 4 generische `scripts/klickdummy/check_iN.py`-Skripte gebaut
 
 ## Bezug
 

--- a/scripts/checks/klickdummy_registry.sh
+++ b/scripts/checks/klickdummy_registry.sh
@@ -37,32 +37,39 @@ PY
 ) || { echo "FATAL: registry/repos.yaml nicht parsebar"; exit 2; }
 
 fail=0 warn=0 checked=0 conform=0
-printf '%-22s %-7s %-40s %s\n' "REPO" "KD?" "KONFORMES ADR (conforms_to: ADR-211)" "STATUS"
-printf '%s\n' "--------------------------------------------------------------------------------------------"
+printf '%-22s %-5s %-34s %-10s %s\n' "REPO" "KD?" "ADR (conforms_to: ADR-211)" "i2-TARGET" "STATUS"
+printf '%s\n' "----------------------------------------------------------------------------------------------"
 
 for repo in "${REPOS[@]}"; do
   dir="$GITHUB_DIR/$repo"
   if [[ ! -d "$dir" ]]; then
-    printf '%-22s %-7s %-40s %s\n' "$repo" "-" "-" "WARN (nicht ausgecheckt)"
+    printf '%-22s %-5s %-34s %-10s %s\n' "$repo" "-" "-" "-" "WARN (nicht ausgecheckt)"
     warn=$((warn+1)); [[ $STRICT -eq 1 ]] && fail=$((fail+1))
     continue
   fi
   # Klickdummy-Verzeichnis (exakt Basename 'klickdummy', .git ausgeschlossen)
   kd="$(find "$dir" -type d -name klickdummy -not -path '*/.git/*' 2>/dev/null | head -1 || true)"
   if [[ -z "$kd" ]]; then
-    printf '%-22s %-7s %-40s %s\n' "$repo" "nein" "n/a" "OK (kein Klickdummy)"
+    printf '%-22s %-5s %-34s %-10s %s\n' "$repo" "nein" "n/a" "n/a" "OK (kein Klickdummy)"
     continue
   fi
   checked=$((checked+1))
-  # Konformes ADR: Frontmatter `conforms_to: platform:ADR-211` (I4-qualifiziert;
+  # (a) Konformes ADR: Frontmatter `conforms_to: platform:ADR-211` (I4-qualifiziert;
   # bare `ADR-211` übergangsweise akzeptiert, vgl. ADR-211 C1 Rev 6).
   adr="$(grep -rIl -E '^[[:space:]]*conforms_to:[[:space:]]*(platform:)?ADR-211([^0-9]|$)' \
            "$dir" --include='ADR-*.md' 2>/dev/null | head -1 || true)"
-  if [[ -n "$adr" ]]; then
-    printf '%-22s %-7s %-40s %s\n' "$repo" "ja" "$(basename "$adr")" "OK"
+  adr_disp="$([[ -n "$adr" ]] && basename "$adr" || echo "— FEHLT —")"
+  # (b) i2-Target im Makefile vorhanden (anti-vacuous-pass plattform-seitig, ADR-211 Rev 9).
+  if [[ -f "$dir/Makefile" ]] && grep -qE '^klickdummy-i2:' "$dir/Makefile"; then
+    i2_disp="ja"
+  else
+    i2_disp="— FEHLT —"
+  fi
+  if [[ -n "$adr" && "$i2_disp" == "ja" ]]; then
+    printf '%-22s %-5s %-34s %-10s %s\n' "$repo" "ja" "$adr_disp" "$i2_disp" "OK"
     conform=$((conform+1))
   else
-    printf '%-22s %-7s %-40s %s\n' "$repo" "ja" "— FEHLT —" "FAIL"
+    printf '%-22s %-5s %-34s %-10s %s\n' "$repo" "ja" "$adr_disp" "$i2_disp" "FAIL"
     fail=$((fail+1))
   fi
 done
@@ -70,10 +77,10 @@ done
 echo
 echo "Klickdummy-Repos: $checked · konform: $conform · Verstöße: $fail · Warnungen: $warn"
 if [[ $fail -gt 0 ]]; then
-  echo "✗ ADR-211 C1 ROT — siehe FAIL-Zeilen. Konformität erklärt ein Repo, indem"
-  echo "  sein Klickdummy-ADR im Frontmatter 'conforms_to: ADR-211' führt"
-  echo "  (meiki-hub:ADR-020, risk-hub:ADR-046, writing-hub:ADR-180)."
+  echo "✗ ADR-211 C1+i2-Existenz ROT — siehe FAIL-Zeilen. Konformität verlangt"
+  echo "  (a) Klickdummy-ADR mit 'conforms_to: platform:ADR-211' und"
+  echo "  (b) 'klickdummy-i2:'-Target im Makefile (anti-vacuous-pass, Rev 9)."
   exit 1
 fi
-echo "✓ ADR-211 C1 GRÜN — alle Klickdummy-Repos konform."
+echo "✓ ADR-211 C1+i2-Existenz GRÜN — alle Klickdummy-Repos konform."
 exit 0


### PR DESCRIPTION
Plattform-Reaktion auf meiki-hub-WIP, die SF3/SF4 in Wahl B umgesetzt hat (klickdummy_class-Feld im Manifest statt im ADR-Frontmatter) und 4 generische check_iN.py-Skripte parallel gebaut hat.

**ADR-211 Rev 9:** kanonische Token `mock-prototyp` / `demo-render` im Klickdummy-Spec/Manifest-Root (alternativ `class:`). Beendet Token-Drift (de/en) vor sie entsteht.

**SF1 `klickdummy_registry.sh` erweitert:** prüft zusätzlich Existenz von `klickdummy-i2:`-Target im Repo-Makefile. Anti-vacuous-pass ist damit **plattform-seitig erzwingbar**, nicht nur als Repo-CI-Pflicht versprochen. Neue Baseline: risk-hub C1+i2 ROT (i2 noch nicht gebaut) — die richtige neue Wahrheit.

Berührt die meiki-hub-WIP **nicht** (kein Manifest-Edit, kein Check-Skript-Duplikat). Bewusst nur Plattform-Schicht.

Folge nach meiki-WIP-Commit: PR #19 (meiki klickdummy-i1) braucht klickdummy-i2-Target-Ergänzung — separater Followup, repo-für-repo wie SF2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)