### PR TITLE
DRAFT docs(ADR-211): Rev 11 — Bundle #228/#229 auf Rev-10-Stand integriert

### DIFF
--- a/docs/adr/ADR-211-klickdummy-benutzeranforderungen-entwicklungsprozess.md
+++ b/docs/adr/ADR-211-klickdummy-benutzeranforderungen-entwicklungsprozess.md
@@ -23,7 +23,7 @@ scope:
 - **Datum:** 2026-05-19
 - **Entscheider:** Achim Dehnert
 - **Verwandt:** risk-hub:ADR-046, writing-hub:ADR-180, meiki-hub:ADR-020
-- **Adversarial reviews:** fünf Cascade-Pässe (Rev 2/3/4/9 + Rev 10), siehe Revisionshistorie
+- **Adversarial reviews:** sechs Cascade-Pässe (Rev 2/3/4/9 + Rev 10 F5-Rollback + Rev 11 #228/#229), siehe Revisionshistorie
 
 ## Zusammenfassung
 
@@ -35,12 +35,15 @@ erzwingbare Entscheidungen, weil jede einen realen Schaden verhindert:
 1. **Spec-zentriert statt Renderer-zentriert.** Dauerhaftes Artefakt ist die
    **maschinenlesbare Anforderungs-Spec**, nicht ihre Darstellung. Ein
    Klickdummy *rendert* sie; ein Parity-Test ist das Konformitäts-Gate.
-2. **Mock-Prototyp ≠ Demo-Render — harter, plattform-extern geprüfter
-   Prod-Guard.** Ein Demo-Render der *echten* App (`?demo=<state>`) ist eine
-   **Prod-Sicherheitsfläche**.
-3. **Parity-grün ist die Off-Ramp, mit TTL.** Parity-grün pro Screen ⇒
-   statische Quelle mechanisch entfernt — beendet das „Static-Leichen"-Muster
-   auch im Dauer-Staging.
+2. **Vier scharf abgegrenzte Patterns, drei brauchen externen Prod-Guard
+   (Rev 11).** Klickdummies kommen in vier Patterns (`mock` / `stub-demo` /
+   `story` / `spec-demo`) entlang *Datenquelle × Code-Pfad-Identität*. Jedes
+   nicht-`mock`-Pattern erfordert eine **distinkte** externe Prod-Probe.
+3. **Parity-grün ist die Off-Ramp, mit TTL — *und* Phase-A bekommt einen
+   harten Termin (Rev 11).** Parity-grün pro Screen ⇒ statische Quelle
+   mechanisch entfernt; **Phase-A ohne Zielsystem** wird zusätzlich durch
+   `sunset_after`-Pflicht-Frontmatter terminiert — beendet das „Static-
+   Leichen"-Muster strukturell, unabhängig davon ob Parity je grün wird.
 
 Die drei *Schaden-Entscheidungen* entsprechen den Invarianten I1–I3; **I4
 (Namensraum)** ergänzt sie als Drift-Schutz für Cross-Repo-Refs.
@@ -68,18 +71,52 @@ Drift-Memory (meiki-hub-Auto-Memory, `drift: true`) **und** Followup-Issue
 | # | Invariante | Erzwingung |
 |---|---|---|
 | **I1 Spec-first** | Maschinenlesbares, versioniertes Spec-Artefakt (YAML/JSON/strukturiertes Frontmatter); Markdown-Bullets zählen nicht. Klickdummy rendert es, ist nicht die Quelle. **Bidirektionale Coverage:** jede Impl-Route hat einen Spec-Eintrag *und* jeder Spec-Eintrag eine Route/Screen — kein einseitiges „Datei existiert & rendert". | `make -C <repo> klickdummy-i1` (Exit-Code), CI-verifiziert — prüft Spec↔Route-Coverage, nicht nur Spec==Render |
-| **I2 Prod-Sicherheit** | Genau eine Klasse je Klickdummy, **explizit deklariert**: **Mock-Prototyp** (kein Backend; Systemgrenzen als Target-Mock) ODER **Demo-Render** (env-gegated; in Prod nicht erreichbar). „Keine Klasse deklariert" ist I2-Verstoß (kein vacuous pass). | **Zwei Schichten:** (a) repo-definierter `make -C <repo> klickdummy-i2` (Selbstaussage); (b) **plattform-externer, repo-unabhängiger Prod-Probe** `klickdummy_prod_guard.sh` gegen die Registry-Prod-URL: `?demo=<state>` live ⇒ 404/disabled. (b) ist das **bindende Cross-Repo-Signal** — die Behauptung wird adversarial extern getestet, nicht dem Repo-Selbstcheck geglaubt (F3) |
-| **I3 Lebenszyklus + TTL** | **A ohne Zielsystem:** endet bei dok. Fachabteilungs-Review → ADR `accepted-frozen`/`superseded`, Spec eingefroren, Pfad `klickdummy/archive/`. **B Transition:** ab erstem Screen mit Impl-Route greift I3 je Screen. **C mit Zielsystem:** Doppelquelle endet bei **`min(prod-Release, Parity-grün + N Tagen)`** (N Default **30 d**, repo-tunbar) — schließt das „ewig auf Staging"-Leck (F4). Staging ist erlaubter Doppelquell-Raum *innerhalb* der TTL. | `make -C <repo> klickdummy-i3`: assert je Screen mit Impl-Route + grünem Parity ⇒ statische Quelle abwesend, sobald prod-Release **oder** Parity-grün-Alter > N |
+| **I2 Prod-Sicherheit (4-Pattern, Rev 11)** | Genau **ein** Pattern je Klickdummy, **explizit deklariert**: `mock` / `stub-demo` / `story` / `spec-demo` (Achsen: *Datenquelle × Code-Pfad-Identität*; vollständige Definition siehe Glossar). „Kein Pattern deklariert" = I2-Verstoß (kein vacuous pass). Die Vereinfachung *Mock-Prototyp/Demo-Render* (Rev ≤10) wird hier verfeinert, weil die drei Nicht-`mock`-Patterns *distinkte* Prod-Probes erfordern. | **Zwei Schichten:** (a) repo-definierter `make -C <repo> klickdummy-i2` (Selbstaussage des Patterns); (b) **plattform-externer Prod-Probe** `klickdummy_prod_guard.sh` mit pattern-spezifischem Verhalten: `mock` ⇒ N/A (Pfad nicht in Prod-Deploy); `stub-demo` ⇒ deklarierte Demo-Route 404; `story` ⇒ Catalog-Route (z. B. `/storybook/`) 404; `spec-demo` ⇒ `?demo=<state>` 404/disabled. (b) bleibt das **bindende Cross-Repo-Signal** (F3) |
+| **I3 Lebenszyklus + TTL + Sunset (Rev 11)** | **A ohne Zielsystem:** Pflicht-Frontmatter `sunset_after: <ISO-Datum>` in der Repo-Klickdummy-ADR (Default ADR-Datum + 12 Monate); nach Fristablauf ohne PR-Extension ⇒ ADR auto-`deprecated`, Pfad `klickdummy/archive/` (siehe §Frontmatter-Konvention). **B Transition:** ab erstem Screen mit Impl-Route greift I3 je Screen. **C mit Zielsystem:** Doppelquelle endet bei **`min(prod-Release, Parity-grün + N Tagen)`** (N Default **30 d**, repo-tunbar) — schließt das „ewig auf Staging"-Leck (F4). Staging ist erlaubter Doppelquell-Raum *innerhalb* der TTL. | `make -C <repo> klickdummy-i3` (Phase B/C); `platform/scripts/checks/adr_sunset.sh` (Phase A, nightly — öffnet Issue bei passierter Frist) |
 | **I4 Namensraum** | Klickdummy-ADRs tragen reserviertes Titel-Präfix; Cross-Repo-Refs **nur** `repo:ADR-NNN` (inkl. `conforms_to: platform:ADR-211`). Drift-Schutz (vgl. Drift-Memory `klickdummy-adr180-collision`). | `platform/scripts/checks/adr_cross_repo_refs.sh` (plattformseitig, kein repo-Make-Target — generischer ADR-Lint) |
 
-**Auswahlhilfe (illustrativ):** Konzeptphase ohne Backend → Mock-Prototyp
-(meiki-hub:ADR-020). App-Repo mit Zielsystem → Demo-Render + Parity
-(writing-hub:ADR-180). UI-Spec primär → Spec-Driven (risk-hub:ADR-046).
-KI-generiert/Figma-as-Spec zulässig, sofern I1–I4 erfüllt.
+**Auswahlhilfe Rev 11 (illustrativ; Mapping bekannter Implementierungen auf
+die 4 Patterns aus I2):**
+
+| Pattern | Beispiel | Datenquelle | Code-Pfad | I2-Externprobe |
+|---|---|---|---|---|
+| `mock` | meiki-hub:ADR-020 | leere/feste Stubs | **separater** Wegwerf-Pfad | N/A |
+| `stub-demo` | (potenziell risk-hub:ADR-046) | synth. im Code | **real**, fester Demo-Pfad | Demo-Route 404 |
+| `story` | (Storybook-Stil — kein Beispiel-Repo) | synth. pro Story | **real**, isolierte Catalog-Route | Catalog-Route 404 |
+| `spec-demo` | writing-hub:ADR-180 | synth. via Flag | **real**, env-gegated | `?demo=` 404 |
+
+KI-generiert/Figma-as-Spec zulässig, sofern I1–I4 erfüllt. Repos mit
+bestehendem `class: Mock-Prototyp` (Rev ≤10) ⇒ `mock`. Repos mit
+`Demo-Render` (Rev ≤10) müssen in der nächsten Conformance-Iteration zu
+einem der drei Nicht-`mock`-Patterns präzisiert werden.
 
 ### Was repo-lokal bleibt
 Tech-Stack, Schema, UI-Bausteine, Teststack. risk-hub:ADR-046 behält seine
 Repo-Lokalität; dieses ADR ersetzt keine Implementierungs-ADR.
+
+## Frontmatter-Konvention für repo-lokale Klickdummy-ADRs (Rev 11, schließt #228)
+
+Repo-lokale ADRs mit `tags: [klickdummy]` MÜSSEN folgende Frontmatter
+führen:
+
+```yaml
+class: mock | stub-demo | story | spec-demo   # Rev-11 I2 (Pflicht)
+sunset_after: 2026-12-31                       # ISO-Datum (Pflicht; Default ADR-Datum + 12 Monate)
+extension_review_required: true                # Optional (Default true für mock, false sonst)
+```
+
+**Geltungsbereich:** ausschließlich **repo-lokale** Klickdummy-ADRs.
+**ADR-211 selbst** (Platform-Policy-ADR mit `tags: [klickdummy, ...]`) ist
+**explizit ausgenommen** — eine Policy-ADR hat keinen Sunset, ihre
+Geltung wird durch `supersedes`/`amends` geregelt.
+
+**Auto-Deprecation:** Nach Ablauf von `sunset_after` ohne PR-Extension:
+- ADR-Status wechselt zu `deprecated` (Validator-erzwungen)
+- Klickdummy-Pfad wandert nach `klickdummy/archive/`
+- Owner-Review nötig für Extension (neuer PR mit neuem `sunset_after`)
+
+**Enforcement:** `platform/scripts/checks/adr_sunset.sh` (nightly CI;
+öffnet GitHub-Issue bei passierter Frist). Adoption-Scoreboard-Item S7.
 
 ### Hinweis zu I4-Scope (Rev 10)
 I4 ist hier *klickdummy-skopiert* (Refs in den Klickdummy-ADRs und
@@ -154,6 +191,16 @@ platform/scripts/checks/adr_cross_repo_refs.sh
 platform/scripts/checks/klickdummy_policy_sync.sh
 #   FAIL wenn SSoT fehlt ODER Injektions-Ziel fehlt/weicht ab (staler Pinned).
 #   SKIP (exit 0) ohne ~/.claude/policies (off-machine CI); --strict ⇒ FAIL.
+#   Doppel-Stale-Check (vs origin/main) seit PR #254.
+
+# S7 sunset_after-Enforcement für Phase-A Klickdummy-ADRs (Rev 11, #228)
+platform/scripts/checks/adr_sunset.sh
+#   Nightly. Scant alle ADRs mit tags: [klickdummy] (außer ADR-211 selbst).
+#   FAIL wenn sunset_after fehlt ODER Frist passiert ohne PR-Extension.
+
+# S8 4-Pattern-Konformität (Rev 11, #229)
+#   Repo-lokale Klickdummy-ADRs MÜSSEN class ∈ {mock,stub-demo,story,spec-demo}
+#   führen (geprüft via klickdummy_registry.sh + Frontmatter-Lint).
 ```
 
 ## Konsequenzen
@@ -182,8 +229,11 @@ behauptete Abhängigkeit zu ADR-207 war Konsequenz der Fehl-Auslagerung F5
 |---|---|
 | **Anforderungs-Spec** | Versioniertes, maschinenlesbares Quell-Artefakt (YAML/JSON/Frontmatter); Markdown-Bullets zählen nicht |
 | **Klickdummy** | Oberbegriff: *Renderer* der Spec zur frühen Validierung |
-| **Mock-Prototyp** | Wegwerf-Renderer ohne Backend (Target-Mock-Systemgrenzen) |
-| **Demo-Render** | Env-gegateter Zustand der echten App (`?demo=`) — Prod-Sicherheitsfläche |
+| **`mock` (Pattern, Rev 11)** | Wegwerf-Renderer, **separater Code-Pfad**, leere/feste Stubs. Beispiel: meiki-hub. I2-Externprobe N/A |
+| **`stub-demo` (Pattern, Rev 11)** | **Realer** Code-Pfad mit synthetischen Daten an dedizierter Demo-Route. I2-Externprobe: Route ⇒ 404 |
+| **`story` (Pattern, Rev 11)** | **Realer** Code-Pfad, isolierter Component-Catalog (z. B. Storybook). I2-Externprobe: Catalog-Route ⇒ 404 |
+| **`spec-demo` (Pattern, Rev 11)** | **Realer** Code-Pfad, env-gegateter Zustand via Flag. Beispiel: writing-hub. I2-Externprobe: `?demo=` ⇒ 404/disabled |
+| **`sunset_after` (Rev 11)** | Pflicht-Frontmatter-Datum für repo-lokale Klickdummy-ADRs; nach Frist ohne Extension ⇒ ADR auto-`deprecated`, Pfad archiviert |
 | **Parity-Test** | Renderer↔Implementierung-Äquivalenztest — Gate **und** Off-Ramp |
 | **Off-Ramp** | Parity-grün ⇒ mechanische Entfernung der statischen Quelle (Grenze: `min(prod-Release, Parity-grün + N d)`) |
 | **Adoption-Scoreboard** | Lebende SF1–SF6-Rollout-Metrik; **gatet `status` nicht** (Rev 9) |
@@ -199,7 +249,7 @@ Properties zu; Acceptance-Logik im Body.)
 
 ## Revisionshistorie
 
-Fünf Cascade-Adversarial-Pässe + Schema-/YAML-Härtung:
+Sechs Cascade-Adversarial-Pässe + Schema-/YAML-Härtung:
 
 - **Rev 1** — initial proposal
 - **Rev 2** (bf7c4d6) — Spec-first, Prod-Guard, Parity-Off-Ramp
@@ -211,10 +261,12 @@ Fünf Cascade-Adversarial-Pässe + Schema-/YAML-Härtung:
 - **Rev 8** — Frontmatter schema-konform (`review_history`/`acceptance_trigger` in Body; YAML-`date:`-Fix)
 - **Rev 9 (tiefer Adversarial-Pass)** — **F1/F2:** Entscheid ↔ Rollout entkoppelt (löst Acceptance-Deadlock + oszillierenden Status; C1–C6 → status-neutrales Adoption-Scoreboard). **F3:** I2 um plattform-externen, repo-unabhängigen Prod-Probe erweitert (Sicherheitsinvariante cross-repo verifizierbar statt per-Vertrauen). **F4:** I3 Off-Ramp-TTL `min(prod-Release, Parity-grün+N d)` (Dauer-Staging-Leck). **F5:** I4 → ADR-207 ausgelagert, `scope` entschlackt, „vier"→„drei Invarianten". **F6:** I1 bidirektionale Spec↔Route-Coverage statt Format-Existenz. **F7/F8** als offene Punkte dokumentiert.
 - **Rev 10** — **F5 zurückgenommen:** ADR-207 ist Doku-Strategie/Ingest-Trichter (eine Doku-Wahrheit pro Repo, MD>PDF>docx, inbox-Trichter) — **nicht** Cross-Repo-ADR-Namensraum. Die I4-Auslagerung war thematische Fehl-Zuordnung. **I4 zurück in ADR-211** (klickdummy-skopiert; eine plattformweite Verallgemeinerung wäre ein eigener ADR, nicht ADR-207). `depends_on: []`, „drei"→„vier Invarianten" zurück, ADR-207 aus Verwandt/Bezug entfernt (war nur wegen F5 drin).
+- **Rev 11 (Bundle #228/#229; orthogonal zu Rev 10)** — **F9 (#229):** I2 von 2 → **4 scharf abgegrenzte Patterns** (`mock`/`stub-demo`/`story`/`spec-demo`) entlang *Datenquelle × Code-Pfad-Identität*. Jedes Pattern erhält eine **distinkte** I2-Externprobe (mock = N/A; sonst je eigene Route/Query). Vermeidet das Theater-Risiko des 4-Pattern-Splits, weil die *Enforcement* je Pattern wirklich anders ist (siehe Glossar/Auswahlhilfe). **F10 (#228):** `sunset_after`-Pflicht-Frontmatter für repo-lokale Klickdummy-ADRs (nicht ADR-211 selbst); Phase-A bekommt damit einen *harten* Termin unabhängig von Parity. Auto-`deprecated` nach Frist, Extension via PR-Review. Enforcement-Script `adr_sunset.sh` als Scoreboard-Item S7; S8 = 4-Pattern-Konformität. I4 bleibt bestehen (Rev 10). **Offene Folge-Punkte:** (F11) `klickdummy_prod_guard.sh` muss pattern-spezifisch verzweigen (Issue #255 SF3-AC vor Bau anpassen); (F12) Migrations-Mapping bestehender Rev-≤10 `Demo-Render`-Repos auf eines der drei Nicht-`mock`-Patterns.
 
 ## Bezug
 
-- risk-hub:ADR-046 · writing-hub:ADR-180 · meiki-hub:ADR-020 (Implementierungen)
-- Followups `adr-211-followup` SF1–SF6 (Adoption-Scoreboard-Baseline 0/6, **nicht status-gatend**)
+- risk-hub:ADR-046 · writing-hub:ADR-180 · meiki-hub:ADR-020 (Implementierungen — Mapping auf Rev-11-Patterns in §Auswahlhilfe)
+- Followups `adr-211-followup` SF1–SF8 (Adoption-Scoreboard, **nicht status-gatend**) — S7/S8 neu durch Rev 11
+- Closes-on-acceptance: **#228** (sunset_after-Frontmatter, F10) und **#229** (4-Pattern-Taxonomie, F9). #255 SF3-AC muss vor Bau an pattern-spezifischen Prod-Guard angepasst werden (F11).
 - Drift-Memory `2026-05-19-klickdummy-adr180-collision` (meiki-hub-Auto-Memory, `drift: true`)
 - Policy `adr-threshold.md` (Selbsttest)


### PR DESCRIPTION
Rebase von #264 (Rev 10 Bundle F9/F10) auf den parallel auf main gelandeten F5-Rollback (I4 zurück, 'vier Invarianten'). **Beide Owner-Entscheidungen erhalten — orthogonal integriert, kein Vorgriff.**

## Was Rev 11 macht
- **F9 (#229):** I2 von 2 → 4 Patterns (`mock`/`stub-demo`/`story`/`spec-demo`); distinkte I2-Externprobe pro Pattern
- **F10 (#228):** `sunset_after` Pflicht-Frontmatter für repo-lokale Klickdummy-ADRs (ADR-211 selbst ausgenommen). Auto-`deprecated` nach Frist. Enforcement via `adr_sunset.sh`.
- **S7 + S8** im Adoption-Scoreboard (sunset enforcement + 4-Pattern-Konformität).
- **I4 bleibt erhalten** (Rev 10 F5-Rollback respektiert).

## Was Rev 11 NICHT ändert
- I1 (Spec↔Route-Coverage, Rev 9) — unverändert
- I4 (Namensraum, Rev 10 zurückgeholt) — unverändert
- ADR-207-Abhängigkeit — bleibt entfernt (Rev 10)

## Closes-on-acceptance
#228 (F10) und #229 (F9). #264 ist obsolet — schließe ich nach Annahme dieses PR.

## F11/F12 als offene Folge-Punkte dokumentiert
F11: `klickdummy_prod_guard.sh` muss pattern-spezifisch verzweigen (Issue #255 SF3-AC anpassen vor Bau). F12: Migrations-Mapping bestehender Rev-≤10 Demo-Render-Repos.

DRAFT, kein Auto-Merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)