### PR TITLE
feat(registry): tenancy_mode Pflicht-Feld für alle Systeme (ADR-212 Issue #247)

### DIFF
--- a/.github/workflows/registry-lint.yml
+++ b/.github/workflows/registry-lint.yml
@@ -1,0 +1,30 @@
+name: Registry Lint
+
+on:
+  push:
+    paths:
+      - "registry/repos.yaml"
+      - "infra/scripts/validate_tenancy.py"
+      - "infra/scripts/validate_repos.py"
+  pull_request:
+    paths:
+      - "registry/repos.yaml"
+      - "infra/scripts/validate_tenancy.py"
+      - "infra/scripts/validate_repos.py"
+
+jobs:
+  tenancy-lint:
+    name: tenancy_mode Pflicht-Feld (ADR-212 Issue #247)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Validate tenancy_mode
+        run: python3 infra/scripts/validate_tenancy.py

--- a/Makefile
+++ b/Makefile
@@ -133,3 +133,16 @@ logs-dev: ## Letzte Logs vom Dev-Server
 backup-db: ## Datenbank-Backup erstellen
 	@echo "$(BOLD)Datenbank-Backup:$(RESET)"
 	@echo "  (noch nicht implementiert - siehe /backup Workflow)"
+
+# =============================================================================
+# REGISTRY LINTING (ADR-212 Issue #247)
+# =============================================================================
+
+lint-tenancy: ## tenancy_mode Pflicht-Feld in registry/repos.yaml prüfen
+	@python3 infra/scripts/validate_tenancy.py
+
+lint-registry: ## Vollständige Registry-Validierung (ports + tenancy)
+	@python3 infra/scripts/validate_repos.py
+	@python3 infra/scripts/validate_tenancy.py
+
+.PHONY: lint-tenancy lint-registry

--- a/infra/scripts/validate_tenancy.py
+++ b/infra/scripts/validate_tenancy.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Tenancy-Mode Registry Lint (ADR-212 Offene Punkte #1, Issue #247).
+
+Prüft registry/repos.yaml auf:
+  1. Pflicht-Feld `tenancy_mode` bei allen Systemen
+  2. Gültiger Enum-Wert (subdomain | path | header | jwt_claim | none)
+  3. Systeme mit `tenancy_mode: subdomain` MÜSSEN `demo_fixture` deklarieren
+     (Klausel-1-Pflicht aus ADR-212)
+
+Nutzung:
+    python infra/scripts/validate_tenancy.py
+    python infra/scripts/validate_tenancy.py --warn-only  # kein Exit 1
+
+Exit-Codes:
+    0 = vollständig und gültig
+    1 = fehlende oder ungültige Felder
+    2 = Datei nicht gefunden
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+REPOS_YAML = (
+    Path(__file__).resolve().parent.parent.parent
+    / "registry"
+    / "repos.yaml"
+)
+
+VALID_TENANCY_MODES = frozenset(
+    {"subdomain", "path", "header", "jwt_claim", "none"}
+)
+
+
+def load_repos(path: Path) -> dict:
+    if not path.exists():
+        print(f"ERROR: {path} nicht gefunden", file=sys.stderr)
+        sys.exit(2)
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def iter_systems(data: dict):
+    """Yield (domain_name, system_dict) for every system in repos.yaml."""
+    for domain in data.get("domains", []):
+        domain_name = domain.get("name", "?")
+        for system in domain.get("systems", []):
+            yield domain_name, system
+
+
+def validate(data: dict) -> list[str]:
+    """Return list of error strings. Empty list = clean."""
+    errors: list[str] = []
+
+    for domain_name, system in iter_systems(data):
+        slug = system.get("name", "<unnamed>")
+        label = f"{domain_name}/{slug}"
+
+        tenancy_mode = system.get("tenancy_mode")
+
+        # Rule 1: tenancy_mode must be present
+        if tenancy_mode is None:
+            errors.append(
+                f"[MISSING] {label}: 'tenancy_mode' fehlt"
+                " — muss einen der Werte"
+                f" {sorted(VALID_TENANCY_MODES)} haben"
+            )
+            continue  # further checks meaningless without the field
+
+        # Rule 2: tenancy_mode must be a valid enum value
+        if tenancy_mode not in VALID_TENANCY_MODES:
+            errors.append(
+                f"[INVALID] {label}: tenancy_mode='{tenancy_mode}'"
+                f" ist kein gültiger Wert."
+                f" Erlaubt: {sorted(VALID_TENANCY_MODES)}"
+            )
+
+        # Rule 3: subdomain systems must declare demo_fixture
+        if tenancy_mode == "subdomain":
+            demo_fixture = system.get("demo_fixture")
+            if demo_fixture is None:
+                errors.append(
+                    f"[MISSING] {label}: tenancy_mode=subdomain"
+                    " erfordert Pflicht-Feld 'demo_fixture: true|false'"
+                    " (ADR-212 Klausel 1 — iil-demo-fixture Anbindung)"
+                )
+
+    return errors
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate tenancy_mode in registry/repos.yaml"
+    )
+    parser.add_argument(
+        "--warn-only",
+        action="store_true",
+        help="Print errors but exit 0 (non-blocking CI mode)",
+    )
+    args = parser.parse_args()
+
+    data = load_repos(REPOS_YAML)
+
+    # Count systems
+    system_count = sum(
+        len(d.get("systems", []))
+        for d in data.get("domains", [])
+    )
+
+    print("=" * 60)
+    print("Tenancy-Mode Registry Lint (ADR-212 Issue #247)")
+    print("=" * 60)
+    print(f"\nSysteme geprüft: {system_count}")
+
+    errors = validate(data)
+
+    if errors:
+        print(f"\n⚠  {len(errors)} Fehler gefunden:\n")
+        for e in errors:
+            print(f"  {e}")
+        print()
+        if args.warn_only:
+            print("--warn-only aktiv: kein Exit 1")
+        else:
+            print("Lint FAILED — bitte registry/repos.yaml korrigieren.")
+            print("=" * 60)
+            sys.exit(1)
+    else:
+        print("\n✅ Alle Systeme haben gültiges 'tenancy_mode'.")
+        # Summarize tenancy distribution
+        counts: dict[str, int] = {}
+        subdomain_systems: list[str] = []
+        for _, system in iter_systems(data):
+            mode = system.get("tenancy_mode", "MISSING")
+            counts[mode] = counts.get(mode, 0) + 1
+            if mode == "subdomain":
+                subdomain_systems.append(system.get("name", "?"))
+
+        print("\nVerteilung:")
+        for mode, count in sorted(counts.items()):
+            print(f"  {mode}: {count}")
+
+        if subdomain_systems:
+            print(f"\nKlausel-1-Systeme (subdomain): {subdomain_systems}")
+            configured = [
+                s for _, s in iter_systems(data)
+                if s.get("tenancy_mode") == "subdomain"
+                and s.get("demo_fixture") is True
+            ]
+            if len(configured) < len(subdomain_systems):
+                pending = len(subdomain_systems) - len(configured)
+                print(
+                    f"  ⚠  {pending} System(e) mit"
+                    " demo_fixture: false"
+                    " — Klausel-1-Pflicht noch offen (Issue #248)"
+                )
+
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/registry/repos.yaml
+++ b/registry/repos.yaml
@@ -11,6 +11,17 @@
 #   deploy.migrate_cmd   — correct Django migrate command
 #   deploy.multi_tenant  — true if django-tenants is used
 #   deploy.port          — host port mapped to container
+#
+# TENANCY FIELDS (added 2026-05-20 — ADR-212 Offene Punkte #1, Issue #247):
+#   tenancy_mode  — REQUIRED. Enum: subdomain | path | header | jwt_claim | none
+#                   subdomain: Tenant via Subdomain (SubdomainTenantMiddleware / django-tenants)
+#                   path:      Tenant via URL-Pfad (/<tenant>/…)
+#                   header:    Tenant via HTTP-Header (z.B. X-API-Key → tenant_id)
+#                   jwt_claim: Tenant aus JWT-Claim
+#                   none:      kein Tenant-Konzept
+#   demo_fixture  — REQUIRED wenn tenancy_mode == subdomain.
+#                   true: Demo-Org-Migration konfiguriert (iil-demo-fixture angebunden)
+#                   false: noch nicht konfiguriert (Klausel-1-Pflicht offen)
 
 domains:
 
@@ -24,6 +35,7 @@ domains:
         url: https://devhub.iil.pet
         type: django
         lifecycle: production
+        tenancy_mode: none  # single-tenant portal, no subdomain/path tenancy
         dockerfile: Dockerfile
         compose: docker-compose.prod.yml
         coverage_threshold: 80
@@ -60,6 +72,7 @@ domains:
         deployed: false
         type: library
         lifecycle: production
+        tenancy_mode: none  # library/tooling, no runtime tenancy
         coverage_threshold: 80
 
       - name: mcp-hub
@@ -69,6 +82,7 @@ domains:
         deployed: true
         type: python
         lifecycle: production
+        tenancy_mode: none  # MCP servers, per-user auth via MCP protocol
         coverage_threshold: 80
 
   - name: Content & Publishing
@@ -81,6 +95,7 @@ domains:
         url: https://bfagent.iil.pet
         type: django
         lifecycle: production
+        tenancy_mode: none  # single-user per-login, no tenant isolation
         dockerfile: Dockerfile
         compose: docker-compose.prod.yml
         coverage_threshold: 80
@@ -101,6 +116,7 @@ domains:
         url: https://pptx-hub.iil.pet
         type: django
         lifecycle: experimental
+        tenancy_mode: none  # single-tenant per user, no org-level isolation
         dockerfile: docker/app/Dockerfile
         compose: docker-compose.prod.yml
         coverage_threshold: 60
@@ -115,6 +131,7 @@ domains:
         url: https://weltenforger.com
         type: django
         lifecycle: production
+        tenancy_mode: none  # single-universe, user-level auth only
         dockerfile: Dockerfile
         compose: docker-compose.prod.yml
         coverage_threshold: 80
@@ -133,6 +150,8 @@ domains:
         url: https://drifttales.app
         type: django
         lifecycle: production
+        tenancy_mode: subdomain  # django-tenants (migrate_schemas --tenant); verified via SubdomainTenantMiddleware
+        demo_fixture: false  # Klausel-1-Pflicht offen — iil-demo-fixture nicht angebunden (Issue #248)
         dockerfile: docker/Dockerfile
         compose: docker-compose.prod.yml
         coverage_threshold: 80
@@ -159,6 +178,8 @@ domains:
         url: https://demo.schutztat.de
         type: django
         lifecycle: production
+        tenancy_mode: subdomain  # SubdomainTenantMiddleware; verified via *.staging.schutztat.de nginx-config (ADR-198 §1.4)
+        demo_fixture: false  # Klausel-1-Pflicht offen — iil-demo-fixture nicht angebunden (Issue #248)
         dockerfile: docker/app/Dockerfile
         compose: docker-compose.prod.yml
         coverage_threshold: 80
@@ -195,6 +216,7 @@ domains:
         deployed: true
         type: django
         lifecycle: experimental
+        tenancy_mode: none  # single-user analysis tool
         dockerfile: Dockerfile
         compose: docker-compose.prod.yml
         coverage_threshold: 60
@@ -206,6 +228,7 @@ domains:
         deployed: true
         type: other
         lifecycle: experimental
+        tenancy_mode: none  # Odoo manages tenancy internally via its own DB-per-company model
         coverage_threshold: 0
 
   - name: Engineering & Construction
@@ -218,6 +241,7 @@ domains:
         url: https://nl2cad.de
         type: django
         lifecycle: production
+        tenancy_mode: none  # single-org deployment, multi_tenant: false
         dockerfile: Dockerfile
         compose: docker-compose.prod.yml
         coverage_threshold: 80
@@ -237,6 +261,7 @@ domains:
         deployed: false
         type: library
         lifecycle: active
+        tenancy_mode: none  # library, no runtime tenancy
         coverage_threshold: 80
 
   - name: Analytics & Data
@@ -249,6 +274,7 @@ domains:
         url: https://bahn.iil.pet
         type: fastapi
         lifecycle: active
+        tenancy_mode: header  # X-API-Key header → tenant_id mapping (verified: core/auth.py get_tenant_id)
         dockerfile: Dockerfile
         compose: docker-compose.prod.yml
         coverage_threshold: 60
@@ -270,6 +296,7 @@ domains:
         deployed: true
         type: django
         lifecycle: experimental
+        tenancy_mode: none  # single-event/single-user planning tool
         dockerfile: Dockerfile
         compose: docker-compose.prod.yml
         coverage_threshold: 60
@@ -282,6 +309,7 @@ domains:
         url: https://137herz.de
         type: django
         lifecycle: production
+        tenancy_mode: none  # community platform, multi_tenant: false
         dockerfile: docker/Dockerfile
         compose: docker-compose.prod.yml
         coverage_threshold: 80


### PR DESCRIPTION
## Summary

- `registry/repos.yaml`: `tenancy_mode` bei allen 15 Systemen mit verifizierten Werten ergänzt
  - `subdomain`: risk-hub (SubdomainTenantMiddleware, ADR-198 §1.4), travel-beat (django-tenants, migrate_schemas)
  - `header`: bahn-hub (X-API-Key → tenant_id, verifiziert: `core/auth.py get_tenant_id`)
  - `none`: 12 Systeme (single-tenant / library)
- `demo_fixture: false` für Klausel-1-Systeme (risk-hub, travel-beat) — offen bis Issue #248 (iil-demo-fixture) angebunden
- `infra/scripts/validate_tenancy.py`: Lint-Script mit 3 Regeln (Pflicht-Feld, Enum, demo_fixture für subdomain)
- `Makefile`: `make lint-tenancy` + `make lint-registry`
- `.github/workflows/registry-lint.yml`: CI läuft bei jedem Push/PR auf `registry/repos.yaml`

## Lint-Output

```
Systeme geprüft: 15
✅ Alle Systeme haben gültiges 'tenancy_mode'.
Verteilung: header: 1, none: 12, subdomain: 2
Klausel-1-Systeme: ['travel-beat', 'risk-hub']
  ⚠ 2 System(e) mit demo_fixture: false — Klausel-1-Pflicht offen (Issue #248)
```

## Test plan

- [ ] `make lint-tenancy` → Exit 0
- [ ] `registry/repos.yaml` manuell: ein System ohne `tenancy_mode` → `make lint-tenancy` schlägt fehl (Exit 1)
- [ ] `registry/repos.yaml`: `tenancy_mode: subdomain` ohne `demo_fixture` → Fail
- [ ] `registry/repos.yaml`: `tenancy_mode: invalid_value` → Fail

## Folge-Arbeiten

- ADR-212 Offene Punkte #1 als gelöst markieren (wenn PR #249 gemergt)
- `demo_fixture: true` setzen wenn Issue #248 (iil-demo-fixture) integriert

Closes #247

🤖 Generated with [Claude Code](https://claude.ai/claude-code)