### PR TITLE
DRAFT docs(ADR-211): Rev 10 Bundle (#228 sunset_after + #229 4 Patterns)

### DIFF
--- a/docs/adr/ADR-211-klickdummy-benutzeranforderungen-entwicklungsprozess.md
+++ b/docs/adr/ADR-211-klickdummy-benutzeranforderungen-entwicklungsprozess.md
@@ -23,7 +23,7 @@ scope:
 - **Datum:** 2026-05-19
 - **Entscheider:** Achim Dehnert
 - **Verwandt:** ADR-207, risk-hub:ADR-046, writing-hub:ADR-180, meiki-hub:ADR-020
-- **Adversarial reviews:** vier Cascade-Pässe (Rev 2/3/4 + Rev 9 tief), siehe Revisionshistorie
+- **Adversarial reviews:** fünf Cascade-Pässe (Rev 2/3/4 + Rev 9 tief + Rev 10 Bundle für #228/#229), siehe Revisionshistorie
 
 ## Zusammenfassung
 
@@ -35,12 +35,17 @@ erzwingbare Entscheidungen, weil jede einen realen Schaden verhindert:
 1. **Spec-zentriert statt Renderer-zentriert.** Dauerhaftes Artefakt ist die
    **maschinenlesbare Anforderungs-Spec**, nicht ihre Darstellung. Ein
    Klickdummy *rendert* sie; ein Parity-Test ist das Konformitäts-Gate.
-2. **Mock-Prototyp ≠ Demo-Render — harter, plattform-extern geprüfter
-   Prod-Guard.** Ein Demo-Render der *echten* App (`?demo=<state>`) ist eine
-   **Prod-Sicherheitsfläche**.
-3. **Parity-grün ist die Off-Ramp, mit TTL.** Parity-grün pro Screen ⇒
-   statische Quelle mechanisch entfernt — beendet das „Static-Leichen"-Muster
-   auch im Dauer-Staging.
+2. **Vier scharf abgegrenzte Patterns, drei brauchen externen Prod-Guard.**
+   Klickdummies kommen in *vier* Patterns entlang der Achsen *Datenquelle ×
+   Code-Pfad-Identität* (`mock`, `stub-demo`, `story`, `spec-demo`) — nicht
+   nur den zwei der Rev-9-Vorstufe. Jedes Pattern erfordert eine
+   **distinkte** externe Prod-Probe (außer `mock`, dessen Pfad strukturell
+   nicht in Prod liegt).
+3. **Parity-grün ist die Off-Ramp, mit TTL — *und* Phase-A bekommt einen
+   harten Termin.** Parity-grün pro Screen ⇒ statische Quelle mechanisch
+   entfernt; **Phase-A ohne Zielsystem** wird zusätzlich durch
+   `sunset_after`-Pflicht-Frontmatter terminiert — beendet das „Static-
+   Leichen"-Muster strukturell, unabhängig davon ob Parity je grün wird.
 
 Die drei Invarianten (I1–I3) entsprechen 1:1 diesen drei Punkten.
 Implementierungs-Stack bleibt repo-lokal; die Invarianten sind ansatz-offen.
@@ -68,13 +73,23 @@ Drift-Memory (meiki-hub-Auto-Memory, `drift: true`) **und** Followup-Issue
 | # | Invariante | Erzwingung |
 |---|---|---|
 | **I1 Spec-first** | Maschinenlesbares, versioniertes Spec-Artefakt (YAML/JSON/strukturiertes Frontmatter); Markdown-Bullets zählen nicht. Klickdummy rendert es, ist nicht die Quelle. **Bidirektionale Coverage:** jede Impl-Route hat einen Spec-Eintrag *und* jeder Spec-Eintrag eine Route/Screen — kein einseitiges „Datei existiert & rendert". | `make -C <repo> klickdummy-i1` (Exit-Code), CI-verifiziert — prüft Spec↔Route-Coverage, nicht nur Spec==Render |
-| **I2 Prod-Sicherheit** | Genau eine Klasse je Klickdummy, **explizit deklariert**: **Mock-Prototyp** (kein Backend; Systemgrenzen als Target-Mock) ODER **Demo-Render** (env-gegated; in Prod nicht erreichbar). „Keine Klasse deklariert" ist I2-Verstoß (kein vacuous pass). | **Zwei Schichten:** (a) repo-definierter `make -C <repo> klickdummy-i2` (Selbstaussage); (b) **plattform-externer, repo-unabhängiger Prod-Probe** `klickdummy_prod_guard.sh` gegen die Registry-Prod-URL: `?demo=<state>` live ⇒ 404/disabled. (b) ist das **bindende Cross-Repo-Signal** — die Behauptung wird adversarial extern getestet, nicht dem Repo-Selbstcheck geglaubt (F3) |
-| **I3 Lebenszyklus + TTL** | **A ohne Zielsystem:** endet bei dok. Fachabteilungs-Review → ADR `accepted-frozen`/`superseded`, Spec eingefroren, Pfad `klickdummy/archive/`. **B Transition:** ab erstem Screen mit Impl-Route greift I3 je Screen. **C mit Zielsystem:** Doppelquelle endet bei **`min(prod-Release, Parity-grün + N Tagen)`** (N Default **30 d**, repo-tunbar) — schließt das „ewig auf Staging"-Leck (F4). Staging ist erlaubter Doppelquell-Raum *innerhalb* der TTL. | `make -C <repo> klickdummy-i3`: assert je Screen mit Impl-Route + grünem Parity ⇒ statische Quelle abwesend, sobald prod-Release **oder** Parity-grün-Alter > N |
+| **I2 Prod-Sicherheit (4-Pattern, Rev 10)** | Genau **ein** Pattern je Klickdummy, **explizit deklariert**: `mock` / `stub-demo` / `story` / `spec-demo` (Achsen: *Datenquelle × Code-Pfad-Identität*; vollständige Definition siehe Glossar). „Kein Pattern deklariert" = I2-Verstoß (kein vacuous pass). Die Vereinfachung *Mock-Prototyp/Demo-Render* der Rev 9 wird hier verfeinert, weil die drei Nicht-`mock`-Patterns *distinkte* Prod-Probes erfordern (siehe nächste Spalte). | **Zwei Schichten:** (a) repo-definierter `make -C <repo> klickdummy-i2` (Selbstaussage des Patterns); (b) **plattform-externer Prod-Probe** `klickdummy_prod_guard.sh` mit pattern-spezifischem Verhalten: `mock` ⇒ N/A (Pfad nicht in Prod-Deploy); `stub-demo` ⇒ deklarierte Demo-Route 404; `story` ⇒ Catalog-Route (z. B. `/storybook/`) 404; `spec-demo` ⇒ `?demo=<state>` 404/disabled. (b) bleibt das **bindende Cross-Repo-Signal** (F3) |
+| **I3 Lebenszyklus + TTL + Sunset (Rev 10)** | **A ohne Zielsystem:** Pflicht-Frontmatter `sunset_after: <ISO-Datum>` in der Repo-Klickdummy-ADR (Default ADR-Datum + 12 Monate); nach Fristablauf ohne PR-Extension ⇒ ADR auto-`deprecated`, Pfad `klickdummy/archive/` (siehe §Frontmatter-Konvention). **B Transition:** ab erstem Screen mit Impl-Route greift I3 je Screen. **C mit Zielsystem:** Doppelquelle endet bei **`min(prod-Release, Parity-grün + N Tagen)`** (N Default **30 d**, repo-tunbar) — schließt das „ewig auf Staging"-Leck (F4). Staging ist erlaubter Doppelquell-Raum *innerhalb* der TTL. | `make -C <repo> klickdummy-i3` (Phase B/C); `platform/scripts/checks/adr_sunset.sh` (Phase A, nightly — öffnet Issue bei passierter Frist) |
 
-**Auswahlhilfe (illustrativ):** Konzeptphase ohne Backend → Mock-Prototyp
-(meiki-hub:ADR-020). App-Repo mit Zielsystem → Demo-Render + Parity
-(writing-hub:ADR-180). UI-Spec primär → Spec-Driven (risk-hub:ADR-046).
-KI-generiert/Figma-as-Spec zulässig, sofern I1–I3 erfüllt.
+**Auswahlhilfe Rev 10 (illustrativ; Mapping der bekannten Implementierungen
+auf die 4 Patterns):**
+
+| Pattern | Beispiel | Datenquelle | Code-Pfad-Identität | I2-Externe-Probe |
+|---|---|---|---|---|
+| `mock` | meiki-hub:ADR-020 (Manifest-Single-File-Mock) | leere/feste Stubs | **separater** Wegwerf-Pfad | N/A (nicht in Prod-Deploy) |
+| `stub-demo` | (potentiell risk-hub:ADR-046 — Spec-Driven-Demo mit synthetischen Daten) | synthetisch im Code | **real**, fester Demo-Pfad | deklarierte Demo-Route 404 |
+| `story` | (Component-Catalog/Storybook-Stil — bisher kein Beispiel-Repo) | synthetisch pro Story | **real**, isolierte Catalog-Route | Catalog-Route 404 |
+| `spec-demo` | writing-hub:ADR-180 (`?demo=<state>` Env-Gate) | synthetisch via Flag | **real**, bedingt env-gegated | `?demo=<state>` 404/disabled |
+
+KI-generiert/Figma-as-Spec zulässig, sofern I1–I3 erfüllt. Repos mit
+bestehendem `class: Mock-Prototyp` (Rev 9) ⇒ `mock`. Repos mit
+`Demo-Render` (Rev 9) müssen in der nächsten Conformance-Iteration zu
+einem der drei Nicht-`mock`-Patterns präzisiert werden.
 
 ### Was repo-lokal bleibt
 Tech-Stack, Schema, UI-Bausteine, Teststack. risk-hub:ADR-046 behält seine
@@ -87,6 +102,30 @@ generische Doku-Konvention, die alle ADRs aller Repos betrifft, gatete hier
 Doku-Konvention, ohnehin `depends_on`). Dorthin verschoben; `scope` dieses
 ADR auf klickdummy-Pfade reduziert. `conforms_to: platform:ADR-211` bleibt
 das Konformitäts-Feld (Format-Regel selbst → ADR-207).
+
+## Frontmatter-Konvention für repo-lokale Klickdummy-ADRs (Rev 10, schließt #228)
+
+Repo-lokale ADRs mit `tags: [klickdummy]` MÜSSEN folgende Frontmatter
+führen:
+
+```yaml
+class: mock | stub-demo | story | spec-demo   # Rev-10 I2 (Pflicht)
+sunset_after: 2026-12-31                       # ISO-Datum (Pflicht; Default ADR-Datum + 12 Monate)
+extension_review_required: true                # Optional (Default true für mock, false sonst)
+```
+
+**Geltungsbereich:** ausschließlich **repo-lokale** Klickdummy-ADRs.
+**ADR-211 selbst** (Platform-Policy-ADR mit `tags: [klickdummy, ...]`) ist
+**explizit ausgenommen** — eine Policy-ADR hat keinen Sunset, ihre
+Geltung wird durch `supersedes`/`amends` geregelt.
+
+**Auto-Deprecation:** Nach Ablauf von `sunset_after` ohne PR-Extension:
+- ADR-Status wechselt zu `deprecated` (Validator-erzwungen)
+- Klickdummy-Pfad wandert nach `klickdummy/archive/`
+- Owner-Review nötig für Extension (neuer PR mit neuem `sunset_after`)
+
+**Enforcement:** `platform/scripts/checks/adr_sunset.sh` (nightly CI;
+öffnet GitHub-Issue bei passierter Frist). Adoption-Scoreboard-Item S7.
 
 ## Enforcement-Pfad
 
@@ -152,6 +191,16 @@ make -C <repo> klickdummy-i3
 platform/scripts/checks/klickdummy_policy_sync.sh
 #   FAIL wenn SSoT fehlt ODER Injektions-Ziel fehlt/weicht ab (staler Pinned).
 #   SKIP (exit 0) ohne ~/.claude/policies (off-machine CI); --strict ⇒ FAIL.
+#   Rev-10-Verschärfung (S6-Doppel-Stale-Fix #254): zusätzlich diff vs origin/main.
+
+# S7 sunset_after-Enforcement für Phase-A Klickdummy-ADRs (Rev 10, SF6/#228)
+platform/scripts/checks/adr_sunset.sh
+#   Nightly. Scant alle ADRs mit tags: [klickdummy] (außer ADR-211 selbst).
+#   FAIL wenn sunset_after fehlt ODER Frist passiert ohne Extension.
+
+# S8 4-Pattern-Konformität (Rev 10, #229)
+#   Repo-lokale Klickdummy-ADRs MÜSSEN class ∈ {mock,stub-demo,story,spec-demo}
+#   führen (geprüft via klickdummy_registry.sh + Frontmatter-Lint).
 ```
 
 ## Konsequenzen
@@ -179,11 +228,14 @@ prüfen; I4-Auslagerung macht 207 zusätzlich relevant.
 |---|---|
 | **Anforderungs-Spec** | Versioniertes, maschinenlesbares Quell-Artefakt (YAML/JSON/Frontmatter); Markdown-Bullets zählen nicht |
 | **Klickdummy** | Oberbegriff: *Renderer* der Spec zur frühen Validierung |
-| **Mock-Prototyp** | Wegwerf-Renderer ohne Backend (Target-Mock-Systemgrenzen) |
-| **Demo-Render** | Env-gegateter Zustand der echten App (`?demo=`) — Prod-Sicherheitsfläche |
+| **`mock` (Pattern, Rev 10)** | Wegwerf-Renderer, **separater Code-Pfad**, leere/feste Stubs als Daten. Beispiel: meiki-hub. Nicht in Prod-Deploy ⇒ I2-Externprobe N/A |
+| **`stub-demo` (Pattern, Rev 10)** | **Realer** Code-Pfad mit synthetischen Daten an einer dedizierten Demo-Route. I2-Externprobe: Route ⇒ 404 |
+| **`story` (Pattern, Rev 10)** | **Realer** Code-Pfad, isolierter Component-Catalog (z. B. Storybook), pro Story eigene synthetische Daten. I2-Externprobe: Catalog-Route ⇒ 404 |
+| **`spec-demo` (Pattern, Rev 10)** | **Realer** Code-Pfad, env-gegateter Zustand der echten App via Flag (`?demo=<state>`). Beispiel: writing-hub. I2-Externprobe: `?demo=` ⇒ 404/disabled |
 | **Parity-Test** | Renderer↔Implementierung-Äquivalenztest — Gate **und** Off-Ramp |
 | **Off-Ramp** | Parity-grün ⇒ mechanische Entfernung der statischen Quelle (Grenze: `min(prod-Release, Parity-grün + N d)`) |
-| **Adoption-Scoreboard** | Lebende SF1–SF6-Rollout-Metrik; **gatet `status` nicht** (Rev 9) |
+| **`sunset_after` (Rev 10)** | Pflicht-Frontmatter-Datum für repo-lokale Klickdummy-ADRs; nach Frist ohne Extension ⇒ ADR auto-`deprecated`, Pfad archiviert |
+| **Adoption-Scoreboard** | Lebende SF-Rollout-Metrik (S1–S8 nach Rev 10); **gatet `status` nicht** (Rev 9) |
 
 ## Acceptance-Trigger
 
@@ -196,7 +248,7 @@ Properties zu; Acceptance-Logik im Body.)
 
 ## Revisionshistorie
 
-Vier Cascade-Adversarial-Pässe + Schema-/YAML-Härtung:
+Fünf Cascade-Adversarial-Pässe + Schema-/YAML-Härtung:
 
 - **Rev 1** — initial proposal
 - **Rev 2** (bf7c4d6) — Spec-first, Prod-Guard, Parity-Off-Ramp
@@ -207,11 +259,13 @@ Vier Cascade-Adversarial-Pässe + Schema-/YAML-Härtung:
 - **Rev 7** — C6 auf Script `klickdummy_policy_sync.sh`; SF6
 - **Rev 8** — Frontmatter schema-konform (`review_history`/`acceptance_trigger` in Body; YAML-`date:`-Fix)
 - **Rev 9 (tiefer Adversarial-Pass)** — **F1/F2:** Entscheid ↔ Rollout entkoppelt (löst Acceptance-Deadlock + oszillierenden Status; C1–C6 → status-neutrales Adoption-Scoreboard). **F3:** I2 um plattform-externen, repo-unabhängigen Prod-Probe erweitert (Sicherheitsinvariante cross-repo verifizierbar statt per-Vertrauen). **F4:** I3 Off-Ramp-TTL `min(prod-Release, Parity-grün+N d)` (Dauer-Staging-Leck). **F5:** I4 → ADR-207 ausgelagert, `scope` entschlackt, „vier"→„drei Invarianten" (Konsistenz mit der 3-Punkte-Zusammenfassung). **F6:** I1 bidirektionale Spec↔Route-Coverage statt Format-Existenz. **F7/F8** als offene Punkte dokumentiert (ADR-207-Dep, fehlende `consulted`).
+- **Rev 10 (Bundle #228/#229)** — **F9 (#229):** I2 von 2 → **4 scharf abgegrenzte Patterns** (`mock`/`stub-demo`/`story`/`spec-demo`) entlang *Datenquelle × Code-Pfad-Identität*. Jedes Pattern erhält eine **distinkte** I2-Externprobe (mock = N/A; sonst je eigene Route/Query). Vermeidet das Theater-Risiko des 4-Pattern-Splits, weil die *Enforcement* je Pattern wirklich anders ist (siehe Glossar/Auswahlhilfe). **F10 (#228):** `sunset_after`-Pflicht-Frontmatter für repo-lokale Klickdummy-ADRs (nicht ADR-211 selbst); Phase-A bekommt damit einen *harten* Termin unabhängig von Parity. Auto-`deprecated` nach Frist, Extension via PR-Review. Enforcement-Script `adr_sunset.sh` als Scoreboard-Item S7. **Offene Folge-Punkte:** (F11) `klickdummy_prod_guard.sh` muss pattern-spezifisch verzweigen (bisher nur `spec-demo`-Probe geplant — Issue #255 SF3-AC vor Bau anpassen); (F12) Migrations-Mapping bestehender Rev-9 `Demo-Render`-Repos auf eines der drei Nicht-`mock`-Patterns (Conformance-Iteration pro Repo).
 
 ## Bezug
 
-- ADR-207 — Cross-Repo-Ingest-/Doku-Konvention (**neu: Heimat der ausgelagerten Ref-Format-Regel, vormals I4**)
-- risk-hub:ADR-046 · writing-hub:ADR-180 · meiki-hub:ADR-020 (Implementierungen)
-- Followups `adr-211-followup` SF1–SF6 (Adoption-Scoreboard-Baseline 0/6, **nicht status-gatend**)
+- ADR-207 — Cross-Repo-Ingest-/Doku-Konvention (**neu seit Rev 9: Heimat der ausgelagerten Ref-Format-Regel, vormals I4**)
+- risk-hub:ADR-046 · writing-hub:ADR-180 · meiki-hub:ADR-020 (Implementierungen — Mapping auf Rev-10-Patterns in §Auswahlhilfe)
+- Followups `adr-211-followup` SF1–SF8 (Adoption-Scoreboard, **nicht status-gatend**) — S7/S8 neu durch Rev 10
+- Closes-on-acceptance: **#228** (sunset_after-Frontmatter, F10) und **#229** (4-Pattern-Taxonomie, F9). #255 SF3-AC muss vor Bau an pattern-spezifischen Prod-Guard angepasst werden (F11).
 - Drift-Memory `2026-05-19-klickdummy-adr180-collision` (meiki-hub-Auto-Memory, `drift: true`)
 - Policy `adr-threshold.md` (Selbsttest)


### PR DESCRIPTION
Fünfter Adversarial-Pass, gebündelt für #228 (sunset_after) und #229 (4-Pattern-Taxonomie).

## F9 (#229): I2 von 2 → 4 Patterns entlang Datenquelle × Code-Pfad-Identität

| Pattern | Code-Pfad | Daten | I2-Externprobe |
|---|---|---|---|
| `mock` | separat (Wegwerf) | leere/feste Stubs | N/A (nicht in Prod) |
| `stub-demo` | real, Demo-Route | synth. im Code | Demo-Route ⇒ 404 |
| `story` | real, Component-Catalog | synth. pro Story | Catalog-Route ⇒ 404 |
| `spec-demo` | real, env-gegated | synth. via Flag | `?demo=` ⇒ 404/disabled |

**Adversarial-Sharpening:** der 4-Split wäre Theater, wenn alle Patterns identische I2-Probes hätten. Die obige Spalte zeigt, dass jedes eine **distinkte** Probe braucht — das rechtfertigt die Vokabular-Erweiterung.

## F10 (#228): `sunset_after`-Frontmatter-Pflicht für repo-lokale Klickdummy-ADRs

- Pflicht: `sunset_after: <ISO-Datum>` (Default ADR-Datum + 12 Monate)
- Nach Frist ohne Extension ⇒ ADR auto-`deprecated`, Pfad → `klickdummy/archive/`
- Extension via PR-Review (Owner)
- **ADR-211 selbst explizit ausgenommen** (Policy-ADR ≠ Klickdummy-ADR)
- Enforcement: `adr_sunset.sh` (nightly, Scoreboard-S7)

## Offene Folge-Punkte (in Rev 10 dokumentiert)
- **F11:** `klickdummy_prod_guard.sh` muss pattern-spezifisch verzweigen (Issue #255 SF3-AC vor Bau anpassen)
- **F12:** Migrations-Mapping der Rev-9 `Demo-Render`-Repos auf einen der 3 Nicht-`mock`-Patterns

## Closes
#228 (F10) und #229 (F9) bei Merge.

DRAFT, kein Auto-Merge — Decider-Review. Policy-Angleichung (`policies/klickdummy.md`) folgt analog #243 → #252 als separater PR nach Annahme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)