### PR TITLE
[DRAFT] ADR-214 — Klickdummy Plattform-Heimat (Distribution + Endpoint)

### DIFF
--- a/docs/adr/ADR-214-klickdummy-plattform-heimat.md
+++ b/docs/adr/ADR-214-klickdummy-plattform-heimat.md
@@ -1,0 +1,343 @@
+---
+id: ADR-214
+title: Klickdummy Plattform-Heimat — Distribution & Feedback-Endpoint
+status: proposed
+date: 2026-05-20
+deciders: [achim]
+informed: [all-repos-with-klickdummy]
+domains: [klickdummy, distribution, services, cross-repo]
+supersedes: []
+extends: [platform:ADR-211]
+depends_on: []
+tags: [klickdummy, distribution, plattform-heimat]
+scope:
+  include_paths:
+    - "packages/iil-klickdummy/**"
+    - "snippets/klickdummy/**"
+    - "schemas/klickdummy/**"
+    - "scripts/checks/klickdummy_*.sh"
+    - "services/feedback-bridge/**"
+---
+
+# ADR-214: Klickdummy Plattform-Heimat — Distribution & Feedback-Endpoint
+
+- **Status:** proposed *(2026-05-20)*
+- **Datum:** 2026-05-20
+- **Entscheider:** Achim Dehnert
+- **Verwandt:** platform:ADR-211 (Rev 12, accepted — Konvention) ← dieser ADR ergänzt um Mechanik
+- **Empiriebasis:** meiki-hub PR #23 (7 Iterationen), Cross-Repo-Migrationsrunde 2026-05-20 (writing-hub#21, risk-hub#125, platform#272, meiki-hub#21/#23/#24)
+
+## Zusammenfassung
+
+`platform:ADR-211` Rev 12 etablierte als Konvention zwei optionale Capabilities
+(Co-Creation-Loop, Requirements-Bridge) und markierte ihre Plattform-Heimat als
+„Best-Effort, kein Termin". Mit **ttz-hub** als 6. Repo + dem expliziten
+Anspruch *„permanente Weiterentwicklung wirkt cross-repo"* wird die Frage der
+Verteilung verbindlich.
+
+Drei harte Entscheidungen:
+
+1. **Hybrid-Distribution (E1).** Python-Code + Schemas via **pip-Paket**
+   `iil-klickdummy`; HTML-Snippets + Templates via **Git-Submodul**
+   `platform-snippets`; lokale Workflows ergänzend via **Symlink-Mechanik**
+   (Bestand aus ADR-211 Rev 5).
+2. **Zentraler Feedback-Endpoint (E2).** `feedback.iil.pet` (FastAPI o. ä.)
+   nimmt Co-Creation-Loop-Payloads entgegen und erzeugt Issues im jeweiligen
+   Repo via GitHub-API. Erkennung per Origin-Header und Repo-Token; ein
+   Audit-Pfad, eine Wartungs-Stelle.
+3. **Eigenständiges ADR (E3).** Nicht als ADR-211 Rev 13, weil
+   Distributions-Mechanik orthogonal zur Spec-Konvention ist und Future-
+   Challenger den Trade-Off (Submodul vs. pip vs. Symlink) klar lesen
+   können soll. ADR-214 referenziert ADR-211 als `extends:`.
+
+## Kontext
+
+Aktueller Stand (post platform#272, 2026-05-20):
+
+- **5 Repos** haben Klickdummy-Code-Pfade: meiki-hub, writing-hub, risk-hub
+  (aktiv); pptx-hub, dev-hub (N/A). **ttz-hub** kommt jetzt als 6. dazu.
+- **Schemas + Skripte sind kopiert**, nicht geteilt: meiki-hub und writing-hub
+  haben je eigene `screens-spec.schema.json`, `check_i1..i4.py`,
+  `extract_requirements.py`. Iteration in einem Repo ist nicht in den anderen
+  sichtbar (Drift-Risiko und manueller Re-Sync).
+- **Widget-Code (≈290 LOC HTML+CSS+JS) lebt in meiki shell.html**. Bei
+  Adoption in anderen Repos: copy-paste — und damit nicht in Co-Evolution.
+- **Feedback-Endpoint existiert nicht.** Pfad A läuft heute „light"
+  (Download → Inbox → Mensch); für die in ADR-211 Rev 12 §Co-Creation
+  beschriebene Aktivierung (≥ 1 Mode ≠ download) fehlt der Server-Teil.
+
+Wenn weitergebaut wird ohne Heimat:
+
+- **Drift-Cascade**: jede Iteration in meiki-hub muss in 5 Repos nachgezogen
+  werden (Iter. 7 hat das beim Type-Wechsel mock-prototyp → mock real gezeigt:
+  5 PRs für eine konzeptuelle Änderung).
+- **Adoption-Friction**: ttz-hub müsste copy-paste klonen statt installieren.
+- **Co-Creation-Loop bleibt unbenutzbar** im Stakeholder-Sinn ohne Endpoint
+  (Pfad A „vollständig" laut ADR-211 Rev 12 §Co-Creation Aktivierungs-
+  Bedingung 4: `feedback_loop.path: A | B`).
+
+## Entscheidung — drei Bausteine
+
+### E1 · Distribution: Hybrid (pip + Submodul + Symlink)
+
+| Material | Wo | Wie distribuiert |
+|---|---|---|
+| **Python-Code** (`check_i1..i4.py`, `extract_requirements.py`, S11-Inventur) | `platform/packages/iil-klickdummy/` | **pip-Paket** mit semver; Repos installieren `pip install iil-klickdummy>=1.0,<2.0` |
+| **JSON-Schemas** (`screens-spec.schema.json`, `feedback-payload.schema.json`, `module-manifest.schema.json`) | `iil-klickdummy/schemas/` (Paket-Resource) | mitversendet im pip-Paket; Repos referenzieren via `importlib.resources` oder `$ref` zu Paket-URL |
+| **HTML-Snippets** (Widget CSS+HTML+JS, Spec-Template, Issue-Template) | `platform/snippets/klickdummy/` | **Git-Submodul** pro Repo `platform-snippets/`; via `<script src="platform-snippets/klickdummy/feedback-widget.js">` |
+| **Lokale Convention-Pfade** (z. B. `~/.claude/policies/klickdummy.md`) | platform-Worktree | **Symlink** (Bestand aus ADR-211 Rev 5, unverändert) |
+
+**Begründung Hybrid statt nur-pip oder nur-Submodul:**
+
+- **pip** ist Standardweg für Python-Code+Schemas (Versionierung, CI-Reproduzierbarkeit, semver-Pinning). HTML-Snippets in pip-Paket sind „gegen die Norm" (Browser läuft kein pip).
+- **Submodul** ist Standardweg für serverseitig-statische HTML-Assets (Build-Inline oder Direct-Reference). Für reinen Python-Code ist Submodul Overhead.
+- **Symlink-Mechanik** für lokale Workflows (Convention-Dateien, gepinnter Worktree) hat sich in ADR-211 Rev 5 bewährt und bleibt unverändert.
+
+### E2 · Feedback-Endpoint: zentral (`feedback.iil.pet`)
+
+**Architektur:**
+
+```
+[Klickdummy-Widget im Browser]
+       │  POST /v1/issues
+       │  Body: { payload, markdown }
+       │  Header: Origin: <repo-domain>
+       ▼
+[feedback.iil.pet]  (FastAPI, klein, stateless)
+       │  1. Origin → Repo-Mapping (Konfig in platform-Repo)
+       │  2. Repo-Token aus Secrets (GitHub App ODER PAT)
+       │  3. GitHub API: POST /repos/<repo>/issues
+       │     Label: klickdummy-feedback
+       │     Body: markdown (vom Widget vorgeformt)
+       ▼
+[GitHub Issue im jeweiligen Repo]
+       │
+       ▼
+[Coding-Agent (Watcher auf Label)] → Diff-PR
+```
+
+**Sicherheit:**
+
+- **Rate-Limit** pro Origin (z. B. 20 Issues/h/Origin) — Spam-Schutz
+- **CSRF**: Origin-Header-Allowlist, kein `*`-CORS
+- **Audit-Log** pro Issue (Origin, Timestamp, Payload-Hash) — getrennt von Issue-Content
+- **PII-Filter** vor Issue-Erstellung (Heuristik: E-Mail, Telefon, IBAN; mark
+  `payload_redacted: true` in Issue-Frontmatter)
+- **Repo-Allowlist** in Service-Config (kein Wildcard) — verhindert
+  Hijack-Issues auf fremde Repos
+
+**Datenschutz-Pfad für Gov-Workloads (ttz-hub-Besonderheit):**
+
+ttz-hub ist `ttz-lif`-Org (Government / Public-Sector mit Data-Sovereignty-
+Regeln). Default ist **zentral**; ttz-hub kann jedoch via Konfiguration
+einen **eigenen Repo-Endpoint** überschreiben (GitHub Action Webhook im
+ttz-hub-Repo). Mechanik:
+
+```html
+<!-- ttz-hub/klickdummy/shell.html: -->
+<script>
+  window.KLICKDUMMY_FEEDBACK_ENDPOINT = "https://ttz-feedback.ttz-lif.de/v1";
+</script>
+```
+
+→ Repo-Override > Platform-Default. Doku-Empfehlung pro Gov-Repo in
+ADR-214 §Migrations-Cookbook.
+
+### E3 · ADR-Strategie: ADR-214 statt ADR-211 Rev 13
+
+Begründung:
+
+| Argument | für ADR-214 (eigenständig) | für ADR-211 Rev 13 (Aufladung) |
+|---|---|---|
+| **Orthogonalität** | Distributions-Mechanik ≠ Spec-Konvention | hält alles zusammen |
+| **Future-Challenger** | sieht 1 ADR pro Frage — Submodul-vs-pip-vs-Symlink getrennt diskutierbar | muss durch alles scrollen |
+| **Revisionierbarkeit** | ADR-214 Rev 2 möglich, ohne ADR-211 anzufassen | jede Mechanik-Änderung = ADR-211 Rev N+1 |
+| **adr-threshold.md** | „new external dependency or service boundary" → ADR-Pflicht | umgeht den Threshold |
+
+→ **ADR-214 eigenständig.** Referenziert ADR-211 als `extends:`, schließt
+keine Frage von dort, erweitert nur die Mechanik.
+
+## Plattform-Bausteine konkret
+
+### Paket `iil-klickdummy` (Python)
+
+```
+platform/packages/iil-klickdummy/
+├── pyproject.toml                          # name=iil-klickdummy, version=1.0.0
+├── README.md
+├── src/iil_klickdummy/
+│   ├── __init__.py
+│   ├── check_i1.py                         # Spec ↔ Route Coverage
+│   ├── check_i2.py                         # 4-Pattern + Strict-Mode (LEGACY={})
+│   ├── check_i3.py                         # Off-Ramp + Sunset
+│   ├── check_i4.py                         # Cross-Repo-Ref-Format
+│   ├── extract_requirements.py             # Spec → UC/FR/NFR/Lasten/Pflicht
+│   ├── inventory.py                        # S11 Cross-Repo Legacy-Inventur
+│   └── schemas/                            # importlib.resources
+│       ├── screens-spec.schema.json
+│       ├── feedback-payload.schema.json
+│       └── module-manifest.schema.json
+└── tests/
+    ├── test_check_i1_2_3_4.py
+    ├── test_extract_requirements.py
+    └── fixtures/                            # Beispiel-Specs
+```
+
+**Versionierung:** semver. Repos pinnen `>=1.0,<2.0` (kompatibel innerhalb
+Major). Breaking Changes (z. B. Pattern-Set ändern) → Major-Bump → ADR-Update.
+
+**Distribution:** initial via `pip install -e ../platform/packages/iil-klickdummy`
+(Workspace-Pattern); später PyPI (öffentlich oder privat `pypi.iil.pet`).
+
+### Submodul `platform-snippets`
+
+```
+platform/snippets/klickdummy/
+├── feedback-widget/
+│   ├── widget.html                          # FAB + Panel-Markup
+│   ├── widget.css
+│   └── widget.js                            # fbToggle, fbSubmit, etc.
+├── issue-template/
+│   └── klickdummy-feedback.md
+├── spec-templates/
+│   ├── screens-spec-template.yaml
+│   └── module-manifest-template.json
+└── shell-bootstrap/
+    └── inject-widget.html                   # 3-Zeilen-Snippet zum Include
+```
+
+**Verteilung:** jeder Repo macht `git submodule add … platform-snippets`.
+`KLICKDUMMY_FEEDBACK_ENDPOINT` ist Konfigurations-Variable, nicht im Snippet
+hardcoded.
+
+### Service `feedback-bridge`
+
+```
+platform/services/feedback-bridge/
+├── pyproject.toml
+├── src/feedback_bridge/
+│   ├── main.py                              # FastAPI
+│   ├── github_client.py                     # GitHub API Wrapper
+│   ├── pii_filter.py                        # E-Mail/Tel/IBAN-Heuristik
+│   ├── audit.py                             # JSON-Lines-Log
+│   └── config.py                            # Origin→Repo-Mapping, Allowlist
+├── Dockerfile
+├── deployment/
+│   ├── docker-compose.yml                   # für staging/prod
+│   └── traefik.yml                          # via ADR-212 Ingress
+└── tests/
+```
+
+**Deployment:** via Traefik-Ingress (ADR-212) auf `feedback.iil.pet`.
+**Im Rahmen dieses ADR nur Skelett**; eigentliches Deployment ist
+**separater Infra-PR** nach ADR-214-Annahme.
+
+### Skript `klickdummy_legacy_class_inventory.sh`
+
+```
+platform/scripts/checks/klickdummy_legacy_class_inventory.sh
+```
+
+Ist die Migration zur **shared Library** als `python3 -m iil_klickdummy.inventory`.
+Bash-Bootstrap aus ADR-211 Rev 12 §Migration bleibt als Fallback erhalten.
+
+## Migrations-Cookbook (5 Repos)
+
+Pro Repo, ~30 Min:
+
+1. **pip-Pin in `requirements-dev.txt`** (oder `pyproject.toml`):
+   `iil-klickdummy>=1.0,<2.0`
+2. **Submodul hinzufügen:**
+   `git submodule add git@github.com:achimdehnert/platform-snippets ... platform-snippets`
+3. **Makefile aktualisieren** — alte Targets aus `scripts/klickdummy/check_iN.py`
+   auf `python3 -m iil_klickdummy.check_iN ...` umstellen.
+4. **shell.html aktualisieren** — Widget-Inline-Code entfernen, durch
+   `<script src="platform-snippets/klickdummy/feedback-widget/widget.js">` ersetzen.
+   Konfiguration: `window.KLICKDUMMY_FEEDBACK_ENDPOINT = "https://feedback.iil.pet/v1/issues";`
+5. **Lokale Kopien deprecaten** — `scripts/klickdummy/` → `scripts/klickdummy.deprecated/`
+   mit README, das auf `iil-klickdummy` verweist. Nach 30 Tagen löschen.
+6. **CI testen** — `make klickdummy` muss grün bleiben.
+7. **Provenance-Eintrag** (falls Co-Creation aktiviert): „Migration auf
+   Plattform-Heimat (ADR-214)".
+
+**ttz-hub (Erst-Adoption):** identisch Schritt 1+2+3+4, plus:
+- Repo-lokales `ADR-XXX-klickdummy-ttz.md` mit `class:`, `sunset_after:`,
+  `conforms_to: platform:ADR-211`, `tags:[klickdummy]`
+- Mindestens 1 `screens-spec.yaml` (auch leer mit nur `class:` + 1 Screen)
+- **Datenschutz-Override** (Gov-Workload): eigenen Endpoint setzen statt
+  Platform-Default. ADR-214 §E2-Datenschutz dokumentiert das.
+
+## Konsequenzen
+
+**Positiv:**
+- **1 Quelle für alle Klickdummy-Mechanik**: jede Iteration in `iil-klickdummy`
+  wirkt cross-repo nach `pip install --upgrade` (oder Submodul `git pull`).
+- **Adoption-Friction für ttz-hub von ~2 Tage auf ~30 Min**: pip + Submodul
+  + Mini-ADR statt copy-paste-clone.
+- **Co-Creation-Loop wird real aktivierbar**: Endpoint existiert → Pfad A
+  vollständig.
+- **Versions-Pinning**: Repos können auf `iil-klickdummy==1.2.0` bleiben,
+  wenn sie noch nicht zu `1.3.0` migrieren wollen (semver-Verträglichkeit).
+
+**Negativ / Kosten:**
+- **Submodul-Komplexität**: 6 Repos müssen `git submodule update`
+  routinemäßig laufen lassen (Submodul-Fatigue). Mitigation: Makefile-Target
+  `make install` macht das transparent; CI macht das auf jedem Build.
+- **Endpoint-Wartung**: 1 zusätzlicher Service (`feedback.iil.pet`). Klein,
+  aber 24/7 verfügbar nötig (sonst Fallback auf Download-Mode).
+- **PII-Filter im Endpoint**: Heuristik ist nie perfekt. Mitigation:
+  `payload_redacted`-Flag transparent; Gov-Workloads (ttz-hub) nutzen
+  Repo-Override.
+- **Migrations-Aufwand**: 5 Repos × 30 Min = ~2.5 h einmalig.
+
+**Offen / Folge-Punkte:**
+- **F1 (ADR-214)**: PyPI-Hosting — initial Workspace-pip, später public PyPI
+  oder privater Index? Entscheidung in `pyproject.toml`-PR.
+- **F2 (ADR-214)**: GitHub-App vs. PAT für Endpoint-Repo-Auth? GitHub-App
+  ist sauberer (Repo-Scope, fine-grained), aber Setup-Aufwand höher. Empfehlung:
+  Start mit PAT (1 Bot-Account), Migration auf App in Rev 2.
+- **F3 (ADR-214)**: Submodul-Branch — `main` oder eigener `release`-Branch?
+  Empfehlung: `main` (semver-disziplin im pip-Paket trägt; Snippets sind
+  rückwärts-kompatibel zu halten).
+
+## Adversarial-Self-Check (Pre-Review)
+
+| Frage | Antwort |
+|---|---|
+| Schafft Hybrid mehr Komplexität als Mehrwert? | Komplexität ist real (2 Mechanismen), aber Mehrwert ist groß (pip-Versionierung für Code, Submodul-Direkt-Reference für HTML). Reine pip-Lösung mit `importlib.resources` für HTML wäre möglich, aber Browser-Build dann ungewohnt. |
+| Single-Point-of-Failure beim zentralen Endpoint? | Ja. Mitigation: Widget hat Fallback auf Download-Mode bei Endpoint-down (`fbSubmit('download')` automatisch). Endpoint-Downtime = degradiertes Co-Creation, nicht Klickdummy-Ausfall. |
+| Wer ist Owner des `iil-klickdummy`-Pakets? | platform-Repo-Maintainer. Releases via GitHub-Releases + (später) PyPI-publish-Workflow. |
+| Was passiert, wenn Endpoint missbraucht wird (Spam, malicious issues)? | Rate-Limit + Origin-Allowlist + PII-Filter + Audit-Log + Repo-lokales `klickdummy-feedback`-Label kann gelöscht/blockiert werden. Coding-Agent reagiert nur auf Label. |
+| Macht der Endpoint die Architektur-Entscheidung „Pfad B verboten" obsolet? | Nein. Pfad B (Direkt-LLM) wäre `feedback.iil.pet` → LLM-Call (Endpoint-seitig, nicht Browser-seitig). Das ist eine künftige Erweiterung dieses Endpoints — bleibt per ADR-211 Rev 12 §Co-Creation an „plattformweite A-Adoption + LLM-Audit-Framework" geknüpft. |
+| Was wenn Repos `iil-klickdummy`-Major bumpen müssen (z. B. Pattern-Set ändert sich)? | semver-Disziplin: Major-Bump = Migrations-Cookbook im ADR (analog ADR-211 Rev 12 §Migration). Soft-Migrate-Pattern wiederverwendbar. |
+
+## Acceptance-Trigger
+
+`status` → `accepted`, sobald:
+1. Decider ratifizieren E1/E2/E3-Wahl.
+2. `iil-klickdummy`-Paket-Skelett gebaut + 1 Test grün.
+3. Mindestens **1 Pilot-Migration** (meiki-hub) erfolgreich (ohne Klickdummy-CI-Bruch).
+
+Adoption-Scoreboard `adr-214-followup` separat (analog ADR-211 SF1–SF11).
+
+## Revisionshistorie
+
+- **Rev 1 (proposed, 2026-05-20)** — Initial. Empirie-getrieben aus
+  meiki-Iter.-7-Migrationsrunde (5 PRs für 1 konzeptuelle Änderung) +
+  ttz-hub-Onboarding-Trigger. 3 Bausteine (pip-Paket, Submodul, Endpoint)
+  + 4 Adversarial-Self-Checks.
+
+## Bezug
+
+- **platform:ADR-211** (Rev 12, accepted) — Konvention, die dieser ADR mechanisch
+  unterlegt. Co-Creation §+Requirements-Bridge §+§Migration sind die Vorgabe.
+- **platform:ADR-212** (accepted) — Traefik-Ingress-Stack für *.iil.pet;
+  `feedback.iil.pet` deployt darüber.
+- **platform:ADR-213** (Rev 1) — Cross-Repo-ADR-Ref-Format (`repo:ADR-NNN`);
+  `iil-klickdummy.check_i4` setzt das durch.
+- **meiki-hub PR #23** — Empirie-Quelle (7 Iterationen).
+- **Cross-Repo-Migrationsrunde 2026-05-20** — writing-hub#21, risk-hub#125,
+  platform#272, meiki-hub#21/#23/#24 — belegt 5-PRs-pro-Konzeptänderung
+  ohne Plattform-Heimat.
+- **Policy `adr-threshold.md`** — Selbsttest bestanden: neue Service-
+  Boundary + Cross-Repo-Impact + non-trivial trade-off ⇒ eigenständiges ADR.

--- a/docs/adr/ADR-214-klickdummy-plattform-heimat.md
+++ b/docs/adr/ADR-214-klickdummy-plattform-heimat.md
@@ -37,10 +37,13 @@ Verteilung verbindlich.
 
 Drei harte Entscheidungen:
 
-1. **Hybrid-Distribution (E1).** Python-Code + Schemas via **pip-Paket**
-   `iil-klickdummy`; HTML-Snippets + Templates via **Git-Submodul**
-   `platform-snippets`; lokale Workflows ergänzend via **Symlink-Mechanik**
-   (Bestand aus ADR-211 Rev 5).
+1. **pip-Paket als alleinige Distribution (E1, revidiert).** Python-Code +
+   Schemas + (in v1.1) HTML-Snippets als `package_data` im **pip-Paket**
+   `iil-klickdummy` (initial via `pip install git+...`, später privates PyPI).
+   Lokale Convention-Workflows ergänzend via **Symlink-Mechanik** (Bestand
+   aus ADR-211 Rev 5). *Initial-Vorschlag „pip + Submodul" wurde im
+   adversarial Pass (J2) verworfen — Submodul auf platform/ würde das
+   ganze Repo ziehen.*
 2. **Zentraler Feedback-Endpoint (E2).** `feedback.iil.pet` (FastAPI o. ä.)
    nimmt Co-Creation-Loop-Payloads entgegen und erzeugt Issues im jeweiligen
    Repo via GitHub-API. Erkennung per Origin-Header und Repo-Token; ein
@@ -78,20 +81,35 @@ Wenn weitergebaut wird ohne Heimat:
 
 ## Entscheidung — drei Bausteine
 
-### E1 · Distribution: Hybrid (pip + Submodul + Symlink)
+### E1 · Distribution: pip-Paket (Python + HTML als package_data) + Symlink
+
+**Initial-Vorschlag war Hybrid pip+Submodul. Im adversarial Pass (J2) wurde
+gezeigt:** ein Git-Submodul auf `platform/snippets/` würde das ganze
+platform-Repo (hunderte MB) in jeden Klickdummy-Repo ziehen — sparse-Checkout
+ist fragil. **Vereinfachte E1:**
 
 | Material | Wo | Wie distribuiert |
 |---|---|---|
-| **Python-Code** (`check_i1..i4.py`, `extract_requirements.py`, S11-Inventur) | `platform/packages/iil-klickdummy/` | **pip-Paket** mit semver; Repos installieren `pip install iil-klickdummy>=1.0,<2.0` |
-| **JSON-Schemas** (`screens-spec.schema.json`, `feedback-payload.schema.json`, `module-manifest.schema.json`) | `iil-klickdummy/schemas/` (Paket-Resource) | mitversendet im pip-Paket; Repos referenzieren via `importlib.resources` oder `$ref` zu Paket-URL |
-| **HTML-Snippets** (Widget CSS+HTML+JS, Spec-Template, Issue-Template) | `platform/snippets/klickdummy/` | **Git-Submodul** pro Repo `platform-snippets/`; via `<script src="platform-snippets/klickdummy/feedback-widget.js">` |
+| **Python-Code** (`check_i1..i4.py`, `extract_requirements.py`, S11-Inventur) | `platform/packages/iil-klickdummy/src/iil_klickdummy/` | **pip-Paket** mit semver; Repos installieren `pip install "iil-klickdummy @ git+https://github.com/achimdehnert/platform.git@v1.0.0#subdirectory=packages/iil-klickdummy"` (F1 geschlossen: Git-URL statt PyPI in v1) |
+| **JSON-Schemas** (`screens-spec.schema.json`, `feedback-payload.schema.json`, `module-manifest.schema.json`) | `iil_klickdummy/schemas/` | `package_data` im pip-Paket; Zugriff via `importlib.resources.files("iil_klickdummy.schemas")` ODER `$ref` zu Paket-URL in Spec-Files |
+| **HTML-Snippets** (Widget CSS+HTML+JS, Spec-Template, Issue-Template) | `iil_klickdummy/snippets/` (in v1.1) | `package_data` im pip-Paket; Repo-Makefile hat `make klickdummy-install-snippets` Target, das via Python aus dem Paket nach `<repo>/platform-snippets/` kopiert/symlinkt |
 | **Lokale Convention-Pfade** (z. B. `~/.claude/policies/klickdummy.md`) | platform-Worktree | **Symlink** (Bestand aus ADR-211 Rev 5, unverändert) |
 
-**Begründung Hybrid statt nur-pip oder nur-Submodul:**
+**Begründung pip-only statt pip+Submodul:**
 
-- **pip** ist Standardweg für Python-Code+Schemas (Versionierung, CI-Reproduzierbarkeit, semver-Pinning). HTML-Snippets in pip-Paket sind „gegen die Norm" (Browser läuft kein pip).
-- **Submodul** ist Standardweg für serverseitig-statische HTML-Assets (Build-Inline oder Direct-Reference). Für reinen Python-Code ist Submodul Overhead.
-- **Symlink-Mechanik** für lokale Workflows (Convention-Dateien, gepinnter Worktree) hat sich in ADR-211 Rev 5 bewährt und bleibt unverändert.
+- **Ein Mechanismus** statt zwei (Vereinfachung).
+- **Keine Submodul-Fatigue** in 6 Repos.
+- HTML in `package_data` ist **idiomatisches Python**, kein „gegen die Norm"
+  (Beispiele: `pip-tools`, `django`, `flask`-templates verteilen HTML so).
+- Repos können die Snippets nach `<repo>/platform-snippets/` **kopieren**
+  ODER **symlinken** (Wahl pro Repo) — Snippet-Updates via `pip install --upgrade`.
+
+**Konsequenz für Snippet-Standort:** In Rev 1 dieses ADR liegen
+Widget/Templates noch unter `platform/snippets/klickdummy/` (für historische
+Sichtbarkeit). In v1.1 von `iil-klickdummy` wandern sie in `iil_klickdummy/
+snippets/` als `package_data` — ein eigener PR auf platform, kein
+Cross-Repo-Bruch (alte Snippet-Pfade werden parallel gehalten, bis alle
+Repos auf v1.1 sind; Soft-Migrate-Pattern aus ADR-211 Rev 12).
 
 ### E2 · Feedback-Endpoint: zentral (`feedback.iil.pet`)
 
@@ -189,26 +207,31 @@ Major). Breaking Changes (z. B. Pattern-Set ändern) → Major-Bump → ADR-Upda
 **Distribution:** initial via `pip install -e ../platform/packages/iil-klickdummy`
 (Workspace-Pattern); später PyPI (öffentlich oder privat `pypi.iil.pet`).
 
