### PR TITLE
DRAFT fix(check): klickdummy_policy_sync.sh — Doppel-Stale-Blind-Spot

### DIFF
--- a/scripts/checks/klickdummy_policy_sync.sh
+++ b/scripts/checks/klickdummy_policy_sync.sh
@@ -20,6 +20,20 @@ INJECT_DIR="${CLAUDE_POLICIES_DIR:-$HOME/.claude/policies}"
 TGT="$INJECT_DIR/klickdummy.md"
 STRICT=0; [[ "${1:-}" == "--strict" ]] && STRICT=1
 
+# Kanonische SSoT = `origin/main:policies/klickdummy.md`. Wir vergleichen den
+# Injektions-Ziel-Inhalt gegen den remote main, nicht nur gegen das lokale
+# Working-Tree — sonst ist der Check blind, wenn lokales Repo UND pinned
+# Worktree am selben staleren Stand sind (Drift-Lehre 2026-05-20: S6 grün
+# obwohl origin/main durch #252 vorausgezogen war).
+REMOTE_SRC=""
+REMOTE_FETCH_OK=0
+if git -C "$REPO_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+  if git -C "$REPO_ROOT" fetch --quiet origin main 2>/dev/null; then
+    REMOTE_FETCH_OK=1
+    REMOTE_SRC="$(git -C "$REPO_ROOT" show origin/main:policies/klickdummy.md 2>/dev/null || true)"
+  fi
+fi
+
 # 1) SSoT MUSS im Repo versioniert sein.
 if [[ ! -f "$SRC" ]]; then
   echo "FAIL: SSoT fehlt — $SRC (Policy muss im platform-Repo versioniert sein)"
@@ -46,14 +60,31 @@ if [[ ! -f "$TGT" ]]; then
   exit 1
 fi
 
-# 4) Deckungsgleich? Abweichung = staler Pinned-Worktree.
+# 4a) Deckungsgleich Working-Tree vs Injektions-Ziel?
 if ! diff -q "$SRC" "$TGT" >/dev/null 2>&1; then
-  echo "FAIL: SSoT und Injektions-Ziel weichen ab (staler gepinnter Worktree)"
+  echo "FAIL: SSoT (lokal) und Injektions-Ziel weichen ab (staler gepinnter Worktree)"
   echo "  SSoT  : $SRC"
   echo "  Ziel  : $TGT  (→ $pinned)"
   echo "  Fix: gepinnten platform-Worktree refreshen (policies/README.md)."
   exit 1
 fi
 
-echo "✓ ADR-211 C6 GRÜN — SSoT == Injektions-Ziel ($pinned), Pinned aktuell."
+# 4b) Kanonisch: TGT vs origin/main (sonst Doppel-Stale-Blind-Spot).
+if [[ $REMOTE_FETCH_OK -eq 1 ]]; then
+  if ! diff -q <(printf '%s' "$REMOTE_SRC") "$TGT" >/dev/null 2>&1; then
+    echo "FAIL: Injektions-Ziel weicht von origin/main ab (lokales Repo UND pinned"
+    echo "      Worktree sind beide stale — Doppel-Drift)."
+    echo "  origin/main:policies/klickdummy.md"
+    echo "  Ziel       : $TGT  (→ $pinned)"
+    echo "  Fix: 'git -C $REPO_ROOT pull --ff-only origin main' UND"
+    echo "       'git -C \$(dirname $pinned) pull --ff-only origin main'."
+    exit 1
+  fi
+  echo "✓ ADR-211 C6 GRÜN — SSoT == Injektions-Ziel ($pinned) UND == origin/main."
+else
+  echo "✓ ADR-211 C6 GRÜN (lokal) — SSoT == Injektions-Ziel ($pinned)."
+  echo "  HINWEIS: origin/main nicht erreichbar (kein git/Netzwerk) → kein"
+  echo "  Doppel-Stale-Check. In strikter CI sicherstellen, dass dieser Check"
+  echo "  auf einem Runner mit Netzwerk-Zugang läuft."
+fi
 exit 0


### PR DESCRIPTION
## Bug
Bisher: `diff $REPO_ROOT/policies/klickdummy.md $TGT` — lokales Working-Tree gegen pinned Worktree. Wenn **beide** am selben staleren Stand sind, ergab diff equal → C6 GRÜN, obwohl `origin/main` weitergezogen war.

**Belegte Drift-Episode 2026-05-20:** PR #252 gemerged (Rev 9, 76 Z.). Lokales platform-Repo + pinned Worktree beide noch auf Rev 4 (53 Z.). Script meldete `✓ C6 GRÜN — Pinned aktuell` — Hook injizierte aber weiterhin Rev 4 in jede Session.

## Fix
Best-effort `git fetch origin main` + zusätzlicher `diff origin/main:policies/klickdummy.md vs $TGT` (4b). Ohne Netzwerk/git → bisheriges Verhalten + expliziter Hinweis. Falsch-grün im Doppel-Stale-Fall ausgeschlossen.

## Dogfood
Script aus dem Rev-9-Worktree gegen den stale Pinned (53 Z.): jetzt FAIL mit Fix-Hint (`git pull --ff-only origin main` im Repo UND im pinned Worktree).

DRAFT — Mechanik-Fix; bei dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)