### PR TITLE
DRAFT feat(registry): wedding-hub staging (ADR-210 R6, #221)

### DIFF
--- a/registry/repos.yaml
+++ b/registry/repos.yaml
@@ -300,6 +300,21 @@ domains:
         dockerfile: Dockerfile
         compose: docker-compose.prod.yml
         coverage_threshold: 60
+        # ADR-210 R6 / Issue #221: staging block — R1-Default-Hostname
+        # (staging-{repo}.iil.pet, weltenhub-Präzedenz). Port 19003 nächstes
+        # frei [19000..19999] nach risk-hub:19001, dev-hub:19002.
+        staging:
+          server_path: /opt/wedding-hub-staging
+          image: ghcr.io/achimdehnert/wedding-hub:${IMAGE_TAG:-latest}
+          web_container: wedding_hub_staging_web
+          web_service: wedding-hub-staging-web
+          migrate_cmd: python manage.py migrate --noinput
+          port: 19003
+          hostnames:
+            - staging-wedding-hub.iil.pet
+        oidc:
+          staging_app_slug: wedding-hub-staging
+          staging_redirect: https://staging-wedding-hub.iil.pet/oidc/callback/
 
       - name: 137-hub
         repo: 137-hub


### PR DESCRIPTION
Phase 1 von #221 — nur die **Registry-Erweiterung**, kein Deploy, kein DNS.

R1-Default-Hostname `staging-wedding-hub.iil.pet` (weltenhub-Präzedenz). Port 19003 (nächstes frei nach risk-hub:19001, dev-hub:19002).

**Wichtige Korrektur per Evidenz (cheapest check):**
- **billing-hub und coach-hub stehen NICHT in der Registry** — nur wedding-hub.
- Ohne Registry-Eintrag kein platform-managed Staging-Bau (SSoT-Verletzung).
- ⇒ Diese PR bedient nur wedding-hub. Für billing-hub/coach-hub ist die Owner-Vorfrage: erst onboarden (volle Registry-Einträge: prod URL, deploy config, ports), DANN Staging — oder bewusst aus Registry rauslassen + Authentik-Provider löschen.

Folge-Schritte (alle gated → eigene Risikokarten): CF-DNS-CNAME , Container/DB/Redis-Deploy auf staging-platform (178.104.184.168), Authentik-Provider  Redirect angleichen.

DRAFT — bei dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)