-### Submodul `platform-snippets`
+### Snippets (HTML/CSS/JS) — initial in `platform/snippets/`, ab v1.1 in pip-Paket
+
+**v1.0 (jetzt):** in `platform/snippets/klickdummy/` (Repo-Sichtbarkeit).
+Repos kopieren manuell oder via `curl`-Skript.
+
+**v1.1 (geplant):** als `package_data` im pip-Paket unter
+`iil_klickdummy/snippets/`. Repos erhalten sie automatisch via `pip install`;
+ein `make klickdummy-install-snippets`-Target kopiert/symlinkt nach
+`<repo>/platform-snippets/`.
 
 ```
-platform/snippets/klickdummy/
+snippets/klickdummy/                       # v1.0 Pfad (auf platform-Repo)
+└── (v1.1: iil_klickdummy/snippets/)       # package_data im pip-Paket
 ├── feedback-widget/
-│   ├── widget.html                          # FAB + Panel-Markup
-│   ├── widget.css
-│   └── widget.js                            # fbToggle, fbSubmit, etc.
+│   └── widget.js                          # selbstständig (CSS+HTML injiziert)
 ├── issue-template/
 │   └── klickdummy-feedback.md
 ├── spec-templates/
-│   ├── screens-spec-template.yaml
-│   └── module-manifest-template.json
+│   └── screens-spec-template.yaml
 └── shell-bootstrap/
-    └── inject-widget.html                   # 3-Zeilen-Snippet zum Include
+    └── inject-widget.html                 # 3-Zeilen-Snippet zum Include
 ```
 
-**Verteilung:** jeder Repo macht `git submodule add … platform-snippets`.
-`KLICKDUMMY_FEEDBACK_ENDPOINT` ist Konfigurations-Variable, nicht im Snippet
-hardcoded.
+`KLICKDUMMY_FEEDBACK_ENDPOINT` und `KLICKDUMMY_SPEC` sind Konfigurations-
+Variablen vom Host gesetzt — nicht im Snippet hardcoded.
 
 ### Service `feedback-bridge`
 
@@ -245,33 +268,51 @@ Bash-Bootstrap aus ADR-211 Rev 12 §Migration bleibt als Fallback erhalten.
 
 Pro Repo, ~30 Min:
 
-1. **pip-Pin in `requirements-dev.txt`** (oder `pyproject.toml`):
-   `iil-klickdummy>=1.0,<2.0`
-2. **Submodul hinzufügen:**
-   `git submodule add git@github.com:achimdehnert/platform-snippets ... platform-snippets`
-3. **Makefile aktualisieren** — alte Targets aus `scripts/klickdummy/check_iN.py`
-   auf `python3 -m iil_klickdummy.check_iN ...` umstellen.
+1. **pip-Install** in `requirements-dev.txt`:
+   ```
+   iil-klickdummy @ git+https://github.com/achimdehnert/platform.git@v1.0.0#subdirectory=packages/iil-klickdummy
+   ```
+   (Sobald privates PyPI: `iil-klickdummy>=1.0,<2.0`.)
+2. **Makefile aktualisieren** — alte Targets aus `scripts/klickdummy/check_iN.py`
+   auf `klickdummy-i1` (Console-Script) oder `python3 -m iil_klickdummy.check_iN`
+   umstellen.
+3. **Snippets installieren** — `make klickdummy-install-snippets` (kopiert
+   aus pip-Paket nach `<repo>/platform-snippets/`). In v1.0 Übergangs-
+   Vorgehen: snippets aus `platform/snippets/klickdummy/` per `curl` o. ä.
+   ziehen; ab v1.1 via `iil_klickdummy.snippets`-Resource.
 4. **shell.html aktualisieren** — Widget-Inline-Code entfernen, durch
-   `<script src="platform-snippets/klickdummy/feedback-widget/widget.js">` ersetzen.
-   Konfiguration: `window.KLICKDUMMY_FEEDBACK_ENDPOINT = "https://feedback.iil.pet/v1/issues";`
-5. **Lokale Kopien deprecaten** — `scripts/klickdummy/` → `scripts/klickdummy.deprecated/`
+   3-Zeilen-Bootstrap ersetzen (`platform-snippets/klickdummy/shell-bootstrap/
+   inject-widget.html`). Konfiguration:
+   ```js
+   window.KLICKDUMMY_SPEC = { id: "repo:klickdummy-spec-<name>", version: "0.1", klickdummy_class: "mock" };
+   window.KLICKDUMMY_FEEDBACK_ENDPOINT = "https://feedback.iil.pet/v1/issues";
+   ```
+5. **Issue-Template kopieren** nach `.github/ISSUE_TEMPLATE/klickdummy-feedback.md`
+   (aus pip-Paket-Resource oder direkt aus `platform/snippets/.../issue-template/`).
+6. **Coding-Agent-Watcher** (per F4 in v1: GitHub Action) — falls
+   Co-Creation aktiviert: `.github/workflows/klickdummy-feedback-watcher.yml`
+   anlegen, triggert auf `labeled:klickdummy-feedback`.
+7. **Lokale Kopien deprecaten** — `scripts/klickdummy/` → `scripts/klickdummy.deprecated/`
    mit README, das auf `iil-klickdummy` verweist. Nach 30 Tagen löschen.
-6. **CI testen** — `make klickdummy` muss grün bleiben.
-7. **Provenance-Eintrag** (falls Co-Creation aktiviert): „Migration auf
-   Plattform-Heimat (ADR-214)".
+8. **CI testen** — `make klickdummy` muss grün bleiben.
+9. **Provenance-Eintrag** (falls Co-Creation aktiviert): „Migration auf
+   Plattform-Heimat (platform:ADR-214)".
 
-**ttz-hub (Erst-Adoption):** identisch Schritt 1+2+3+4, plus:
+**ttz-hub (Erst-Adoption):** identisch Schritt 1+2+3+4+5+8, plus:
 - Repo-lokales `ADR-XXX-klickdummy-ttz.md` mit `class:`, `sunset_after:`,
   `conforms_to: platform:ADR-211`, `tags:[klickdummy]`
-- Mindestens 1 `screens-spec.yaml` (auch leer mit nur `class:` + 1 Screen)
-- **Datenschutz-Override** (Gov-Workload): eigenen Endpoint setzen statt
-  Platform-Default. ADR-214 §E2-Datenschutz dokumentiert das.
+- Mindestens 1 `screens-spec.yaml` (auch minimal — Template unter
+  `platform/snippets/klickdummy/spec-templates/screens-spec-template.yaml`).
+- **Datenschutz-Override (Gov-Workload, Pflicht):** eigenen Endpoint setzen
+  statt Platform-Default. PII-Filter im zentralen Endpoint ist Best-Effort
+  (F6) — Gov-Repos müssen sich nicht darauf verlassen.
 
 ## Konsequenzen
 
 **Positiv:**
 - **1 Quelle für alle Klickdummy-Mechanik**: jede Iteration in `iil-klickdummy`
-  wirkt cross-repo nach `pip install --upgrade` (oder Submodul `git pull`).
+  wirkt cross-repo nach `pip install --upgrade` (v1.0 via Git-URL, v1.1+
+  via privates PyPI sobald aufgesetzt).
 - **Adoption-Friction für ttz-hub von ~2 Tage auf ~30 Min**: pip + Submodul
   + Mini-ADR statt copy-paste-clone.
 - **Co-Creation-Loop wird real aktivierbar**: Endpoint existiert → Pfad A
@@ -280,9 +321,9 @@ Pro Repo, ~30 Min:
   wenn sie noch nicht zu `1.3.0` migrieren wollen (semver-Verträglichkeit).
 
 **Negativ / Kosten:**
-- **Submodul-Komplexität**: 6 Repos müssen `git submodule update`
-  routinemäßig laufen lassen (Submodul-Fatigue). Mitigation: Makefile-Target
-  `make install` macht das transparent; CI macht das auf jedem Build.
+- **pip-via-Git-URL** in v1: `pip install` braucht Git-Zugang zur platform-
+  Repo-URL (öffentlich oder per SSH-Schlüssel in CI). Mitigation: dokumentiert
+  im Migrations-Cookbook; ab privates PyPI verschwindet das.
 - **Endpoint-Wartung**: 1 zusätzlicher Service (`feedback.iil.pet`). Klein,
   aber 24/7 verfügbar nötig (sonst Fallback auf Download-Mode).
 - **PII-Filter im Endpoint**: Heuristik ist nie perfekt. Mitigation:
@@ -290,15 +331,42 @@ Pro Repo, ~30 Min:
   Repo-Override.
 - **Migrations-Aufwand**: 5 Repos × 30 Min = ~2.5 h einmalig.
 
-**Offen / Folge-Punkte:**
-- **F1 (ADR-214)**: PyPI-Hosting — initial Workspace-pip, später public PyPI
-  oder privater Index? Entscheidung in `pyproject.toml`-PR.
-- **F2 (ADR-214)**: GitHub-App vs. PAT für Endpoint-Repo-Auth? GitHub-App
-  ist sauberer (Repo-Scope, fine-grained), aber Setup-Aufwand höher. Empfehlung:
-  Start mit PAT (1 Bot-Account), Migration auf App in Rev 2.
-- **F3 (ADR-214)**: Submodul-Branch — `main` oder eigener `release`-Branch?
-  Empfehlung: `main` (semver-disziplin im pip-Paket trägt; Snippets sind
-  rückwärts-kompatibel zu halten).
+**Distributions-Mechanik konkret (vor Acceptance entschieden):**
+
+- **F1 GESCHLOSSEN — Paket-Distribution via `pip install git+...`** statt
+  PyPI in v1. `pip install "iil-klickdummy @ git+https://github.com/achimdehnert/platform.git@main#subdirectory=packages/iil-klickdummy"`
+  funktioniert ohne PyPI-Infra; semver via Git-Tags (`v1.0.0`, `v1.1.0`).
+  Migration auf privates PyPI (`pypi.iil.pet`) wenn aufgesetzt — eigenes
+  Adoption-ADR/Rev, nicht Voraussetzung für Rev 1.
+- **F2 (ADR-214)**: GitHub-App vs. PAT für Endpoint-Repo-Auth — Start mit
+  PAT (1 Bot-Account), Migration auf App in Rev 2. Empfehlung steht.
+- **F3 GESCHLOSSEN — HTML-Snippets via pip-Paket statt Submodul.**
+  Initiale E1-Hybrid-Wahl wurde im adversarial Pass revidiert (J2): Submodul
+  auf `platform/snippets/` zieht ganzes platform-Repo (hunderte MB ohne
+  sparse-Checkout). **Saubere Lösung:** HTML/JS/CSS-Snippets sind
+  `package_data` im pip-Paket; Repos installieren via `pip install` und
+  bekommen die Resources über `importlib.resources`. Ein `make
+  klickdummy-install-snippets`-Target kopiert/symlinkt sie in den
+  Repo-Pfad `platform-snippets/` (oder direkt in `shell.html`-Pfad).
+  → **E1 wird vereinfacht: nur pip-Paket** (Python + HTML+CSS+JS als
+  Resources). Symlink-Mechanik (ADR-211 Rev 5) bleibt unverändert für
+  Convention-Dateien.
+- **F4 (ADR-214)**: Coding-Agent-Watcher — der Endpoint legt Issues mit
+  Label `klickdummy-feedback`. **Wer reagiert?** Pro Rev 1: **GitHub Action
+  pro Repo** (`.github/workflows/klickdummy-feedback-watcher.yml`), die
+  bei Issue-Open mit dem Label einen Coding-Agent triggert (z. B. via
+  Claude-Code-Action). Ein zentraler Cross-Repo-Watcher wäre Rev 2.
+- **F5 (ADR-214)**: Rate-Limit-Skalierung — in-memory ist v1
+  (single-replica). Multi-Replica via Redis o. ä. → Rev 2 + Infra-PR.
+- **F6 (ADR-214)**: PII-Filter ist **Best-Effort-Heuristik**, KEIN
+  DSGVO-konformer Anonymisierer. Gov-Workloads (`ttz-hub`) MÜSSEN
+  Repo-Endpoint-Override nutzen (siehe §E2-Datenschutz). Doku-Pflicht im
+  ttz-hub-Klickdummy-ADR.
+- **F7 (ADR-214)**: Snippet-Templating — `REPO:klickdummy-spec-NAME`-
+  Placeholder im `inject-widget.html` ist kein echtes Build-System.
+  Migrations-Cookbook beschreibt: Repo führt `sed`/`envsubst`-Schritt im
+  `make install`-Target aus, oder kopiert den Snippet und ersetzt manuell.
+  Build-System (z. B. Jinja2-Render) als optionale Erweiterung in Rev 2.
 
 ## Adversarial-Self-Check (Pre-Review)
 
@@ -324,8 +392,25 @@ Adoption-Scoreboard `adr-214-followup` separat (analog ADR-211 SF1–SF11).
 
 - **Rev 1 (proposed, 2026-05-20)** — Initial. Empirie-getrieben aus
   meiki-Iter.-7-Migrationsrunde (5 PRs für 1 konzeptuelle Änderung) +
-  ttz-hub-Onboarding-Trigger. 3 Bausteine (pip-Paket, Submodul, Endpoint)
-  + 4 Adversarial-Self-Checks.
+  ttz-hub-Onboarding-Trigger. 3 Bausteine (pip-Paket, Snippets, Endpoint)
+  + 6 Adversarial-Self-Checks.
+- **Rev 1 adversarial Pass (2026-05-20)** — 6 Findings eingearbeitet vor
+  Decider-Review:
+  - **J1 (🔴):** F1 (Distributions-Mechanik) geschlossen — pip via
+    `git+https://...@v1.0.0#subdirectory=...` statt PyPI in v1.
+  - **J2 (🔴):** Submodul-Ansatz für HTML-Snippets verworfen (würde ganzes
+    platform-Repo ziehen). **E1 vereinfacht zu pip-only mit `package_data`**
+    für HTML/CSS/JS in v1.1.
+  - **J3 (🟡):** Coding-Agent-Watcher als F4 konkret: GitHub Action pro
+    Repo (`klickdummy-feedback-watcher.yml`); zentraler Cross-Repo-Watcher
+    in Rev 2.
+  - **J4 (🟡):** Rate-Limit als v1 single-replica markiert; Multi-Replica
+    via Redis als F5 in Rev 2.
+  - **J5 (🟡):** PII-Filter als „Best-Effort, KEIN DSGVO-konformer
+    Anonymisierer" deklariert (F6); Gov-Workloads (ttz-hub) MÜSSEN
+    Endpoint-Override nutzen.
+  - **J6 (🟡):** Snippet-Templating als F7 — Migrations-Cookbook
+    beschreibt `sed`/`envsubst`-Schritt; Build-System optional in Rev 2.
 
 ## Bezug
 

--- a/packages/iil-klickdummy/README.md
+++ b/packages/iil-klickdummy/README.md
@@ -1,0 +1,70 @@
+# `iil-klickdummy` — Shared Infrastructure for platform:ADR-211
+
+> **Versioniertes Python-Paket mit Schemas + Skripten für Klickdummy-Konformität
+> nach `platform:ADR-211` (Rev 12, accepted) und Plattform-Heimat-Mechanik nach
+> `platform:ADR-214`.**
+
+## Install
+
+```bash
+pip install iil-klickdummy>=1.0,<2.0
+```
+
+Workspace-Pattern (vor PyPI-Release):
+
+```bash
+pip install -e ../platform/packages/iil-klickdummy
+```
+
+## CLI
+
+Alle Targets als Console-Scripts verfügbar:
+
+```bash
+klickdummy-i1 docs/.../spec.yaml:docs/.../spec.schema.json
+klickdummy-i2 docs/.../spec.yaml:docs/.../spec.schema.json
+klickdummy-i3 docs/.../spec.yaml:docs/.../spec.schema.json
+klickdummy-i4 docs/                      # rekursiver Cross-Repo-Ref-Lint
+klickdummy-extract-requirements docs/.../spec.yaml
+klickdummy-inventory                     # S11 Cross-Repo Legacy-Inventur
+```
+
+Repo-Makefile kann wahlweise via `python3 -m` oder direkt aufrufen:
+
+```makefile
+klickdummy-i1:
+	klickdummy-i1 docs/01-architektur/mockups/<klickdummy>/spec.yaml:docs/.../spec.schema.json
+```
+
+## Schemas
+
+Verfügbar via `importlib.resources`:
+
+```python
+from importlib.resources import files
+import json
+
+schema_text = files("iil_klickdummy.schemas").joinpath("screens-spec.schema.json").read_text()
+schema = json.loads(schema_text)
+```
+
+Oder in `spec.yaml`:
+
+```yaml
+$schema: https://raw.githubusercontent.com/achimdehnert/platform/main/packages/iil-klickdummy/src/iil_klickdummy/schemas/screens-spec.schema.json
+```
+
+## Versionierung
+
+`semver`. Breaking Changes (z. B. Pattern-Set ändern) → Major-Bump → Migrations-
+Cookbook im ADR-Update (analog ADR-211 Rev 12 §Migration).
+
+| Version | Datum | Highlights |
+|---|---|---|
+| 1.0.0 | 2026-05-20 | Initial. Rev-11 4-Pattern strict, S11-Inventur, Requirements-Bridge. |
+
+## Bezug
+
+- `platform:ADR-211` Rev 12 — Konvention (was die Skripte prüfen)
+- `platform:ADR-214` — Mechanik (warum das Paket existiert)
+- `platform:ADR-213` — Cross-Repo-Ref-Format (was check_i4 prüft)

--- a/packages/iil-klickdummy/README.md
+++ b/packages/iil-klickdummy/README.md
@@ -6,11 +6,19 @@
 
 ## Install
 
+**v1.0 (jetzt):** via Git-URL (ADR-214 F1):
+
 ```bash
-pip install iil-klickdummy>=1.0,<2.0
+pip install "iil-klickdummy @ git+https://github.com/achimdehnert/platform.git@v1.0.0#subdirectory=packages/iil-klickdummy"
 ```
 
-Workspace-Pattern (vor PyPI-Release):
+**v1.1+ (sobald privates PyPI aufgesetzt):**
+
+```bash
+pip install "iil-klickdummy>=1.0,<2.0"
+```
+
+**Workspace-Pattern (Development):**
 
 ```bash
 pip install -e ../platform/packages/iil-klickdummy

--- a/packages/iil-klickdummy/pyproject.toml
+++ b/packages/iil-klickdummy/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "iil-klickdummy"
+version = "1.0.0"
+description = "Shared infrastructure for platform:ADR-211 Klickdummy conformance (I1-I4, Co-Creation, Requirements-Bridge)"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "Achim Dehnert", email = "achim.dehnert@iil.gmbh" }]
+keywords = ["klickdummy", "adr-211", "spec-driven-ui", "mockup", "requirements"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "pyyaml>=6.0",
+    "jsonschema>=4.0",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0", "pytest-cov>=4.0"]
+
+[project.urls]
+"Homepage" = "https://github.com/achimdehnert/platform"
+"ADR-211" = "https://github.com/achimdehnert/platform/blob/main/docs/adr/ADR-211-klickdummy-benutzeranforderungen-entwicklungsprozess.md"
+"ADR-214" = "https://github.com/achimdehnert/platform/blob/main/docs/adr/ADR-214-klickdummy-plattform-heimat.md"
+
+[project.scripts]
+klickdummy-i1 = "iil_klickdummy.check_i1:main_cli"
+klickdummy-i2 = "iil_klickdummy.check_i2:main_cli"
+klickdummy-i3 = "iil_klickdummy.check_i3:main_cli"
+klickdummy-i4 = "iil_klickdummy.check_i4:main_cli"
+klickdummy-extract-requirements = "iil_klickdummy.extract_requirements:main_cli"
+klickdummy-inventory = "iil_klickdummy.inventory:main_cli"
+
+[tool.setuptools.package-data]
+iil_klickdummy = ["schemas/*.json"]

--- a/packages/iil-klickdummy/src/iil_klickdummy/__init__.py
+++ b/packages/iil-klickdummy/src/iil_klickdummy/__init__.py
@@ -1,0 +1,15 @@
+"""iil-klickdummy — shared infrastructure for platform:ADR-211 conformance.
+
+Public surface:
+    check_i1, check_i2, check_i3, check_i4 — invariant checks
+    extract_requirements                    — Spec → UC/FR/NFR/Lasten/Pflicht
+    inventory                               — S11 Cross-Repo Legacy-Inventur
+
+Version follows semver. Major-bump = ADR-update with migration cookbook.
+"""
+
+__version__ = "1.0.0"
+__author__ = "Achim Dehnert"
+
+# Re-exports for `python -m iil_klickdummy.<module>` compatibility
+from . import check_i1, check_i2, check_i3, check_i4, extract_requirements, inventory  # noqa: F401, E402

--- a/packages/iil-klickdummy/src/iil_klickdummy/check_i1.py
+++ b/packages/iil-klickdummy/src/iil_klickdummy/check_i1.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""I1 Spec-first — Spec gegen JSON-Schema validieren.
+
+Aufruf:  python3 scripts/klickdummy/check_i1.py <spec_path>:<schema_path> [...]
+Policy:  ~/.claude/policies/klickdummy.md · platform:ADR-211
+Exit:    0 = PASS, 1 = FAIL, 2 = Setup-Fehler (fehlende Deps)
+"""
+from __future__ import annotations
+import json, pathlib, sys
+
+try:
+    import yaml  # PyYAML
+except ImportError:
+    print("FAIL (setup): PyYAML fehlt. pip install pyyaml")
+    sys.exit(2)
+
+try:
+    import jsonschema
+except ImportError:
+    print("FAIL (setup): jsonschema fehlt. pip install jsonschema")
+    sys.exit(2)
+
+
+def load(path: str):
+    text = pathlib.Path(path).read_text(encoding="utf-8")
+    if path.endswith((".yaml", ".yml")):
+        return yaml.safe_load(text)
+    return json.loads(text)
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("Usage: check_i1.py <spec>:<schema> ...")
+        return 2
+    errs = 0
+    print("== I1 Spec-first ==")
+    for pair in argv:
+        if ":" not in pair:
+            print(f"  ✗ ungültiger Eintrag: {pair!r}")
+            errs += 1
+            continue
+        spec_path, schema_path = pair.split(":", 1)
+        print(f"  · {spec_path}")
+        try:
+            spec = load(spec_path)
+            schema = load(schema_path)
+            jsonschema.validate(spec, schema)
+            print(f"      ✓ schema-konform ({schema_path})")
+        except FileNotFoundError as e:
+            print(f"      ✗ Datei fehlt: {e.filename}")
+            errs += 1
+        except jsonschema.ValidationError as e:
+            loc = "/".join(str(p) for p in e.absolute_path) or "(root)"
+            print(f"      ✗ Schema-Verletzung @ {loc}: {e.message}")
+            errs += 1
+        except Exception as e:  # noqa: BLE001
+            print(f"      ✗ {type(e).__name__}: {e}")
+            errs += 1
+    print(f"I1 → {'PASS' if errs == 0 else f'FAIL ({errs})'}")
+    return 0 if errs == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))
+
+
+def main_cli() -> int:
+    """Console-Script entry (pyproject.toml [project.scripts])."""
+    import sys
+    return main(sys.argv[1:])

--- a/packages/iil-klickdummy/src/iil_klickdummy/check_i2.py
+++ b/packages/iil-klickdummy/src/iil_klickdummy/check_i2.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""I2 Prod-Sicherheit — genau EINE Klasse explizit deklariert.
+
+Mock-Prototyp (kein Backend, Target-Mock) ODER Demo-Render (env-gated, in Prod
+unerreichbar). Keine Klasse = Verstoß (kein vacuous pass).
+
+Akzeptierte Felder im Spec-Root:
+  - `class`              (YAML/JSON, neue Specs)
+  - `klickdummy_class`   (additive Variante für Bestands-Manifeste)
+
+Aufruf:  python3 scripts/klickdummy/check_i2.py <spec>:<schema> [...]
+Exit:    0 = PASS, 1 = FAIL, 2 = Setup-Fehler
+"""
+from __future__ import annotations
+import json, pathlib, sys
+
+try:
+    import yaml
+except ImportError:
+    print("FAIL (setup): PyYAML fehlt. pip install pyyaml")
+    sys.exit(2)
+
+ALLOWED = {"mock", "stub-demo", "story", "spec-demo"}
+# Strict-Mode aktiv seit 2026-05-20 (platform:ADR-211 Rev 12 §Migration
+# Scoreboard S11 erfüllt: 0 echte Drift-Treffer cross-repo nach Migrations-
+# Runde — meiki-hub#23, writing-hub#21, risk-hub#125 alle gemerged). F12
+# damit endgültig geschlossen, lange vor Hard-Deadline 2026-08-20.
+LEGACY = {}  # Soft-Migrate vorbei
+CLASS_KEYS = ("class", "klickdummy_class")
+
+
+def load(path: str):
+    text = pathlib.Path(path).read_text(encoding="utf-8")
+    if path.endswith((".yaml", ".yml")):
+        return yaml.safe_load(text)
+    return json.loads(text)
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("Usage: check_i2.py <spec>:<schema> ...")
+        return 2
+    errs = 0
+    print("== I2 Prod-Sicherheit ==")
+    for pair in argv:
+        spec_path = pair.split(":", 1)[0]
+        print(f"  · {spec_path}")
+        try:
+            spec = load(spec_path) or {}
+            cls = None
+            for k in CLASS_KEYS:
+                if k in spec:
+                    cls = spec[k]
+                    break
+            if cls is None:
+                print(
+                    f"      ✗ keine Klasse deklariert "
+                    f"(erwartet eines von {CLASS_KEYS}, z. B. 'mock')"
+                )
+                errs += 1
+            elif cls in LEGACY:
+                # weich, mit Migrations-Hinweis (kein FAIL — sonst CI-Bruch
+                # vor abgeschlossener Migration in allen Schwester-Repos)
+                print(f"      ⚠ class={cls!r} (Rev-10-Begriff) — bitte auf "
+                      f"{LEGACY[cls]!r} migrieren (platform:ADR-211 Rev 11, 4-Pattern)")
+            elif cls not in ALLOWED:
+                print(f"      ✗ class={cls!r} nicht in {sorted(ALLOWED)}")
+                errs += 1
+            else:
+                print(f"      ✓ class={cls}")
+        except FileNotFoundError as e:
+            print(f"      ✗ Datei fehlt: {e.filename}")
+            errs += 1
+        except Exception as e:  # noqa: BLE001
+            print(f"      ✗ {type(e).__name__}: {e}")
+            errs += 1
+    print(f"I2 → {'PASS' if errs == 0 else f'FAIL ({errs})'}")
+    return 0 if errs == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))
+
+
+def main_cli() -> int:
+    """Console-Script entry (pyproject.toml [project.scripts])."""
+    import sys
+    return main(sys.argv[1:])

--- a/packages/iil-klickdummy/src/iil_klickdummy/check_i3.py
+++ b/packages/iil-klickdummy/src/iil_klickdummy/check_i3.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""I3 Off-Ramp — Doppelquell-Grenze + Status je Screen.
+
+Anforderungen (platform:ADR-211):
+  - Spec hat `off_ramp`-Block mit `doppelquell_grenze: prod-release`
+  - Falls Screens definiert: jeder Screen hat `off_ramp_status` aus
+    {static, parity-staging, parity-green, removed}
+
+Phase 0 ist ein Berichts-Runner, keine echte Parity-Maschinerie — die entsteht,
+sobald der Produkt-Repo Staging hat.
+
+Aufruf:  python3 scripts/klickdummy/check_i3.py <spec>:<schema> [...]
+Exit:    0 = PASS, 1 = FAIL, 2 = Setup-Fehler
+"""
+from __future__ import annotations
+import json, pathlib, sys
+
+try:
+    import yaml
+except ImportError:
+    print("FAIL (setup): PyYAML fehlt. pip install pyyaml")
+    sys.exit(2)
+
+STATUS = ("static", "parity-staging", "parity-green", "removed")
+
+
+def load(path: str):
+    text = pathlib.Path(path).read_text(encoding="utf-8")
+    if path.endswith((".yaml", ".yml")):
+        return yaml.safe_load(text)
+    return json.loads(text)
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("Usage: check_i3.py <spec>:<schema> ...")
+        return 2
+    errs = 0
+    print("== I3 Off-Ramp ==")
+    for pair in argv:
+        spec_path = pair.split(":", 1)[0]
+        print(f"  · {spec_path}")
+        try:
+            spec = load(spec_path) or {}
+            off = spec.get("off_ramp")
+            if not off:
+                print("      ✗ kein 'off_ramp'-Block deklariert")
+                errs += 1
+                continue
+            if off.get("doppelquell_grenze") != "prod-release":
+                print(
+                    f"      ✗ doppelquell_grenze={off.get('doppelquell_grenze')!r} "
+                    "— erwartet 'prod-release'"
+                )
+                errs += 1
+            screens = spec.get("screens") or []
+            if screens:
+                counts: dict[str, int] = {s: 0 for s in STATUS}
+                bad = []
+                for sc in screens:
+                    st = sc.get("off_ramp_status", "static")
+                    if st not in STATUS:
+                        bad.append((sc.get("id", "?"), st))
+                    counts[st] = counts.get(st, 0) + 1
+                if bad:
+                    for sid, st in bad:
+                        print(f"      ✗ screen {sid!r}: off_ramp_status={st!r} unzulässig")
+                    errs += len(bad)
+                summary = ", ".join(f"{k}={v}" for k, v in counts.items() if v)
+                print(f"      ✓ {len(screens)} Screen(s) — {summary}")
+            else:
+                print(f"      ✓ off_ramp-Policy: {off.get('policy', '(unbenannt)')}")
+        except FileNotFoundError as e:
+            print(f"      ✗ Datei fehlt: {e.filename}")
+            errs += 1
+        except Exception as e:  # noqa: BLE001
+            print(f"      ✗ {type(e).__name__}: {e}")
+            errs += 1
+    print(f"I3 → {'PASS' if errs == 0 else f'FAIL ({errs})'}")
+    return 0 if errs == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))
+
+
+def main_cli() -> int:
+    """Console-Script entry (pyproject.toml [project.scripts])."""
+    import sys
+    return main(sys.argv[1:])

--- a/packages/iil-klickdummy/src/iil_klickdummy/check_i4.py
+++ b/packages/iil-klickdummy/src/iil_klickdummy/check_i4.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""I4 Namensraum — Cross-Repo-ADR-Refs nur als repo:ADR-NNN.
+
+Heuristik:
+  - Scannt klickdummy-Dateien (md/html/yaml/yml/json) rekursiv unter dem
+    übergebenen Root-Verzeichnis.
+  - Jeder Treffer auf 'ADR-NNN' muss eine der drei Formen haben:
+      (a) repo-qualifiziert, z. B. `meiki:ADR-021` / `platform:ADR-211`
+      (b) lokale meiki-ADR (Whitelist unten) — unqualifiziert erlaubt
+      (c) in einem Code-/Pre-Block einer Schema-Beispielzeile
+
+Whitelist lokaler ADRs wird aus docs/adr/ADR-NNN-*.md autoermittelt.
+
+Aufruf:  python3 scripts/klickdummy/check_i4.py <root_dir>
+Exit:    0 = PASS, 1 = FAIL, 2 = Setup-Fehler
+"""
+from __future__ import annotations
+import pathlib, re, sys
+
+# Erfasst sowohl 'ADR-021' als auch 'foo:ADR-021'
+ADR_PATTERN = re.compile(r"(?P<prefix>[A-Za-z][A-Za-z0-9_-]*:)?(?P<adr>ADR-\d{3})")
+SCAN_EXT = {".md", ".html", ".yaml", ".yml", ".json"}
+ADR_DIR = pathlib.Path("docs/adr")
+
+
+def local_adr_set() -> set[str]:
+    """Sammelt lokal vorhandene meiki-ADR-Nummern aus docs/adr/ADR-NNN-*.md."""
+    out: set[str] = set()
+    if ADR_DIR.exists():
+        for p in ADR_DIR.glob("ADR-*.md"):
+            m = re.match(r"(ADR-\d{3})", p.name)
+            if m:
+                out.add(m.group(1))
+    return out
+
+
+def check_file(path: pathlib.Path, local: set[str]) -> list[tuple[int, str, str]]:
+    """Gibt (zeilen_nr, treffer, hinweis)-Liste zurück; leer = ok."""
+    findings: list[tuple[int, str, str]] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return findings
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for m in ADR_PATTERN.finditer(line):
+            adr = m.group("adr")
+            prefix = m.group("prefix")
+            if prefix:
+                continue  # repo:ADR-NNN — ok
+            if adr in local:
+                continue  # lokale meiki-ADR — ok
+            findings.append((lineno, adr, f"unqualifiziert (nicht in local-set, nicht repo:ADR-NNN)"))
+    return findings
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("Usage: check_i4.py <root_dir>")
+        return 2
+    root = pathlib.Path(argv[0])
+    if not root.exists():
+        print(f"FAIL: Root fehlt: {root}")
+        return 2
+    local = local_adr_set()
+    print(f"== I4 Namensraum == (root={root}, lokale ADRs: {len(local)})")
+    errs = 0
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix not in SCAN_EXT:
+            continue
+        findings = check_file(path, local)
+        if findings:
+            print(f"  · {path}")
+            for lineno, adr, hint in findings:
+                print(f"      ✗ Zeile {lineno}: {adr} — {hint}")
+                errs += 1
+    if errs == 0:
+        print("I4 → PASS")
+        return 0
+    print(f"I4 → FAIL ({errs}) — Cross-Repo-Refs als 'repo:ADR-NNN' qualifizieren")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))
+
+
+def main_cli() -> int:
+    """Console-Script entry (pyproject.toml [project.scripts])."""
+    import sys
+    return main(sys.argv[1:])

--- a/packages/iil-klickdummy/src/iil_klickdummy/extract_requirements.py
+++ b/packages/iil-klickdummy/src/iil_klickdummy/extract_requirements.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Klickdummy → Requirements-Skeleton (UC/FR/NFR/Lasten-/Pflichtenheft).
+
+Parst eine Klickdummy-Spec (YAML) und generiert Markdown-Skelette für:
+  - requirements/use-cases/UC-NN-<screen>.md       (1 UC pro Screen)
+  - requirements/fr.md                              (Funktionale Requirements)
+  - requirements/nfr.md                             (Nicht-funktionale)
+  - requirements/schnittstellen.md                  (Adapter / Systemgrenzen)
+  - requirements/lastenheft-skeleton.md             (high-level, Auftraggeber-Sicht)
+  - requirements/pflichtenheft-skeleton.md          (concrete, Auftragnehmer-Sicht)
+
+Output ist *Skelett* — Editieren erwartet. Drift gegen Spec via Re-Extract +
+git-diff sichtbar. Eine Quelle wahr: die Spec (analog ADR-211 I1 Spec-first).
+
+Aufruf:
+    python3 scripts/klickdummy/extract_requirements.py <spec.yaml> [<out-dir>]
+
+Exit: 0 ok, 1 Schema-Fehler, 2 Setup-Fehler.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+from datetime import date
+
+try:
+    import yaml
+except ImportError:
+    print("FAIL (setup): PyYAML fehlt. pip install pyyaml")
+    sys.exit(2)
+
+
+# -- Helpers ------------------------------------------------------------------
+
+def slug(s: str) -> str:
+    return re.sub(r"[^a-z0-9-]+", "-", s.lower()).strip("-")
+
+
+def load_spec(path: pathlib.Path) -> dict:
+    if not path.exists():
+        print(f"FAIL: Spec fehlt: {path}")
+        sys.exit(1)
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def write(out_root: pathlib.Path, rel: str, content: str) -> None:
+    p = out_root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    print(f"  ✓ {rel}")
+
+
+# -- Generators ---------------------------------------------------------------
+
+def gen_uc(spec: dict, out: pathlib.Path) -> None:
+    """1 UseCase pro Screen — als RUP/UML-Skelett.
+
+    Räumt veraltete UC-Dateien (`UC-*.md` im Zielordner) vor dem Schreiben weg,
+    damit Re-Extract bei Screen-Reihenfolge- oder Namensänderung nicht zwei
+    parallele UC-Sets stehenlässt.
+    """
+    uc_dir = out / "requirements" / "use-cases"
+    if uc_dir.exists():
+        for stale in uc_dir.glob("UC-*.md"):
+            stale.unlink()
+    screens = spec.get("screens", []) or []
+    spec_id = spec.get("spec_id", "spec")
+    for i, sc in enumerate(screens, start=1):
+        sid = sc.get("id", f"screen-{i}")
+        title = sc.get("title", sid)
+        personas = sc.get("personas", []) or []
+        purpose = sc.get("purpose") or sc.get("title") or ""
+        pa = sc.get("parity_acceptance", []) or []
+        konzept = sc.get("konzept_ref", []) or []
+        targets = sc.get("target_mocks", []) or []
+        datafields = sc.get("datafields", []) or []
+        body = f"""---
+type: use-case
+uc_id: UC-{i:02d}-{slug(sid)}
+source_spec: {spec_id}
+source_screen: {sid}
+extracted_at: {date.today().isoformat()}
+status: draft   # draft | reviewed | approved
+---
+
+# UC-{i:02d} · {title}
+
+> Generiert aus Klickdummy-Spec (Screen `{sid}`). Skelett — bitte editieren.
+
+## Akteure
+{chr(10).join(f"- {a}" for a in personas) or "- _(noch nicht spezifiziert)_"}
+
+## Zweck / Ziel
+{purpose}
+
+## Vorbedingung
+- Aktor ist angemeldet, Persona-Sicht aktiv.
+- _(weitere Vorbedingungen ergänzen — z. B. vorheriger Screen)_
+
+## Hauptablauf
+{chr(10).join(f"{j+1}. {p.get('check','')}" for j, p in enumerate(pa)) or "1. _(noch nicht spezifiziert)_"}
+
+## Nachbedingung
+- _(z. B. Folge-Screen erreicht, Zustand geändert, Audit-Eintrag erzeugt)_
+
+## Beteiligte Systeme / Schnittstellen
+{chr(10).join(f"- {t}" for t in targets) or "- _(keine externen Systeme deklariert)_"}
+
+## Datenfelder
+{chr(10).join(f"- `{d.get('name','?')}` ({d.get('type','?')}) — Quelle: {d.get('source','?')}" for d in datafields) or "- _(keine Datenfelder im Spec deklariert)_"}
+
+## Konzept-Bezug
+{chr(10).join(f"- {k}" for k in konzept) or "- _(kein Konzept-Bezug)_"}
+
+## Abgeleitete FRs
+{chr(10).join(f"- FR-{slug(sid)}-{j+1:02d}: {p.get('check','')}" for j, p in enumerate(pa)) or "- _(keine)_"}
+"""
+        write(out, f"requirements/use-cases/UC-{i:02d}-{slug(sid)}.md", body)
+
+
+def gen_fr(spec: dict, out: pathlib.Path) -> None:
+    rows = []
+    for sc in spec.get("screens", []) or []:
+        sid = sc.get("id", "?")
+        for j, p in enumerate(sc.get("parity_acceptance", []) or [], start=1):
+            rows.append(
+                f"| FR-{slug(sid)}-{j:02d} | {sid} | {p.get('id','')} | {p.get('check','')} |"
+            )
+    body = f"""---
+type: functional-requirements
+source_spec: {spec.get('spec_id','spec')}
+extracted_at: {date.today().isoformat()}
+status: draft
+---
+
+# Funktionale Requirements (FR)
+
+> Aus Klickdummy-Spec `{spec.get('spec_id','?')}` v{spec.get('spec_version','?')} abgeleitet.
+> Jede Zeile entspricht einem `parity_acceptance`-Eintrag eines Screens (= platform:ADR-211 I1-Acceptance).
+> Drift-Check: Re-Extract gegen committeten Stand → `git diff`.
+
+| FR-ID | Screen | Anker | Anforderung |
+|---|---|---|---|
+{chr(10).join(rows) or "| — | — | — | _(keine parity_acceptance im Spec)_ |"}
+"""
+    write(out, "requirements/fr.md", body)
+
+
+def gen_nfr(spec: dict, out: pathlib.Path) -> None:
+    cls = spec.get("class", "?")
+    ev = spec.get("class_evidence", {}) or {}
+    off = spec.get("off_ramp", {}) or {}
+    adr = spec.get("adr", {}) or {}
+
+    nfrs: list[tuple[str, str, str]] = []  # (id, kategorie, anforderung)
+    # Security / Prod-Sicherheit (I2)
+    if cls == "mock":
+        if ev.get("no_backend"):
+            nfrs.append(("NFR-Sec-01", "Security", "Klickdummy darf keinen echten Backend-Code-Pfad enthalten (`class: mock`, `class_evidence.no_backend: true`)."))
+        if ev.get("no_demo_param"):
+            nfrs.append(("NFR-Sec-02", "Security", "Kein `?demo=`-Render in der echten App (`class_evidence.no_demo_param: true`)."))
+        if ev.get("target_mocks_visible"):
+            nfrs.append(("NFR-Sec-03", "Security", "Alle Systemgrenzen müssen als anklickbare Target-Mocks sichtbar sein (kein toter Link)."))
+    elif cls == "spec-demo":
+        pg = ev.get("prod_guard", {}) or {}
+        nfrs.append(("NFR-Sec-01", "Security", f"`?demo=`-Render ist in Produktion nicht erreichbar (Guard: {pg.get('setting','?')} + DEBUG/TESTING; Response: {pg.get('response_in_prod','?')})."))
+        nfrs.append(("NFR-Sec-02", "Security", "Guard ist durch automatisierten Test bewiesen (Demo-Tour-Tests mit `KLICKDUMMY_TOUR_ENABLED=False`)."))
+    elif cls == "stub-demo":
+        nfrs.append(("NFR-Sec-01", "Security", "Dedizierte Demo-Route ist in Produktion nicht erreichbar (404)."))
+    elif cls == "story":
+        nfrs.append(("NFR-Sec-01", "Security", "Component-Catalog (Storybook o. ä.) ist in Produktion nicht erreichbar (404)."))
+
+    # Lifecycle (I3)
+    if off.get("doppelquell_grenze"):
+        nfrs.append(("NFR-Lifecycle-01", "Lifecycle", f"Doppelquellen-Pflege endet bei `{off['doppelquell_grenze']}`."))
+    if off.get("ttl_days"):
+        nfrs.append(("NFR-Lifecycle-02", "Lifecycle", f"Off-Ramp-TTL: max. {off['ttl_days']} Tage nach Parity-grün."))
+
+    # Integration (Systemgrenzen)
+    for i, s in enumerate(ev.get("systemgrenzen", []) or [], start=1):
+        nfrs.append((f"NFR-Integ-{i:02d}", "Integration", f"Schnittstelle: `{s}` (generisch, mandantenkonfigurierbar)."))
+
+    # Namensraum (I4)
+    if adr.get("conforms_to"):
+        nfrs.append(("NFR-Gov-01", "Governance", f"ADR-Konformität: `{adr['conforms_to']}` (Klickdummy-Cross-Repo-Rahmen)."))
+
+    rows = "\n".join(f"| {n[0]} | {n[1]} | {n[2]} |" for n in nfrs) or "| — | — | _(keine NFRs ableitbar)_ |"
+    body = f"""---
+type: non-functional-requirements
+source_spec: {spec.get('spec_id','spec')}
+extracted_at: {date.today().isoformat()}
+status: draft
+---
+
+# Nicht-funktionale Requirements (NFR)
+
+> Aus `class`, `class_evidence`, `off_ramp` und `adr` der Klickdummy-Spec abgeleitet.
+> **Asymmetrische Brücke:** NFRs *dürfen* über den Klickdummy hinausgehen — Performance, Skalierung, Audit etc.
+> sind hier nicht erschöpft und müssen manuell ergänzt werden.
+
+| NFR-ID | Kategorie | Anforderung |
+|---|---|---|
+{rows}
+
+## Manuell zu ergänzen (typisch im Klickdummy nicht abgedeckt)
+
+- **Performance:** Antwortzeiten, Durchsatz, Last-/Stresstest-Schwellen
+- **Verfügbarkeit:** SLA, MTBF, MTTR
+- **Datenschutz:** DSFA-Bezug, Aufbewahrungsfristen, Löschpflichten
+- **Audit / Logging:** Auditpflichtige Aktionen, Retention
+- **Barrierefreiheit:** WCAG-Level, Tastatur-Navigation
+- **Internationalisierung:** Sprachen, Datumsformate, Kalender
+"""
+    write(out, "requirements/nfr.md", body)
+
+
+def gen_schnittstellen(spec: dict, out: pathlib.Path) -> None:
+    ev = spec.get("class_evidence", {}) or {}
+    systemgrenzen = ev.get("systemgrenzen", []) or []
+    # Sammle alle target_mocks aus Screens
+    mocks: set[str] = set()
+    for sc in spec.get("screens", []) or []:
+        for t in sc.get("target_mocks", []) or []:
+            mocks.add(t)
+    body = f"""---
+type: interfaces
+source_spec: {spec.get('spec_id','spec')}
+extracted_at: {date.today().isoformat()}
+status: draft
+---
+
+# Schnittstellen (Adapter / Systemgrenzen)
+
+> Aus `class_evidence.systemgrenzen` (Klassen-Liste) und `screens[].target_mocks` (Pro-Screen-Bezug) abgeleitet.
+
+## Generische Adapter-Familien (aus `class_evidence.systemgrenzen`)
+
+{chr(10).join(f"- **{s}**" for s in systemgrenzen) or "- _(keine deklariert)_"}
+
+## Pro Screen verwendet (aus `screens[].target_mocks`)
+
+{chr(10).join(f"- `{m}`" for m in sorted(mocks)) or "- _(keine deklariert)_"}
+
+## Manuell zu konkretisieren (Pflichtenheft-Übergang)
+
+Pro Adapter:
+- API-Vertrag (Methoden, Payload-Format, Auth)
+- SLA / Verfügbarkeit
+- Fehlerfallverhalten (Timeout, Retry, Fallback)
+- Daten-Mapping zu internem Modell
+"""
+    write(out, "requirements/schnittstellen.md", body)
+
+
+def gen_lastenheft(spec: dict, out: pathlib.Path) -> None:
+    title = spec.get("title", spec.get("spec_id", "Klickdummy"))
+    personas = set()
+    for sc in spec.get("screens", []) or []:
+        for p in sc.get("personas", []) or []:
+            personas.add(p)
+    main_goals = [sc.get("title", "?") for sc in spec.get("screens", []) or []]
+    body = f"""---
+type: lastenheft
+source_spec: {spec.get('spec_id','spec')}
+extracted_at: {date.today().isoformat()}
+status: skeleton
+audience: auftraggeber
+---
+
+# Lastenheft (Skelett) · {title}
+
+> *Was* der Auftraggeber will. Aus Klickdummy abgeleitet — high-level.
+> Vor Verwendung: editieren, priorisieren, fachlich ergänzen.
+
+## 1. Ausgangslage und Motivation
+
+_(Manuell: Warum dieses Vorhaben? Welcher Schmerz wird beseitigt? Welche Strategie wird umgesetzt?)_
+
+## 2. Zielgruppen
+
+{chr(10).join(f"- {p}" for p in sorted(personas)) or "- _(keine Personas deklariert)_"}
+
+## 3. Hauptziele (aus Screens abgeleitet)
+
+{chr(10).join(f"{i+1}. {g}" for i, g in enumerate(main_goals)) or "1. _(keine)_"}
+
+## 4. Funktionale Anforderungen (Übersicht)
+
+Siehe [`fr.md`](fr.md). Jede Zeile dort = eine `parity_acceptance` aus dem Klickdummy.
+
+## 5. Nicht-funktionale Anforderungen (Übersicht)
+
+Siehe [`nfr.md`](nfr.md). **Klickdummy bildet nur Teil ab** — manuell ergänzen:
+Performance, Verfügbarkeit, Datenschutz, Audit, Barrierefreiheit.
+
+## 6. Schnittstellen
+
+Siehe [`schnittstellen.md`](schnittstellen.md).
+
+## 7. Abgrenzung / Out-of-Scope
+
+_(Manuell: Was wird ausdrücklich NICHT geliefert?)_
+
+## 8. Termine / Meilensteine
+
+_(Manuell)_
+
+## 9. Bezug
+
+- Spec: `{spec.get('spec_id','?')}` v{spec.get('spec_version','?')}
+- Klickdummy-Pfad: _(Repo-Pfad der Klickdummy-Implementierung)_
+- ADR-Verankerung: {spec.get('adr',{}).get('local','?')} (`conforms_to: {spec.get('adr',{}).get('conforms_to','?')}`)
+"""
+    write(out, "requirements/lastenheft-skeleton.md", body)
+
+
+def gen_pflichtenheft(spec: dict, out: pathlib.Path) -> None:
+    title = spec.get("title", spec.get("spec_id", "Klickdummy"))
+    body = f"""---
+type: pflichtenheft
+source_spec: {spec.get('spec_id','spec')}
+extracted_at: {date.today().isoformat()}
+status: skeleton
+audience: auftragnehmer
+---
+
+# Pflichtenheft (Skelett) · {title}
+
+> *Wie* der Auftragnehmer das Lastenheft umsetzt. Aus Klickdummy + Lastenheft abzuleiten.
+> Vor Verwendung: technische Architektur ergänzen.
+
+## 1. Bezug zum Lastenheft
+
+Siehe [`lastenheft-skeleton.md`](lastenheft-skeleton.md). Diese Datei konkretisiert dessen Punkte 4–6.
+
+## 2. Architektur-Skizze
+
+_(Manuell: Container-/Component-Diagramm; Ports & Adapter; Datenflüsse.)_
+
+Klickdummy-Klasse: `{spec.get('class','?')}` (platform:ADR-211 I2)
+Off-Ramp-Strategie: `{spec.get('off_ramp',{}).get('doppelquell_grenze','?')}` (TTL {spec.get('off_ramp',{}).get('ttl_days','?')} d)
+
+## 3. UseCases (Verzeichnis)
+
+Siehe [`use-cases/`](use-cases/) — je UC ein Markdown mit Akteur/Ablauf/Nachbedingung/Daten.
+
+## 4. Datenmodell
+
+_(Manuell zu konkretisieren — die Klickdummy-`datafields` sind nur Anker.)_
+
+Klickdummy-Datenfelder (je Screen) siehe `use-cases/`-Skelette unter „Datenfelder".
+
+## 5. Schnittstellen-Verträge
+
+Siehe [`schnittstellen.md`](schnittstellen.md). Pro Adapter zu ergänzen:
+API-Methoden, Payload-Format, Auth-Mechanismus, SLA, Fehlerfallverhalten.
+
+## 6. Nicht-funktionale Realisierung
+
+Siehe [`nfr.md`](nfr.md). Mapping je NFR-ID → technische Maßnahme.
+
+## 7. Test-/Abnahme-Konzept
+
+- **I1 Spec ↔ Render** (platform:ADR-211): Spec-Konformität via `make klickdummy-i1`.
+- **Parity-Test** (bei Demo-Render): Klickdummy ⊆ flow.md ⊆ App.
+- **UC-Tests:** je UC ein E2E-Pfad (Browser/Playwright o. ä.).
+- **NFR-Tests:** Performance/Last/Penetration je nach Kategorie.
+
+## 8. Bezug
+
+- Spec: `{spec.get('spec_id','?')}` v{spec.get('spec_version','?')}
+- ADR (lokal): {spec.get('adr',{}).get('local','?')}
+- ADR (Rahmen): {spec.get('adr',{}).get('conforms_to','?')}
+- Schwester-Implementierungen: {', '.join(spec.get('adr',{}).get('sister_of',[]) or []) or '(keine)'}
+"""
+    write(out, "requirements/pflichtenheft-skeleton.md", body)
+
+
+# -- Main ---------------------------------------------------------------------
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("Usage: extract_requirements.py <spec.yaml> [<out-dir>]")
+        return 2
+    spec_path = pathlib.Path(argv[0])
+    out_root = pathlib.Path(argv[1]) if len(argv) > 1 else spec_path.parent
+    spec = load_spec(spec_path)
+    print(f"== Extract Requirements ==")
+    print(f"  Spec : {spec_path}")
+    print(f"  Out  : {out_root}/requirements/")
+    print()
+    gen_uc(spec, out_root)
+    gen_fr(spec, out_root)
+    gen_nfr(spec, out_root)
+    gen_schnittstellen(spec, out_root)
+    gen_lastenheft(spec, out_root)
+    gen_pflichtenheft(spec, out_root)
+    print()
+    print(f"  Hinweis: alle generierten Dateien tragen `status: draft|skeleton` —")
+    print(f"  manuell editieren, dann committen. Drift gegen Spec via Re-Extract + git diff.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))
+
+
+def main_cli() -> int:
+    """Console-Script entry (pyproject.toml [project.scripts])."""
+    import sys
+    return main(sys.argv[1:])

--- a/packages/iil-klickdummy/src/iil_klickdummy/inventory.py
+++ b/packages/iil-klickdummy/src/iil_klickdummy/inventory.py
@@ -1,0 +1,115 @@
+"""S11 Cross-Repo Legacy-Class-Inventur (platform:ADR-211 Rev 12 §Migration).
+
+Sucht nach Rev-≤10-Klassen-Begriffen (`mock-prototyp`, `demo-render`) in
+allen bekannten Klickdummy-Repos. Exit 0 wenn 0 echte Treffer ⇒ Strict-Mode
+(`LEGACY={}`) kann aktiviert werden.
+
+Verwendung:
+    python -m iil_klickdummy.inventory                # default-Repos
+    python -m iil_klickdummy.inventory --base ~/github --repos meiki-hub,...
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import re
+import sys
+
+DEFAULT_REPOS = ["meiki-hub", "writing-hub", "risk-hub", "pptx-hub", "dev-hub", "ttz-hub"]
+LEGACY_PATTERN = re.compile(r"mock-prototyp|demo-render")
+INCLUDE_EXT = {".yaml", ".yml", ".json", ".md", ".html", ".py"}
+EXCLUDE_PATH_PARTS = {"node_modules", ".venv", "__pycache__", "build", "dist", "_archiv"}
+# Diese Pfade enthalten *beabsichtigte* History/Compat-Referenzen:
+EXCLUDE_FILES_SUFFIX = ("feedback-log.md",)
+# Zeilen, die LEGACY-Maps oder History-Kommentare definieren, sind kein Drift:
+INTENTIONAL_LINE_PATTERNS = [
+    re.compile(r'LEGACY\s*=\s*\{'),
+    re.compile(r'"mock-prototyp"\s*:\s*"mock"'),
+    re.compile(r'"demo-render"\s*:\s*"spec-demo"'),
+    re.compile(r'#\s*vorher\s+(mock-prototyp|demo-render)'),
+    re.compile(r'\(vorher\s+(mock-prototyp|demo-render)'),
+    re.compile(r'in\s+\("mock",\s*"mock-prototyp"\)'),
+    re.compile(r'in\s+\("demo-render",\s*"spec-demo"\)'),
+]
+
+
+def _is_intentional(line: str) -> bool:
+    return any(p.search(line) for p in INTENTIONAL_LINE_PATTERNS)
+
+
+def _scan_repo(repo_root: pathlib.Path) -> list[tuple[str, int, str]]:
+    """Returns list of (relative_path, line_number, line_content) for real drift."""
+    hits: list[tuple[str, int, str]] = []
+    for p in repo_root.rglob("*"):
+        if not p.is_file():
+            continue
+        if p.suffix not in INCLUDE_EXT:
+            continue
+        if any(part in EXCLUDE_PATH_PARTS for part in p.parts):
+            continue
+        if p.name.endswith(EXCLUDE_FILES_SUFFIX):
+            continue
+        try:
+            text = p.read_text(encoding="utf-8", errors="replace")
+        except (OSError, UnicodeError):
+            continue
+        for i, line in enumerate(text.splitlines(), start=1):
+            if LEGACY_PATTERN.search(line) and not _is_intentional(line):
+                hits.append((str(p.relative_to(repo_root)), i, line.strip()))
+    return hits
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default=os.path.expanduser("~/github"),
+                        help="Base directory containing repo checkouts")
+    parser.add_argument("--repos", default=",".join(DEFAULT_REPOS),
+                        help="Comma-separated repo names")
+    parser.add_argument("--strict", action="store_true",
+                        help="Exit 1 on first hit (default: report all then exit)")
+    args = parser.parse_args(argv)
+
+    base = pathlib.Path(args.base)
+    repos = [r.strip() for r in args.repos.split(",") if r.strip()]
+
+    print("== S11 Cross-Repo Legacy-Class-Inventur (platform:ADR-211 Rev 12) ==")
+    print(f"Base: {base}")
+    print(f"Repos: {', '.join(repos)}")
+    print()
+
+    total = 0
+    for repo in repos:
+        d = base / repo
+        if not d.exists():
+            print(f"=== {repo}: NOT PRESENT (skip) ===")
+            continue
+        hits = _scan_repo(d)
+        if hits:
+            print(f"=== {repo}: {len(hits)} echte Drift-Treffer ===")
+            for rel, ln, content in hits[:10]:
+                print(f"  {rel}:{ln}  {content[:120]}")
+            if len(hits) > 10:
+                print(f"  … und {len(hits) - 10} weitere")
+            total += len(hits)
+            if args.strict:
+                return 1
+        else:
+            print(f"=== {repo}: ✓ clean ===")
+
+    print()
+    if total == 0:
+        print("S11 → 0 echte Drift-Treffer cross-repo. Strict-Mode kann aktiviert werden.")
+        return 0
+    else:
+        print(f"S11 → {total} Treffer. Strict-Mode noch nicht möglich.")
+        return 1
+
+
+def main_cli() -> int:
+    return main(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    sys.exit(main_cli())

--- a/packages/iil-klickdummy/src/iil_klickdummy/schemas/feedback-payload.schema.json
+++ b/packages/iil-klickdummy/src/iil_klickdummy/schemas/feedback-payload.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/achimdehnert/platform/main/packages/iil-klickdummy/src/iil_klickdummy/schemas/feedback-payload.schema.json",
+  "title": "Klickdummy Feedback-Payload (Co-Creation-Loop, platform:ADR-211 Rev 12)",
+  "description": "Was das Widget submittet. Empirie-basiert aus meiki-Iter. 1-6, formalisiert in platform:ADR-214 (Plattform-Heimat).",
+  "type": "object",
+  "required": ["screen", "category", "text", "spec_id", "spec_version", "klickdummy_class", "timestamp"],
+  "additionalProperties": false,
+  "properties": {
+    "screen": {
+      "type": ["string", "null"],
+      "description": "data-screen der aktiven Section zum Zeitpunkt des Submits"
+    },
+    "persona": {
+      "type": ["string", "null"],
+      "description": "Aktive Persona (repo-spezifisch — frei wählbar)"
+    },
+    "verfahren": {
+      "type": ["string", "null"],
+      "description": "Optionaler globaler Verfahrens-Kontext (repo-spezifisch)"
+    },
+    "feedback_scope": {
+      "type": "string",
+      "enum": ["app", "klickdummy-tool"],
+      "default": "app",
+      "description": "App-Feedback vs. Feedback über das Widget selbst (Reflexivität-Trennung per ADR-211 Rev 12 Pflicht 6)"
+    },
+    "category": {
+      "type": "string",
+      "enum": ["bug", "feature", "ux", "spec", "ki"],
+      "description": "Stakeholder-Klassifikation"
+    },
+    "text": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Freitext-Feedback"
+    },
+    "related_screens": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": [],
+      "description": "Multi-Select-Repro-Anker zu anderen Screens (Widget v0.2)"
+    },
+    "related_actions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["label"],
+        "properties": {
+          "label": { "type": "string" },
+          "target": { "type": ["string", "null"] }
+        }
+      },
+      "default": [],
+      "description": "Buttons/Aktionen im aktuellen Screen (Widget v0.3)"
+    },
+    "dom_snapshot": {
+      "type": ["string", "null"],
+      "description": "Section-HTML gekürzt auf 8 KB (Widget v0.3 opt-in)"
+    },
+    "attachments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "type", "size"],
+        "properties": {
+          "name": { "type": "string" },
+          "type": { "type": "string" },
+          "size": { "type": "integer" },
+          "data_url": { "type": ["string", "null"] },
+          "skipped": { "type": ["string", "null"] }
+        }
+      },
+      "default": [],
+      "description": "Datei-Anhänge (max 5x1MB als Base64-DataURL; Widget v0.3)"
+    },
+    "spec_id": {
+      "type": "string",
+      "description": "Pinning auf die Quell-Spec (repo:klickdummy-spec-<name>)"
+    },
+    "spec_version": {
+      "type": "string",
+      "description": "Spec-Version zum Zeitpunkt des Submits"
+    },
+    "klickdummy_class": {
+      "type": "string",
+      "enum": ["mock", "stub-demo", "story", "spec-demo"],
+      "description": "I2-Pattern per ADR-211 Rev 11"
+    },
+    "user_agent": { "type": ["string", "null"] },
+    "viewport": {
+      "type": "object",
+      "properties": {
+        "w": { "type": "integer" },
+        "h": { "type": "integer" }
+      }
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "url": { "type": "string" }
+  }
+}

--- a/packages/iil-klickdummy/src/iil_klickdummy/schemas/module-manifest.schema.json
+++ b/packages/iil-klickdummy/src/iil_klickdummy/schemas/module-manifest.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MEiKI Klick-Dummy Modul-Manifest",
+  "description": "SSoT fuer Fachverfahren, Querschnitts-Buchungseinheiten und je-LRA-Buchung. Trennt bewusst Schicht A (Fachverfahren = fachliche Sicht) von Schicht B (gebucht = technische Buchungseinheit je LRA).",
+  "type": "object",
+  "required": ["version", "identitaeten", "rollen", "fachverfahren", "querschnitt", "lra", "eingangsquellen", "klickdummy_class", "off_ramp"],
+  "additionalProperties": true,
+  "properties": {
+    "version": { "type": "string" },
+    "stand":   { "type": "string" },
+    "hinweis": { "type": "string" },
+    "klickdummy_class": {
+      "type": "string",
+      "enum": ["mock", "stub-demo", "story", "spec-demo"],
+      "description": "I2 Prod-Sicherheit (platform:ADR-211 Rev 11, 4-Pattern entlang Datenquelle × Code-Pfad-Identität). Genau eine Klasse — kein vacuous pass."
+    },
+    "off_ramp": {
+      "type": "object",
+      "description": "I3 Off-Ramp (platform:ADR-211). Doppelquell-Grenze = prod-release; Staging erlaubt.",
+      "required": ["policy", "unit", "rule", "doppelquell_grenze", "parity_runner"],
+      "properties": {
+        "policy":             { "type": "string" },
+        "unit":               { "type": "string" },
+        "rule":               { "type": "string" },
+        "doppelquell_grenze": { "type": "string", "enum": ["prod-release"] },
+        "staging_doppelquell":{ "type": "string", "enum": ["allowed"] },
+        "parity_runner":      { "type": "string" },
+        "status_overall":     { "type": "string" }
+      }
+    },
+    "identitaeten": {
+      "type": "object",
+      "description": "Schicht D — Identitaetsquellen (Login). Jede Quelle bildet auf genau eine Rolle (Schicht C) ab.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["label", "rolle"],
+        "properties": {
+          "label":        { "type": "string" },
+          "icon":         { "type": "string" },
+          "rolle":        { "type": "string", "description": "Muss ein Schluessel aus rollen sein." },
+          "art":          { "type": "string" },
+          "niveau":       { "type": "string" },
+          "betreiber":    { "type": "string" },
+          "beschreibung": { "type": "string" }
+        }
+      }
+    },
+    "eingangsquellen": {
+      "type": "object",
+      "description": "Kanal des Antragseingangs. cases[].eingangsquelle referenziert genau diese Schluessel.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["label"],
+        "properties": {
+          "label": { "type": "string" },
+          "icon":  { "type": "string" }
+        }
+      }
+    },
+    "rollen": {
+      "type": "object",
+      "description": "Schicht C — Rollen/Rechte. Bestimmt, welche Sicht eine Person auf dieselbe Kachel hat.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["label"],
+        "properties": {
+          "label":        { "type": "string" },
+          "beschreibung": { "type": "string" }
+        }
+      }
+    },
+    "fachverfahren": {
+      "type": "object",
+      "description": "Schicht A — fachliches Vokabular, plattformweit stabil.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["label", "status"],
+        "properties": {
+          "label":          { "type": "string" },
+          "kuerzel":        { "type": "string" },
+          "icon":           { "type": "string" },
+          "rechtsgrundlage":{ "type": "string" },
+          "status":         { "enum": ["ready", "planned"] },
+          "rollen":         { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+        }
+      }
+    },
+    "querschnitt": {
+      "type": "object",
+      "description": "Querschnitts-Buchungseinheiten (z. B. Buergerportal). Kein eigenes Verfahren.",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["label", "status"],
+        "properties": {
+          "label":        { "type": "string" },
+          "icon":         { "type": "string" },
+          "beschreibung": { "type": "string" },
+          "status":       { "enum": ["ready", "planned"] },
+          "rollen":       { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+        }
+      }
+    },
+    "lra": {
+      "type": "object",
+      "description": "Schicht B — was die jeweilige LRA lizenziert/aktiviert hat.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["label", "gebucht"],
+        "properties": {
+          "label":   { "type": "string" },
+          "gebucht": {
+            "type": "array",
+            "description": "Modul-IDs (aus fachverfahren ODER querschnitt). Sichtbar in dieser LRA = genau diese Menge.",
+            "items": { "type": "string" },
+            "uniqueItems": true
+          },
+          "variationspunkte": { "type": "object" }
+        }
+      }
+    }
+  }
+}

--- a/packages/iil-klickdummy/src/iil_klickdummy/schemas/screens-spec.schema.json
+++ b/packages/iil-klickdummy/src/iil_klickdummy/schemas/screens-spec.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "meiki:klickdummy-spec-fristenmanagement.schema",
+  "title": "Klickdummy Screens-Spec (App-Deep-Dive)",
+  "description": "I1 Spec-Schema. Konformität wird via `make klickdummy-i1` geprüft (platform:ADR-211).",
+  "type": "object",
+  "required": ["spec_id", "spec_version", "spec_date", "adr", "class", "grounding", "off_ramp", "personas", "screens"],
+  "additionalProperties": true,
+  "properties": {
+    "$schema":       { "type": "string" },
+    "spec_id":       { "type": "string", "pattern": "^[a-z][a-z0-9_-]*:[a-z][a-z0-9_-]*$" },
+    "spec_version":  { "type": "string", "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$" },
+    "spec_date":     { "type": "string", "format": "date" },
+    "title":         { "type": "string" },
+
+    "adr": {
+      "type": "object",
+      "required": ["local", "conforms_to"],
+      "properties": {
+        "local":       { "type": "string", "pattern": "^[a-z][a-z0-9_-]*:ADR-[0-9]{3}$" },
+        "conforms_to": { "type": "string", "pattern": "^platform:ADR-[0-9]{3}$" },
+        "sister_of": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_-]*:ADR-[0-9]{3}$" }
+        }
+      }
+    },
+
+    "class": {
+      "type": "string",
+      "enum": ["mock", "stub-demo", "story", "spec-demo"],
+      "description": "I2 Prod-Sicherheit (platform:ADR-211 Rev 11, 4-Pattern). Genau eine Klasse — kein vacuous pass."
+    },
+    "class_evidence": { "type": "object" },
+
+    "grounding": {
+      "type": "object",
+      "required": ["konzept", "pilot"],
+      "properties": {
+        "konzept":  { "type": "string" },
+        "konzept_id":     { "type": "string" },
+        "konzept_version":{ "type": "string" },
+        "pilot":          { "type": "string" },
+        "rechtsrahmen_kernnormen": { "type": "object" }
+      }
+    },
+
+    "off_ramp": {
+      "type": "object",
+      "required": ["policy", "unit", "rule", "doppelquell_grenze", "parity_runner"],
+      "properties": {
+        "policy":              { "type": "string" },
+        "unit":                { "type": "string", "enum": ["per-screen", "per-feature"] },
+        "rule":                { "type": "string" },
+        "doppelquell_grenze":  { "type": "string", "enum": ["prod-release"] },
+        "staging_doppelquell": { "type": "string", "enum": ["allowed"] },
+        "parity_runner":       { "type": "string" },
+        "product_repo_planned":{ "type": "string" },
+        "status_overall":      { "type": "string" }
+      }
+    },
+
+    "personas": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["label", "rolle", "sieht"],
+        "properties": {
+          "label": { "type": "string" },
+          "rolle": { "type": "string" },
+          "sieht": { "type": "array", "items": { "type": "string" } },
+          "sieht_eingeschraenkt": { "type": "array", "items": { "type": "string" } },
+          "freigaben": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+
+    "screens": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "title", "personas", "purpose", "parity_acceptance", "off_ramp_status"],
+        "additionalProperties": true,
+        "properties": {
+          "id":        { "type": "string", "pattern": "^[a-z][a-z0-9_-]*$" },
+          "title":     { "type": "string" },
+          "personas":  { "type": "array", "minItems": 1, "items": { "type": "string" } },
+          "purpose":   { "type": "string" },
+          "konzept_ref": { "type": "array", "items": { "type": "string" } },
+          "datafields": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["name"],
+              "additionalProperties": true,
+              "properties": {
+                "name":     { "type": "string" },
+                "type":     { "type": "string" },
+                "source":   { "type": "string" },
+                "semantic": { "type": "string" }
+              }
+            }
+          },
+          "target_mocks": { "type": "array", "items": { "type": "string" } },
+          "parity_acceptance": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["id", "check"],
+              "properties": {
+                "id":    { "type": "string", "pattern": "^[a-z][a-z0-9_.-]*$" },
+                "check": { "type": "string", "minLength": 8 }
+              }
+            }
+          },
+          "off_ramp_status": {
+            "type": "string",
+            "enum": ["static", "parity-staging", "parity-green", "removed"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/iil-klickdummy/tests/test_smoke.py
+++ b/packages/iil-klickdummy/tests/test_smoke.py
@@ -1,0 +1,68 @@
+"""Smoke tests for iil-klickdummy package — every public surface importable + callable."""
+from __future__ import annotations
+
+import json
+from importlib.resources import files
+
+import pytest
+
+
+def test_package_imports():
+    import iil_klickdummy
+    assert iil_klickdummy.__version__ == "1.0.0"
+
+
+def test_all_modules_present():
+    import iil_klickdummy
+    for mod in ("check_i1", "check_i2", "check_i3", "check_i4",
+                "extract_requirements", "inventory"):
+        assert hasattr(iil_klickdummy, mod), f"missing module: {mod}"
+
+
+def test_all_main_cli_endpoints():
+    import iil_klickdummy
+    for mod_name in ("check_i1", "check_i2", "check_i3", "check_i4",
+                     "extract_requirements", "inventory"):
+        mod = getattr(iil_klickdummy, mod_name)
+        assert callable(getattr(mod, "main_cli", None)), \
+            f"{mod_name}.main_cli missing"
+
+
+def test_schemas_resource():
+    schemas_dir = files("iil_klickdummy.schemas")
+    names = sorted(p.name for p in schemas_dir.iterdir())
+    assert "screens-spec.schema.json" in names
+    assert "module-manifest.schema.json" in names
+    assert "feedback-payload.schema.json" in names
+
+
+def test_screens_spec_schema_is_valid_json():
+    text = files("iil_klickdummy.schemas").joinpath("screens-spec.schema.json").read_text()
+    schema = json.loads(text)
+    assert schema["properties"]["class"]["enum"] == \
+        ["mock", "stub-demo", "story", "spec-demo"]
+
+
+def test_feedback_payload_schema_required_fields():
+    text = files("iil_klickdummy.schemas").joinpath("feedback-payload.schema.json").read_text()
+    schema = json.loads(text)
+    required = set(schema["required"])
+    assert {"screen", "category", "text", "spec_id",
+            "klickdummy_class", "timestamp"}.issubset(required)
+
+
+def test_check_i2_strict_mode():
+    """LEGACY must be empty per ADR-211 Rev 12 S11-Strict-Mode."""
+    from iil_klickdummy import check_i2
+    assert check_i2.LEGACY == {}, \
+        "iil-klickdummy ships strict-mode (LEGACY={}). Repos with legacy values must migrate first."
+    assert check_i2.ALLOWED == {"mock", "stub-demo", "story", "spec-demo"}
+
+
+def test_inventory_runs_clean_on_default_base():
+    """Inventory should at minimum import and run without crashing."""
+    import sys
+    from iil_klickdummy import inventory
+    # nonexistent base → all "NOT PRESENT", exit 0
+    exit_code = inventory.main(["--base", "/nonexistent/path/does/not/exist"])
+    assert exit_code == 0

--- a/scripts/checks/klickdummy_legacy_class_inventory.sh
+++ b/scripts/checks/klickdummy_legacy_class_inventory.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# platform/scripts/checks/klickdummy_legacy_class_inventory.sh
+# S11 Cross-Repo-Inventur per platform:ADR-211 Rev 12 §Migration.
+# Bootstrap-Bash (Fallback); kanonische Implementation: iil_klickdummy.inventory
+#
+# Exit 0 wenn 0 echte Treffer ⇒ Strict-Mode (LEGACY={}) aktivierbar.
+# Exit 1 sonst (+ Liste Repos+Pfade auf stdout).
+set -euo pipefail
+
+REPOS_BASE="${REPOS_BASE:-$HOME/github}"
+REPOS="${REPOS:-meiki-hub writing-hub risk-hub pptx-hub dev-hub ttz-hub}"
+PATTERNS='mock-prototyp|demo-render'
+
+# Beabsichtigte Referenzen ignorieren (LEGACY-Maps, History-Kommentare)
+INTENTIONAL_GREP='-v LEGACY|"mock-prototyp":\s*"mock"|"demo-render":\s*"spec-demo"|#\s*vorher\s+(mock-prototyp|demo-render)|\(vorher\s+(mock-prototyp|demo-render)'
+
+FOUND=0
+for repo in $REPOS; do
+  d="$REPOS_BASE/$repo"
+  [[ -d "$d" ]] || { echo "=== $repo: NOT PRESENT (skip) ==="; continue; }
+  matches=$(grep -rEn --include='*.yaml' --include='*.yml' --include='*.json' \
+            --include='*.md' --include='*.html' --include='*.py' "$PATTERNS" "$d" 2>/dev/null | \
+            grep -v 'node_modules\|\.venv\|__pycache__\|/build/\|/dist/\|feedback-log\|_archiv' | \
+            grep -Ev 'LEGACY|"mock-prototyp": "mock"|"demo-render": "spec-demo"|# vorher|\(vorher ' || true)
+  if [[ -n "$matches" ]]; then
+    echo "=== $repo ($(echo "$matches" | wc -l) Treffer) ==="
+    echo "$matches" | head -10
+    FOUND=1
+  else
+    echo "=== $repo: ✓ clean ==="
+  fi
+done
+
+if [[ $FOUND -eq 0 ]]; then
+  echo ""
+  echo "S11 → 0 echte Drift-Treffer cross-repo. Strict-Mode kann aktiviert werden."
+fi
+exit $FOUND

--- a/services/feedback-bridge/Dockerfile
+++ b/services/feedback-bridge/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY pyproject.toml .
+COPY src/ ./src/
+
+RUN pip install --no-cache-dir -e . && \
+    useradd -m -u 1001 bridge
+
+USER bridge
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD python -c "import httpx; httpx.get('http://localhost:8000/v1/health').raise_for_status()"
+
+CMD ["uvicorn", "feedback_bridge.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/feedback-bridge/pyproject.toml
+++ b/services/feedback-bridge/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "klickdummy-feedback-bridge"
+version = "0.1.0"
+description = "feedback.iil.pet — Pfad-A-Endpoint for Klickdummy Co-Creation-Loop (platform:ADR-214)"
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi>=0.110",
+    "uvicorn[standard]>=0.27",
+    "httpx>=0.27",
+    "pydantic>=2.0",
+    "iil-klickdummy>=1.0,<2.0",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0", "httpx>=0.27"]

--- a/services/feedback-bridge/src/feedback_bridge/main.py
+++ b/services/feedback-bridge/src/feedback_bridge/main.py
@@ -1,0 +1,160 @@
+"""feedback.iil.pet — Klickdummy Co-Creation-Loop Pfad A Endpoint.
+
+POST /v1/issues  — Widget submittet hier, Service erzeugt GitHub-Issue.
+
+Architektur (per platform:ADR-214 §E2):
+  1. Origin-Header → Repo-Mapping (Konfig)
+  2. PII-Filter (Heuristik) → payload_redacted-Flag bei Match
+  3. Rate-Limit pro Origin
+  4. GitHub API (Bot-PAT in Secret) → Issue create mit Label klickdummy-feedback
+  5. Audit-Log (JSON-Lines)
+  6. Response: { issue_url, ok }
+
+Skelett — Deployment via Traefik (platform:ADR-212) auf feedback.iil.pet.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Annotated, Any
+
+import httpx
+from fastapi import FastAPI, Header, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+log = logging.getLogger("feedback-bridge")
+app = FastAPI(title="klickdummy-feedback-bridge", version="0.1.0")
+
+# --- Config -----------------------------------------------------------------
+
+# Origin → GitHub-Repo (owner/repo) Mapping. Erweitern pro ADR-214 §Adoption.
+REPO_MAP: dict[str, str] = json.loads(os.environ.get("REPO_MAP_JSON", "{}"))
+# Default-Mapping bei leerer ENV — wird in prod via Secret/ConfigMap überschrieben:
+REPO_MAP = REPO_MAP or {
+    "https://klickdummy.meiki-lra.iil.pet": "meiki-lra/meiki-hub",
+    "https://klickdummy.writing.iil.pet":   "achimdehnert/writing-hub",
+    "https://klickdummy.risk.iil.pet":      "achimdehnert/risk-hub",
+}
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
+RATE_LIMIT_PER_HOUR = int(os.environ.get("RATE_LIMIT_PER_HOUR", "20"))
+AUDIT_LOG_PATH = Path(os.environ.get("AUDIT_LOG_PATH", "/var/log/feedback-bridge/audit.jsonl"))
+
+# --- PII-Filter (Heuristik) -------------------------------------------------
+
+PII_PATTERNS = [
+    (re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"), "<email>"),
+    (re.compile(r"\b\+?\d[\d\s\-/().]{7,}\d\b"), "<phone>"),
+    (re.compile(r"\b[A-Z]{2}\d{2}[A-Z0-9]{1,30}\b"), "<iban>"),
+]
+
+def _redact(text: str) -> tuple[str, bool]:
+    """Returns (redacted_text, was_redacted)."""
+    redacted = False
+    for pat, repl in PII_PATTERNS:
+        if pat.search(text):
+            text = pat.sub(repl, text)
+            redacted = True
+    return text, redacted
+
+# --- Rate-Limit (in-memory, simpel) -----------------------------------------
+
+_rate_state: dict[str, list[float]] = {}
+
+def _rate_check(origin: str) -> bool:
+    """True if within budget, False if exceeded."""
+    now = dt.datetime.now().timestamp()
+    window = 3600
+    bucket = [t for t in _rate_state.get(origin, []) if now - t < window]
+    if len(bucket) >= RATE_LIMIT_PER_HOUR:
+        return False
+    bucket.append(now)
+    _rate_state[origin] = bucket
+    return True
+
+# --- Models -----------------------------------------------------------------
+
+class FeedbackRequest(BaseModel):
+    payload: dict[str, Any]
+    markdown: str = Field(..., min_length=1, max_length=64_000)
+
+class FeedbackResponse(BaseModel):
+    ok: bool
+    issue_url: str | None = None
+    payload_redacted: bool = False
+    note: str | None = None
+
+# --- Endpoints --------------------------------------------------------------
+
+@app.get("/v1/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok", "version": app.version}
+
+@app.post("/v1/issues", response_model=FeedbackResponse)
+async def create_issue(
+    body: FeedbackRequest,
+    request: Request,
+    origin: Annotated[str | None, Header(alias="Origin")] = None,
+) -> FeedbackResponse:
+    # 1. Origin → Repo
+    if not origin or origin not in REPO_MAP:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "origin not in allowlist")
+    repo = REPO_MAP[origin]
+
+    # 2. Rate-Limit
+    if not _rate_check(origin):
+        raise HTTPException(status.HTTP_429_TOO_MANY_REQUESTS,
+                            f"rate limit {RATE_LIMIT_PER_HOUR}/h exceeded for origin")
+
+    # 3. PII-Filter
+    redacted_md, was_redacted = _redact(body.markdown)
+    title_base = (body.payload.get("category", "feedback")
+                  + " · " + (body.payload.get("screen") or "n/a"))
+    title = f"[Klickdummy-Feedback] {title_base}"
+
+    # 4. GitHub Issue create
+    if not GITHUB_TOKEN:
+        # Dev-Mode: log only
+        log.warning("GITHUB_TOKEN missing — dev-mode (no issue created)")
+        return FeedbackResponse(ok=True, issue_url=None, payload_redacted=was_redacted,
+                                note="dev-mode (no GITHUB_TOKEN)")
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        r = await client.post(
+            f"https://api.github.com/repos/{repo}/issues",
+            headers={"Authorization": f"Bearer {GITHUB_TOKEN}",
+                     "Accept": "application/vnd.github+json"},
+            json={"title": title, "body": redacted_md,
+                  "labels": ["klickdummy-feedback"]},
+        )
+    if r.status_code >= 300:
+        log.error("github create failed: %s %s", r.status_code, r.text[:200])
+        raise HTTPException(status.HTTP_502_BAD_GATEWAY, "github issue create failed")
+    issue = r.json()
+
+    # 5. Audit-Log
+    try:
+        AUDIT_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with AUDIT_LOG_PATH.open("a", encoding="utf-8") as f:
+            f.write(json.dumps({
+                "ts": dt.datetime.utcnow().isoformat() + "Z",
+                "origin": origin,
+                "repo": repo,
+                "issue_number": issue.get("number"),
+                "payload_redacted": was_redacted,
+                "screen": body.payload.get("screen"),
+                "category": body.payload.get("category"),
+                "spec_id": body.payload.get("spec_id"),
+            }) + "\n")
+    except OSError as e:
+        log.warning("audit log write failed: %s", e)
+
+    return FeedbackResponse(ok=True, issue_url=issue["html_url"],
+                            payload_redacted=was_redacted)
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/snippets/klickdummy/feedback-widget/widget.js
+++ b/snippets/klickdummy/feedback-widget/widget.js
@@ -1,0 +1,181 @@
+/**
+ * Klickdummy Feedback-Widget v0.4 — Shared Snippet (platform:ADR-214)
+ *
+ * Configuration (set BEFORE this script loads):
+ *   window.KLICKDUMMY_FEEDBACK_ENDPOINT  — POST URL (Pfad A), default null → download-Fallback
+ *   window.KLICKDUMMY_FEEDBACK_FORCE     — bool: bypass ?feedback=on opt-in
+ *   window.KLICKDUMMY_SPEC               — { id, version, klickdummy_class }
+ *
+ * Mount target: any <body>. Widget injects #fb-fab and #fb-panel itself.
+ * Repo MUST opt-in via URL ?feedback=on (default off — class-erhaltend).
+ *
+ * Empirie-Basis: meiki-hub PR #23, 7 Iterationen, v0.1→v0.4. Original-Code
+ * in meiki-hub/.../shell.html; hier konsolidiert + repo-agnostisch gemacht.
+ */
+
+(function () {
+  'use strict';
+  if (window.__klickdummyFeedbackLoaded) return;
+  window.__klickdummyFeedbackLoaded = true;
+
+  const SPEC = window.KLICKDUMMY_SPEC || {
+    id: 'unknown', version: '0.0', klickdummy_class: 'mock'
+  };
+  const ENDPOINT = window.KLICKDUMMY_FEEDBACK_ENDPOINT || null;
+
+  function fbEnabled() {
+    const qs = new URLSearchParams(location.search);
+    return qs.get('feedback') === 'on' || window.KLICKDUMMY_FEEDBACK_FORCE === true;
+  }
+
+  function injectStyles() {
+    if (document.getElementById('fb-styles')) return;
+    const css = `
+#fb-fab{position:fixed;right:20px;bottom:20px;z-index:200;background:#1a3a6c;color:#fff;width:54px;height:54px;border-radius:50%;border:none;font-size:22px;cursor:pointer;box-shadow:0 4px 16px rgba(0,0,0,.25);display:none}
+#fb-fab:hover{background:#005ea2}
+#fb-panel{position:fixed;right:20px;bottom:84px;z-index:201;width:380px;max-width:calc(100vw - 40px);background:#fff;border:1px solid #d8e0e8;border-radius:10px;box-shadow:0 8px 32px rgba(0,0,0,.25);padding:16px;display:none;font-family:system-ui,-apple-system,sans-serif}
+#fb-panel.open{display:block}
+#fb-panel h3{margin:0 0 8px;font-size:14px;color:#1a3a6c}
+#fb-panel .meta{font-size:11px;color:#6a7888;margin-bottom:10px}
+#fb-panel textarea{width:100%;min-height:120px;border:1px solid #d8e0e8;border-radius:6px;padding:8px;font-family:inherit;font-size:13px;box-sizing:border-box;resize:vertical}
+#fb-panel select{font-family:inherit;font-size:12px;padding:4px 6px;border-radius:6px;border:1px solid #d8e0e8;width:100%;margin-bottom:8px}
+#fb-panel .fb-actions{display:flex;gap:6px;margin-top:10px;flex-wrap:wrap}
+#fb-panel .fb-actions button{flex:1;font-size:12px;padding:7px 10px;border-radius:6px;cursor:pointer;font-family:inherit;font-weight:600;border:1px solid #d8e0e8;background:#fff;color:#3a4a5a}
+#fb-panel .fb-actions button.primary{background:#1a3a6c;border-color:#1a3a6c;color:#fff}
+#fb-panel .fb-foot{font-size:10px;color:#8893a3;margin-top:8px;line-height:1.5}
+`;
+    const s = document.createElement('style');
+    s.id = 'fb-styles';
+    s.textContent = css;
+    document.head.appendChild(s);
+  }
+
+  function injectMarkup() {
+    if (document.getElementById('fb-fab')) return;
+    const wrap = document.createElement('div');
+    wrap.innerHTML = `
+<button id="fb-fab" title="Feedback (Co-Development-Loop, ADR-211 Rev 12)">💬</button>
+<div id="fb-panel">
+  <h3>💬 Klickdummy-Feedback</h3>
+  <div class="meta">Screen <code id="fb-screen">—</code> · Spec <code>${SPEC.id} v${SPEC.version}</code> · Klasse <code>${SPEC.klickdummy_class}</code></div>
+  <label class="meta">Kategorie</label>
+  <select id="fb-cat">
+    <option value="bug">🐛 Fehler</option>
+    <option value="feature" selected>💡 Funktion / Anforderung</option>
+    <option value="ux">🎨 UX</option>
+    <option value="spec">📋 Spec-Lücke</option>
+    <option value="ki">🤖 KI-Idee</option>
+  </select>
+  <textarea id="fb-text" placeholder="Was beobachtest, vermisst, schlägst vor?"></textarea>
+  <div class="fb-actions">
+    <button id="fb-dl">⬇ Download .md</button>
+    <button id="fb-cb">📋 Clipboard</button>
+    <button class="primary" id="fb-ep">🚀 Senden</button>
+  </div>
+  <div class="fb-foot">Pfad A: ${ENDPOINT ? 'Endpoint ' + ENDPOINT : 'kein Endpoint konfiguriert — Download-Fallback'}</div>
+</div>`;
+    document.body.appendChild(wrap);
+    document.getElementById('fb-fab').addEventListener('click', toggle);
+    document.getElementById('fb-dl').addEventListener('click', () => submit('download'));
+    document.getElementById('fb-cb').addEventListener('click', () => submit('clipboard'));
+    document.getElementById('fb-ep').addEventListener('click', () => submit('endpoint'));
+  }
+
+  function currentScreen() {
+    const s = document.querySelector('section.active, [data-screen]');
+    return s ? (s.getAttribute('data-screen') || null) : null;
+  }
+
+  function toggle() {
+    const p = document.getElementById('fb-panel');
+    p.classList.toggle('open');
+    if (p.classList.contains('open')) {
+      document.getElementById('fb-screen').textContent = currentScreen() || '—';
+    }
+  }
+
+  function payload() {
+    return {
+      screen: currentScreen(),
+      category: document.getElementById('fb-cat').value,
+      text: document.getElementById('fb-text').value.trim(),
+      spec_id: SPEC.id,
+      spec_version: SPEC.version,
+      klickdummy_class: SPEC.klickdummy_class,
+      user_agent: navigator.userAgent,
+      viewport: { w: window.innerWidth, h: window.innerHeight },
+      timestamp: new Date().toISOString(),
+      url: location.href
+    };
+  }
+
+  function asMarkdown(p) {
+    return `---
+type: klickdummy-feedback
+spec_id: ${p.spec_id}
+spec_version: ${p.spec_version}
+klickdummy_class: ${p.klickdummy_class}
+screen: ${p.screen || '(n/a)'}
+category: ${p.category}
+timestamp: ${p.timestamp}
+---
+
+## [${p.category}] Klickdummy-Feedback · ${p.screen || '?'}
+
+${p.text}
+
+---
+*Quelle: \`${p.url}\` · UA: \`${p.user_agent}\`*
+`;
+  }
+
+  function toast(msg) {
+    // Fallback if host has no toast
+    if (typeof window.toast === 'function') return window.toast(msg);
+    console.log('[klickdummy-feedback]', msg);
+  }
+
+  async function submit(mode) {
+    const p = payload();
+    if (!p.text) { toast('Bitte Text eingeben'); return; }
+    const md = asMarkdown(p);
+    if (mode === 'download') {
+      const blob = new Blob([md], { type: 'text/markdown;charset=utf-8' });
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = `klickdummy-feedback-${p.screen || 'unknown'}-${Date.now()}.md`;
+      document.body.appendChild(a); a.click(); a.remove();
+      toast('Markdown heruntergeladen');
+    } else if (mode === 'clipboard') {
+      try { await navigator.clipboard.writeText(md); toast('In Clipboard'); }
+      catch (e) { toast('Clipboard nicht verfügbar — Download'); }
+    } else if (mode === 'endpoint') {
+      if (!ENDPOINT) { toast('Kein Endpoint — Download-Fallback'); return submit('download'); }
+      try {
+        const r = await fetch(ENDPOINT, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ payload: p, markdown: md })
+        });
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        const j = await r.json().catch(() => ({}));
+        toast('Gesendet · ' + (j.issue_url || 'OK'));
+        document.getElementById('fb-text').value = '';
+        toggle();
+      } catch (e) { toast('Senden fehlgeschlagen — ' + e.message); }
+    }
+  }
+
+  function init() {
+    if (!fbEnabled()) return;
+    injectStyles();
+    injectMarkup();
+    document.getElementById('fb-fab').style.display = 'block';
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/snippets/klickdummy/issue-template/klickdummy-feedback.md
+++ b/snippets/klickdummy/issue-template/klickdummy-feedback.md
@@ -1,0 +1,39 @@
+---
+name: 💬 Klickdummy-Feedback
+about: Feedback aus dem Klickdummy-Feedback-Widget (Co-Development-Loop, Pfad A)
+title: "[Klickdummy-Feedback] "
+labels: ["klickdummy-feedback"]
+assignees: []
+---
+
+<!--
+Vorlage für Issues, die das Klickdummy-Feedback-Widget erzeugt
+(opt-in via ?feedback=on). Der Coding-Agent reagiert auf Issues mit
+diesem Label und versucht einen PR mit den vorgeschlagenen Änderungen.
+
+Der Endpoint (feedback.iil.pet pro platform:ADR-214) sollte das vom
+Widget gelieferte Markdown direkt unten einfügen.
+-->
+
+## Kontext
+
+- **Spec:** _(aus payload.spec_id)_
+- **Klasse:** _(aus payload.klickdummy_class)_
+- **Screen:** _(aus payload.screen)_
+- **Kategorie:** _(bug | feature | ux | spec | ki)_
+
+## Feedback
+
+_(Markdown aus dem Widget hier einfügen — vom Endpoint übernommen.)_
+
+## Erwartetes Vorgehen (Coding-Agent)
+
+1. Issue lesen, Klassifikation übernehmen (Kategorie + Screen).
+2. Repro-Schritte oder Spec-Abgleich.
+3. PR mit Änderungen am Klickdummy ODER Hinweis im Issue, falls Diskussion vor Code nötig.
+4. Bei `category: spec`: erst Spec anpassen, dann Render.
+
+## Bezug
+
+- `platform:ADR-211` (Klickdummy-Cross-Repo-Rahmen)
+- `platform:ADR-214` (Plattform-Heimat, dieses Issue-Template)

--- a/snippets/klickdummy/shell-bootstrap/inject-widget.html
+++ b/snippets/klickdummy/shell-bootstrap/inject-widget.html
@@ -1,0 +1,20 @@
+<!--
+Klickdummy-Widget-Bootstrap (platform:ADR-214 §E1 Distribution Hybrid).
+Repos includen das in ihre shell.html (oder Build-Inline) — Snippet ist via
+Git-Submodul platform-snippets/ verfügbar.
+
+Voraussetzung im Host:
+  - body[data-screen] oder section.active[data-screen] (Widget findet aktiven Screen)
+  - optional window.toast(msg) (Widget hat Console-Fallback)
+-->
+<script>
+  // Klickdummy-Widget-Konfiguration (vor Widget-Script setzen!)
+  window.KLICKDUMMY_SPEC = {
+    id: "REPO:klickdummy-spec-NAME",        // ← anpassen
+    version: "0.1",                          // ← anpassen
+    klickdummy_class: "mock"                 // ← anpassen (mock|stub-demo|story|spec-demo)
+  };
+  // Endpoint: platform-default ODER repo-Override (für Gov-Workloads wie ttz-hub)
+  window.KLICKDUMMY_FEEDBACK_ENDPOINT = "https://feedback.iil.pet/v1/issues";
+</script>
+<script src="platform-snippets/klickdummy/feedback-widget/widget.js" defer></script>

--- a/snippets/klickdummy/spec-templates/screens-spec-template.yaml
+++ b/snippets/klickdummy/spec-templates/screens-spec-template.yaml
@@ -1,0 +1,51 @@
+# =============================================================================
+# Klickdummy Screens-Spec — Template (platform:ADR-214 §E1)
+# Pro platform:ADR-211 Rev 12 4-Pattern.
+#
+# Anweisung: kopieren nach <repo>/<klickdummy-pfad>/screens-spec.yaml,
+# Felder mit ↳ ANPASSEN markieren.
+# =============================================================================
+$schema: https://raw.githubusercontent.com/achimdehnert/platform/main/packages/iil-klickdummy/src/iil_klickdummy/schemas/screens-spec.schema.json
+spec_id: REPO:klickdummy-spec-NAME        # ↳ ANPASSEN — repo:klickdummy-spec-<name>
+spec_version: "0.1"
+spec_date: "YYYY-MM-DD"                   # ↳ ANPASSEN
+title: NAME — App-Deep-Dive Klickdummy   # ↳ ANPASSEN
+
+# ---- I4 ADR-Verankerung ----------------------------------------------------
+adr:
+  local: repo:ADR-NNN                     # ↳ ANPASSEN — repo-lokales Klickdummy-ADR
+  conforms_to: platform:ADR-211
+  sister_of: []                           # optional: repo:ADR-NNN-Refs
+
+# ---- I2 Prod-Sicherheit ----------------------------------------------------
+class: mock                               # ↳ WÄHLEN — mock | stub-demo | story | spec-demo
+class_evidence:
+  # Belege für die Klasse (Strukturkonform mit platform:ADR-211 §Auswahlhilfe)
+  no_backend: true                        # für mock
+  no_demo_param: true                     # für mock
+  target_mocks_visible: true              # für mock
+  systemgrenzen: []                       # generische Adapter-Familien
+
+# ---- I3 Off-Ramp ----------------------------------------------------------
+off_ramp:
+  policy: platform:ADR-211 Static→Echt-Migrationspfad
+  unit: per-screen
+  rule: "Parity-grün pro Screen ⇒ Screen aus statischer Quelle entfernen"
+  doppelquell_grenze: prod-release
+  parity_runner: make klickdummy-i3
+
+# ---- Optional: Co-Creation-Loop (Pfad A — platform:ADR-211 Rev 12 §C) -----
+# feedback_loop:
+#   path: A
+#   enabled_by: "URL-Parameter ?feedback=on (opt-in)"
+#   ...
+
+# ---- Screens ---------------------------------------------------------------
+screens:
+  - id: example                           # ↳ ANPASSEN
+    title: Example Screen
+    purpose: Beispiel-Screen für Klickdummy-Template
+    parity_acceptance:
+      - id: example.first-check
+        check: "Erste Acceptance-Behauptung"
+    off_ramp_status: static


### PR DESCRIPTION
**Draft — bittet um Review.** Phase 1 von ADR-214. Etabliert die in platform:ADR-211 Rev 12 als „Best-Effort" markierte Plattform-Heimat als konkrete Mechanik.

## Drei Bausteine geliefert

1. **`packages/iil-klickdummy/` v1.0.0** — pip-Paket via Git-URL (F1 geschlossen)
   - check_i1..i4.py / extract_requirements.py / inventory.py (S11)
   - Schemas: screens-spec, module-manifest, feedback-payload (alle Rev-11 strict)
   - 8 Smoke-Tests grün (incl. `LEGACY={}` Strict-Mode-Beleg)
   - Console-Scripts: `klickdummy-i1..i4`, `-extract-requirements`, `-inventory`

2. **`snippets/klickdummy/`** — HTML/JS/Templates (v1.0 in platform/snippets/, v1.1 in pip package_data)
   - feedback-widget/widget.js (repo-agnostisch portiert aus meiki v0.4)
   - issue-template + spec-template + shell-bootstrap

3. **`services/feedback-bridge/`** — FastAPI-Service-Skelett für feedback.iil.pet
   - POST /v1/issues mit Origin-Allowlist, Rate-Limit, PII-Filter, Audit-Log
   - Dockerfile + Health-Check; Deployment via Traefik (ADR-212) separater Infra-PR

## Adversarial Pass · 6 Findings eingearbeitet

| # | Schwere | Was geändert |
|---|---|---|
| J1 | 🔴 | F1 Paket-Distribution konkret: pip via Git-URL (`@v1.0.0#subdirectory=...`) statt offen |
| J2 | 🔴 | **E1 vereinfacht zu pip-only** — Submodul-Ansatz verworfen (würde platform-Repo hunderte MB schwer machen) |
| J3 | 🟡 | Coding-Agent-Watcher konkret: GitHub Action pro Repo (F4) |
| J4 | 🟡 | Rate-Limit als v1 single-replica markiert; Multi-Replica Rev 2 |
| J5 | 🟡 | PII-Filter als 'Best-Effort, NICHT DSGVO' deklariert; Gov-Repos Endpoint-Override Pflicht |
| J6 | 🟡 | Snippet-Templating als F7 (sed/envsubst im Migrations-Cookbook) |

## Cross-Repo-Inventur (S11 live)

```
=== meiki-hub: ✓ clean ===
=== writing-hub: ✓ clean ===
=== risk-hub: ✓ clean ===
=== pptx-hub: ✓ clean ===
=== dev-hub: ✓ clean ===
=== ttz-hub: ✓ clean ===
S11 → 0 echte Drift-Treffer cross-repo. Strict-Mode kann aktiviert werden.
```

## Vor Acceptance noch zu tun

- [ ] Decider ratifiziert E1/E2/E3-Wahl
- [ ] Pilot-Migration (meiki-hub) erfolgreich (Phase 2)
- [ ] Mindestens 1 Stakeholder-Iteration produktiv durch Endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
