### PR TITLE
[DRAFT] ADR-211 Rev 13 — Plattform-Heimat (pip-Paket) + Co-Creation-Pfade A neu (Decider-Pivot)

### DIFF
--- a/docs/adr/ADR-211-klickdummy-benutzeranforderungen-entwicklungsprozess.md
+++ b/docs/adr/ADR-211-klickdummy-benutzeranforderungen-entwicklungsprozess.md
@@ -23,7 +23,7 @@ scope:
 - **Datum:** 2026-05-19
 - **Entscheider:** Achim Dehnert
 - **Verwandt:** risk-hub:ADR-046, writing-hub:ADR-180, meiki-hub:ADR-020, meiki-hub:ADR-026 (Rev 12)
-- **Adversarial reviews:** sechs Cascade-Pässe (Rev 2/3/4/9 + Rev 10 F5-Rollback + Rev 11 #228/#229) + Rev-12-Empiriebasis (meiki-hub PR #23, 7 Iterationen 2026-05-20), siehe Revisionshistorie
+- **Adversarial reviews:** sechs Cascade-Pässe (Rev 2/3/4/9 + Rev 10 F5-Rollback + Rev 11 #228/#229) + Rev-12-Empiriebasis (meiki-hub PR #23, 7 Iterationen 2026-05-20) + Rev-13-Decider-Pivot (ADR-214-Draft als advocatus diabolus zurückgezogen, 4 🔴-Findings), siehe Revisionshistorie
 
 ## Zusammenfassung
 
@@ -233,13 +233,31 @@ Widget bleibt unter `class: mock` ein Mock-Pfad ohne Backend; bei
 `spec-demo` o. ä. greift weiterhin der Prod-Guard). Kein Pflicht-Pattern —
 Repos, die ohne Co-Creation auskommen, müssen nichts implementieren.
 
-**Erlaubte Pfade entlang Vertrauens-Perimeter:**
+**Erlaubte Pfade entlang Vertrauens-Perimeter** (Rev 13 neu strukturiert
+nach Decider-Pivot 2026-05-20: zentraler Endpoint zurückgezogen, da
+0 produktive Iterationen in 7 meiki-Iter. + Coding-Agent existiert nicht):
 
-| Pfad | Was | Status in Rev 12 |
+| Pfad | Was | Status in Rev 13 |
 |---|---|---|
-| **A · Bridge** | Widget → Endpoint → Issue → Coding-Agent → Diff-PR | **Erlaubt + Default.** Auditierbar, kein LLM-Call aus Browser. |
-| **B · Direkt-LLM** | Widget → Endpoint → LLM → Diff-PR | **Erlaubt nach plattformweiter A-Adoption** (mindestens 2 Repos mit Pfad A produktiv) **und** Existenz eines plattformseitigen LLM-Audit-Frameworks (Logging, Rate-Limit, CSRF, Spam-Schutz, Cost-Cap). „Repo-lokale A-Erfahrung" reicht nicht — B ist plattformweite Reife-Stufe. |
-| **C · Browser-LLM** | Widget → LLM mit Code-Schreib-Rechten aus Browser | **Verboten.** Außerhalb des Rahmens dieses ADR. Aktivierung erfordert **neuen ADR** (mit Audit-/Threat-Model). „Nicht umgesetzt" ist ungenügend — der Pfad ist nicht prospektiv-erlaubt. |
+| **A-light** | Widget → Submit-Mode `download` oder `clipboard` → Issue manuell anlegen | **Default.** Offline-fähig, kein GitHub-Token nötig, kein Service-Abhängigkeit. Empirisch validiert durch meiki-Iter. 1-7. |
+| **A-User-Direct** | Widget → Submit-Mode `github` → `POST api.github.com/repos/.../issues` mit **User-PAT** (im `localStorage.klickdummy_github_token`) | **Erlaubt + Default für GitHub-User-Workflows.** Issue-Author = realer User; Rate-Limit/Audit/CSRF GitHub-native (5000 req/h pro Token); kein Service zu betreiben; kein PII-Filter-Risiko (User entscheidet selbst, was committet wird — analog zum normalen Issue-Anlegen). |
+| **A-Agent** *(noch nicht aktiviert)* | Issue mit Label `klickdummy-feedback` → automatischer Coding-Agent → Diff-PR | **Voraussetzung:** GitHub-Action wie `anthropics/claude-code-action` o. ä. **im Ziel-Repo eingerichtet.** Aktuell in **keinem** Repo aktiv. „A-Agent aktiviert" = nachzuweisen per Workflow-Existenz, nicht per Behauptung. |
+| **B · Direkt-LLM** | Widget → LLM direkt | **Verboten** in dieser Rev. Aktivierung erfordert neuen ADR (Audit-/Threat-Model, Cost-Cap). Wäre nicht „Browser → LLM mit Code-Rechten" (das war C in Rev 12), sondern „Browser → Backend → LLM" — also auch ein Service. Wenn Service-Bedarf empirisch belegt ist (S9 zeigt skaliertes Co-Creation), neu evaluieren. |
+| **C · Browser-LLM** | Widget → LLM mit Code-Schreib-Rechten aus Browser | **Verboten.** Wie Rev 12. |
+
+**Pivot-Begründung (Rev 13):** Rev 12 hatte „A · Bridge" als Pfad-A-Default
+mit zentralem Endpoint `feedback.iil.pet` vorgesehen. Decider-Review
+2026-05-20 (4 K-Findings 🔴) verwarf das:
+
+- **K1**: 0 produktive Endpoint-Iterationen — Hypothese, nicht Empirie
+- **K3**: Coding-Agent existiert nicht — Service ohne Konsument
+- **K6/K12**: Service-Wartung amortisiert sich nicht
+- **K10**: Datenschutz-Default falsch herum (4/6 Repos sind sensibel)
+
+**GitHub-Direkt-API ist 2026-Standard** für solche Mini-Tools — Audit/
+Rate-Limit/Auth-Modell sind native. Wenn Skalierung später Service
+erfordert, kann „A-Bridge" als neuer Pfad in Rev 14 mit Empirie ergänzt
+werden — bis dahin nicht gebaut.
 
 **Aktivierungs-Definition** (eindeutig, prüfbar):
 
@@ -251,8 +269,10 @@ Bedingungen erfüllt sind:**
 2. Widget ist in der Klickdummy-Render-Quelle vorhanden UND opt-in
    (Default: aus; z. B. `?feedback=on` oder Build-Flag).
 3. Provenance-Log `feedback-log.md` existiert neben der Spec.
-4. **Pfad-Deklaration**: `feedback_loop.path: A | B` (Pfad C ist verboten,
-   siehe Pfade-Tabelle). Verhindert Vacuous-Pass „aktiviert ohne Pfad".
+4. **Pfad-Deklaration**: `feedback_loop.path: A-light | A-User-Direct | A-Agent`
+   (Rev 13 — Pfade B/C bleiben verboten). Verhindert Vacuous-Pass „aktiviert
+   ohne Pfad". `A-Agent` setzt nachgewiesene Coding-Agent-Workflow-Existenz
+   im Repo voraus.
 5. Repo-lokales Klickdummy-ADR referenziert die Aktivierung — bevorzugt
    `tags: [klickdummy, co-creation]` (analog Requirements-Bridge); Fallback
    Body-Section `## Co-Creation-Loop aktiv (Pfad <A|B>)`.
@@ -410,6 +430,66 @@ behoben).
 CLI-Flags (`--out-dir`, `--no-cleanup`, `--strict-class`). Bis dahin gilt
 die meiki-hub-Implementierung als Referenz; copy-paste-Adoption erlaubt;
 Migration auf Plattform-Heimat innerhalb 30 Tagen nach Bereitstellung.
+
+## §Distribution — Plattform-Heimat (Rev 13)
+
+**Was Rev 12 als „Best-Effort, kein Termin" markierte, ist jetzt konkret.**
+Auslöser: ttz-hub als 6. Klickdummy-Repo + Anspruch *„permanente
+Weiterentwicklung wirkt cross-repo"*.
+
+### Drei Bausteine
+
+| Material | Wo | Wie |
+|---|---|---|
+| **Python-Code** (`check_i1..i4`, `extract_requirements`, `inventory`, `install_snippets`) | `platform/packages/iil-klickdummy/src/iil_klickdummy/` | **pip-Paket** via Git-URL: `pip install "iil-klickdummy @ git+https://github.com/achimdehnert/platform.git@v1.0.0#subdirectory=packages/iil-klickdummy"`. Privates PyPI (sobald `pypi.iil.pet` aufgesetzt) ⇒ `pip install "iil-klickdummy>=1.0,<2.0"`. |
+| **JSON-Schemas** + **HTML-Snippets** (Widget v0.5, Issue-Template, Spec-Template, Shell-Bootstrap) | `iil_klickdummy/{schemas,snippets}/` als `package_data` | Mitversendet im pip-Paket. Snippet-Installation pro Repo via Console-Script `klickdummy-install-snippets [--symlink]` nach `<repo>/platform-snippets/klickdummy/`. |
+| **Convention-Pfade** (z. B. `~/.claude/policies/klickdummy.md`) | platform-Worktree | **Symlink** (Bestand aus Rev 5, unverändert). |
+
+**Distributions-Wahl-Begründung (Decider-Pivot 2026-05-20):** Initial-Vorschlag
+„pip + Git-Submodul" wurde verworfen — Submodul auf platform/ würde das
+ganze Repo (hunderte MB) in jeden Klickdummy-Repo ziehen. Sparse-Checkout
+ist fragil. **Reine pip-Lösung mit `package_data` für HTML** ist
+idiomatisches Python (django/flask/pip-tools machen es so).
+
+### Versionierung
+
+semver. Git-Tag `v{X.Y.Z}` auf platform-main. Repos pinnen
+`@vX.Y.Z#subdirectory=...` für reproduzierbare Builds; Major-Bump = ADR-
+Update mit Migrations-Cookbook (analog F12-Soft-Migrate). v1.0.0 enthält
+den Strict-Mode-Stand (Rev 12 + Pfad-A-Pivot 2026-05-20).
+
+### Widget v0.5 — Plugin-Architektur (Rev 13)
+
+Widget verlangt Konfiguration über `window.KLICKDUMMY_*`-Globals:
+
+```js
+window.KLICKDUMMY_SPEC = { id, version, klickdummy_class };
+window.KLICKDUMMY_FEEDBACK_REPO = "owner/repo";
+// optional:
+window.KLICKDUMMY_CATEGORIES = [{value,label}, ...];     // override default 5
+window.KLICKDUMMY_PERSONA_HOOK = () => '<persona>';
+window.KLICKDUMMY_VERFAHREN_HOOK = () => '<verfahren>';
+```
+
+**Plugin-Hooks** machen Repo-Customization möglich ohne Fork — z. B.
+ttz-hub-Categories (`datenschutz-bedenken`), risk-hub-Categories
+(`compliance`), oder repo-spezifische Persona-Auflösung.
+
+### Coding-Agent (Pfad A-Agent, Vorausschau)
+
+Statt zentralem Service: **GitHub-Action pro Repo**, getriggert auf Label
+`klickdummy-feedback`. Workflow-Skelett unter `iil_klickdummy/snippets/`
+(als Rev-13-Folge-PR; v1.0 liefert nur das Issue-Template). Existenz der
+Action ist die Voraussetzung für Pfad-A-Agent-Aktivierung (siehe
+§Co-Creation Aktivierungs-Bedingung 4).
+
+### Eigenständiges ADR — bewusst NICHT
+
+Rev 12 hatte „Plattform-Heimat" als „Best-Effort". Rev 13 macht sie konkret,
+**bleibt aber in ADR-211**, weil Distribution-Mechanik ohne Service-Boundary
+keine neue Architektur-Entscheidung mehr ist (`adr-threshold.md`: „following
+an existing pattern" → kein eigener ADR). Decider-Review 2026-05-20 verwarf
+ADR-214-Draft mit dieser Begründung.
 
 ## §Migration Rev-≤10 → Rev-11 (Rev 12, F12 in Schließung)
 
@@ -575,6 +655,7 @@ Sechs Cascade-Adversarial-Pässe + Schema-/YAML-Härtung:
 - **Rev 10** — **F5 zurückgenommen:** ADR-207 ist Doku-Strategie/Ingest-Trichter (eine Doku-Wahrheit pro Repo, MD>PDF>docx, inbox-Trichter) — **nicht** Cross-Repo-ADR-Namensraum. Die I4-Auslagerung war thematische Fehl-Zuordnung. **I4 zurück in ADR-211** (klickdummy-skopiert; eine plattformweite Verallgemeinerung wäre ein eigener ADR, nicht ADR-207). `depends_on: []`, „drei"→„vier Invarianten" zurück, ADR-207 aus Verwandt/Bezug entfernt (war nur wegen F5 drin).
 - **Rev 11 (Bundle #228/#229; orthogonal zu Rev 10)** — **F9 (#229):** I2 von 2 → **4 scharf abgegrenzte Patterns** (`mock`/`stub-demo`/`story`/`spec-demo`) entlang *Datenquelle × Code-Pfad-Identität*. Jedes Pattern erhält eine **distinkte** I2-Externprobe (mock = N/A; sonst je eigene Route/Query). Vermeidet das Theater-Risiko des 4-Pattern-Splits, weil die *Enforcement* je Pattern wirklich anders ist (siehe Glossar/Auswahlhilfe). **F10 (#228):** `sunset_after`-Pflicht-Frontmatter für repo-lokale Klickdummy-ADRs (nicht ADR-211 selbst); Phase-A bekommt damit einen *harten* Termin unabhängig von Parity. Auto-`deprecated` nach Frist, Extension via PR-Review. Enforcement-Script `adr_sunset.sh` als Scoreboard-Item S7; S8 = 4-Pattern-Konformität. I4 bleibt bestehen (Rev 10). **Offene Folge-Punkte:** (F11) `klickdummy_prod_guard.sh` muss pattern-spezifisch verzweigen (Issue #255 SF3-AC vor Bau anpassen); (F12) Migrations-Mapping bestehender Rev-≤10 `Demo-Render`-Repos auf eines der drei Nicht-`mock`-Patterns.
 - **Rev 12 (Empirie-getrieben aus meiki-hub PR #23, 7 Iterationen 2026-05-20)** — **Erweiterung, kein neuer Entscheid**; `status` bleibt `accepted`. Pre-Check per `adr-threshold.md`: keine neue Boundary, kein 5. Invariant, kein eigener ADR-21X. **F12 in Schließung** (§Migration Rev-≤10 → Rev-11) — Soft-Migrate-Pattern mit **Hard-Deadline 2026-08-20** (Rev-11-Datum + 3 Monate) etabliert; vor Deadline ⚠-Warning, ab Deadline FAIL; Strict-Mode-Trigger als Scoreboard-Item S11 (Inventur-Skript ODER Deadline schließt F12). **Zwei optionale Capabilities** als Erweiterung von I1: **§Co-Creation-Loop** (Stakeholder-Feedback aus Klickdummy → Spec, 3 Vertrauens-Pfade A/B/C — meiki-hub:ADR-026 als Referenz) und **§Requirements-Bridge** (Spec → UC/FR/NFR/Lasten/Pflicht, deterministisch + drift-aware, asymmetrisch — Forward auto, Reverse menschlich). Scoreboard erweitert um S9 (Co-Creation-Adoption), S10 (Requirements-Bridge-Adoption), S11 (Strict-Mode-Trigger). **Iteration-Typologie:** *stakeholder-getriggert* (klassisch) + *compliance-getriggert* (Policy-Hook erkennt Drift → dieselbe Pipe — meiki Iter. 7 als Erstanwendung). **Reflexivität dokumentiert** (Widget kann sich über sich selbst weiterentwickeln, meiki Iter. 6). **F11 weiterhin offen** (pattern-spezifischer Prod-Guard — gehört in Issue #255-Umsetzung, nicht ADR-Text).
+- **Rev 13 (Decider-Pivot 2026-05-20 — Plattform-Heimat konkret + Co-Creation-Pfade neu)** — Auslöser: ttz-hub als 6. Klickdummy-Repo + Anspruch *„permanente Weiterentwicklung wirkt cross-repo"*. **Initial ADR-214-Draft (Distribution + Service-Endpoint) wurde nach Decider-Review als advocatus diabolus zurückgezogen** (4 🔴-Findings: K1 0% Empirie für Endpoint, K3 Coding-Agent existiert nicht, K6/K12 Service-Wartung ohne ROI, K10 Datenschutz-Default falsch herum). **Konsequenzen in Rev 13:** (a) **§Distribution** als ADR-211-§ statt ADR-214 (`adr-threshold.md`: ohne Service-Boundary keine neue Architektur-Entscheidung). pip-Paket `iil-klickdummy` v1.0.0 mit Schemas + Skripten + Widget v0.5 als `package_data`; via Git-URL bis privates PyPI aufgesetzt ist. (b) **§Co-Creation Pfade A neu strukturiert:** `A-light` (download/clipboard, empirisch validiert) + `A-User-Direct` (Widget POSTet direkt an `api.github.com` mit User-PAT in localStorage — GitHub-native Audit/Rate-Limit/Auth) + `A-Agent` (GitHub-Action pro Repo, Voraussetzung nachweisbar). „A-Bridge" mit zentralem Endpoint **gestrichen** — wenn Skalierung Service erfordert, neu evaluieren in Rev 14. (c) **Plugin-Architektur im Widget** (`KLICKDUMMY_CATEGORIES`/`PERSONA_HOOK`/`VERFAHREN_HOOK`) — Repo-Customization ohne Fork. (d) **Widget v0.5 = voller meiki-v0.4-Stand** (Action-Liste, DOM-Snapshot, File-Upload, Scope-Selector, Verfahrens-Kontext) — Iterations-Rückschritt bei Adoption vermieden.
 
 ## Bezug
 

--- a/packages/iil-klickdummy/README.md
+++ b/packages/iil-klickdummy/README.md
@@ -1,0 +1,67 @@
+# `iil-klickdummy` — Shared Infrastructure for `platform:ADR-211` (Rev 13)
+
+> Versioniertes pip-Paket mit allem, was Klickdummy-Konformität braucht:
+> Schemas, Konformitäts-Checks (I1–I4), Requirements-Bridge, S11-Inventur,
+> **und** das Feedback-Widget v0.5 (Co-Creation-Loop, GitHub-Direkt-API).
+
+## Install
+
+```bash
+pip install "iil-klickdummy @ git+https://github.com/achimdehnert/platform.git@v1.0.0#subdirectory=packages/iil-klickdummy"
+```
+
+Privates PyPI (sobald aufgesetzt):
+
+```bash
+pip install "iil-klickdummy>=1.0,<2.0"
+```
+
+## Console-Scripts
+
+```bash
+klickdummy-i1 <spec>:<schema> ...          # Spec ↔ Route Coverage
+klickdummy-i2 <spec>:<schema> ...          # 4-Pattern (strict-mode)
+klickdummy-i3 <spec>:<schema> ...          # Off-Ramp + Sunset
+klickdummy-i4 docs/                        # Cross-Repo-Ref-Format
+klickdummy-extract-requirements <spec>     # Spec → UC/FR/NFR/Lasten/Pflicht
+klickdummy-inventory                       # S11 cross-repo legacy class scan
+klickdummy-install-snippets [--symlink]    # HTML+JS+templates in <repo>/platform-snippets/
+```
+
+## Feedback-Widget (v0.5)
+
+Browser-side, opt-in via `?feedback=on`. Submit-Modes:
+
+| Mode | Was passiert |
+|---|---|
+| `download` | Markdown-Datei (offline-fähig, kein GitHub-Token nötig) |
+| `clipboard` | navigator.clipboard.writeText |
+| `github` | **POST direkt an `api.github.com/repos/.../issues`** mit User-PAT aus `localStorage.klickdummy_github_token`; Issue-Author = realer GitHub-User; Audit native |
+
+**Konfiguration im Host (vor Widget-Script-Tag):**
+
+```html
+<script>
+  window.KLICKDUMMY_SPEC = { id: "repo:klickdummy-spec-<name>", version: "0.1", klickdummy_class: "mock" };
+  window.KLICKDUMMY_FEEDBACK_REPO = "owner/repo";        // GitHub-Zielrepo
+  // optional Plugin-Hooks:
+  window.KLICKDUMMY_CATEGORIES = [...];                  // override default 5
+  window.KLICKDUMMY_PERSONA_HOOK = () => '...';
+  window.KLICKDUMMY_VERFAHREN_HOOK = () => '...';
+</script>
+<script src="platform-snippets/klickdummy/feedback-widget/widget.js" defer></script>
+```
+
+## Schemas (importlib.resources)
+
+```python
+from importlib.resources import files
+import json
+schema = json.loads(files("iil_klickdummy.schemas").joinpath("screens-spec.schema.json").read_text())
+```
+
+## Bezug
+
+- `platform:ADR-211` Rev 13 — Konvention + Distribution + Co-Creation-Pfade
+- `platform:ADR-212` — Traefik-Ingress (für künftige PyPI-Selbsthost)
+- `platform:ADR-213` — Cross-Repo-Ref-Format (was `klickdummy-i4` prüft)

--- a/packages/iil-klickdummy/pyproject.toml
+++ b/packages/iil-klickdummy/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "iil-klickdummy"
+version = "1.0.0"
+description = "Shared infrastructure for platform:ADR-211 Rev 13 Klickdummy conformance + Co-Creation-Widget"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "Achim Dehnert", email = "achim.dehnert@iil.gmbh" }]
+keywords = ["klickdummy", "adr-211", "spec-driven-ui", "mockup", "requirements"]
+dependencies = ["pyyaml>=6.0", "jsonschema>=4.0"]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0", "pytest-cov>=4.0"]
+
+[project.urls]
+"Homepage" = "https://github.com/achimdehnert/platform"
+"ADR-211" = "https://github.com/achimdehnert/platform/blob/main/docs/adr/ADR-211-klickdummy-benutzeranforderungen-entwicklungsprozess.md"
+
+[project.scripts]
+klickdummy-i1 = "iil_klickdummy.check_i1:main_cli"
+klickdummy-i2 = "iil_klickdummy.check_i2:main_cli"
+klickdummy-i3 = "iil_klickdummy.check_i3:main_cli"
+klickdummy-i4 = "iil_klickdummy.check_i4:main_cli"
+klickdummy-extract-requirements = "iil_klickdummy.extract_requirements:main_cli"
+klickdummy-inventory = "iil_klickdummy.inventory:main_cli"
+klickdummy-install-snippets = "iil_klickdummy.install_snippets:main_cli"
+
+[tool.setuptools.package-data]
+iil_klickdummy = [
+    "schemas/*.json",
+    "snippets/feedback-widget/*",
+    "snippets/issue-template/*",
+    "snippets/spec-templates/*",
+    "snippets/shell-bootstrap/*",
+]

--- a/packages/iil-klickdummy/src/iil_klickdummy/__init__.py
+++ b/packages/iil-klickdummy/src/iil_klickdummy/__init__.py
@@ -1,0 +1,20 @@
+"""iil-klickdummy — shared infrastructure for platform:ADR-211 Rev 13.
+
+Public surface:
+    check_i1, check_i2, check_i3, check_i4 — invariant checks
+    extract_requirements                    — Spec → UC/FR/NFR/Lasten/Pflicht
+    inventory                               — S11 Cross-Repo Legacy-Inventur
+    install_snippets                        — copy/symlink HTML+JS+templates into a repo
+
+Distribution: pip via Git-URL (v1.0+, ADR-211 Rev 13 §Distribution).
+Snippets shipped as package_data; consumers install them via
+`klickdummy-install-snippets` console-script.
+"""
+
+__version__ = "1.0.0"
+__author__ = "Achim Dehnert"
+
+from . import (  # noqa: F401
+    check_i1, check_i2, check_i3, check_i4,
+    extract_requirements, inventory, install_snippets,
+)

--- a/packages/iil-klickdummy/src/iil_klickdummy/check_i1.py
+++ b/packages/iil-klickdummy/src/iil_klickdummy/check_i1.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""I1 Spec-first — Spec gegen JSON-Schema validieren.
+
+Aufruf:  python3 scripts/klickdummy/check_i1.py <spec_path>:<schema_path> [...]
+Policy:  ~/.claude/policies/klickdummy.md · platform:ADR-211
+Exit:    0 = PASS, 1 = FAIL, 2 = Setup-Fehler (fehlende Deps)
+"""
+from __future__ import annotations
+import json, pathlib, sys
+
+try:
+    import yaml  # PyYAML
+except ImportError:
+    print("FAIL (setup): PyYAML fehlt. pip install pyyaml")
+    sys.exit(2)
+
+try:
+    import jsonschema
+except ImportError:
+    print("FAIL (setup): jsonschema fehlt. pip install jsonschema")
+    sys.exit(2)
+
+
+def load(path: str):
+    text = pathlib.Path(path).read_text(encoding="utf-8")
+    if path.endswith((".yaml", ".yml")):
+        return yaml.safe_load(text)
+    return json.loads(text)
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("Usage: check_i1.py <spec>:<schema> ...")
+        return 2
+    errs = 0
+    print("== I1 Spec-first ==")
+    for pair in argv:
+        if ":" not in pair:
+            print(f"  ✗ ungültiger Eintrag: {pair!r}")
+            errs += 1
+            continue
+        spec_path, schema_path = pair.split(":", 1)
+        print(f"  · {spec_path}")
+        try:
+            spec = load(spec_path)
+            schema = load(schema_path)
+            jsonschema.validate(spec, schema)
+            print(f"      ✓ schema-konform ({schema_path})")
+        except FileNotFoundError as e:
+            print(f"      ✗ Datei fehlt: {e.filename}")
+            errs += 1
+        except jsonschema.ValidationError as e:
+            loc = "/".join(str(p) for p in e.absolute_path) or "(root)"
+            print(f"      ✗ Schema-Verletzung @ {loc}: {e.message}")
+            errs += 1
+        except Exception as e:  # noqa: BLE001
+            print(f"      ✗ {type(e).__name__}: {e}")
+            errs += 1
+    print(f"I1 → {'PASS' if errs == 0 else f'FAIL ({errs})'}")
+    return 0 if errs == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))
+
+
+def main_cli() -> int:
+    """Console-Script entry (pyproject.toml [project.scripts])."""
+    import sys
+    return main(sys.argv[1:])

--- a/packages/iil-klickdummy/src/iil_klickdummy/check_i2.py
+++ b/packages/iil-klickdummy/src/iil_klickdummy/check_i2.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""I2 Prod-Sicherheit — genau EINE Klasse explizit deklariert.
+
+Mock-Prototyp (kein Backend, Target-Mock) ODER Demo-Render (env-gated, in Prod
+unerreichbar). Keine Klasse = Verstoß (kein vacuous pass).
+
+Akzeptierte Felder im Spec-Root:
+  - `class`              (YAML/JSON, neue Specs)
+  - `klickdummy_class`   (additive Variante für Bestands-Manifeste)
+
+Aufruf:  python3 scripts/klickdummy/check_i2.py <spec>:<schema> [...]
+Exit:    0 = PASS, 1 = FAIL, 2 = Setup-Fehler
+"""
+from __future__ import annotations
+import json, pathlib, sys
+
+try:
+    import yaml
+except ImportError:
+    print("FAIL (setup): PyYAML fehlt. pip install pyyaml")
+    sys.exit(2)
+
+ALLOWED = {"mock", "stub-demo", "story", "spec-demo"}
+# Strict-Mode aktiv seit 2026-05-20 (platform:ADR-211 Rev 12 §Migration
+# Scoreboard S11 erfüllt: 0 echte Drift-Treffer cross-repo nach Migrations-
+# Runde — meiki-hub#23, writing-hub#21, risk-hub#125 alle gemerged). F12
+# damit endgültig geschlossen, lange vor Hard-Deadline 2026-08-20.
+LEGACY = {}  # Soft-Migrate vorbei
+CLASS_KEYS = ("class", "klickdummy_class")
+
+
+def load(path: str):
+    text = pathlib.Path(path).read_text(encoding="utf-8")
+    if path.endswith((".yaml", ".yml")):
+        return yaml.safe_load(text)
+    return json.loads(text)
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("Usage: check_i2.py <spec>:<schema> ...")
+        return 2
+    errs = 0
+    print("== I2 Prod-Sicherheit ==")
+    for pair in argv:
+        spec_path = pair.split(":", 1)[0]
+        print(f"  · {spec_path}")
+        try:
+            spec = load(spec_path) or {}
+            cls = None
+            for k in CLASS_KEYS:
+                if k in spec:
+                    cls = spec[k]
+                    break
+            if cls is None:
+                print(
+                    f"      ✗ keine Klasse deklariert "
+                    f"(erwartet eines von {CLASS_KEYS}, z. B. 'mock')"
+                )
+                errs += 1
+            elif cls in LEGACY:
+                # weich, mit Migrations-Hinweis (kein FAIL — sonst CI-Bruch
+                # vor abgeschlossener Migration in allen Schwester-Repos)
+                print(f"      ⚠ class={cls!r} (Rev-10-Begriff) — bitte auf "
+                      f"{LEGACY[cls]!r} migrieren (platform:ADR-211 Rev 11, 4-Pattern)")
+            elif cls not in ALLOWED:
+                print(f"      ✗ class={cls!r} nicht in {sorted(ALLOWED)}")
+                errs += 1
+            else:
+                print(f"      ✓ class={cls}")
+        except FileNotFoundError as e:
+            print(f"      ✗ Datei fehlt: {e.filename}")
+            errs += 1
+        except Exception as e:  # noqa: BLE001
+            print(f"      ✗ {type(e).__name__}: {e}")
+            errs += 1
+    print(f"I2 → {'PASS' if errs == 0 else f'FAIL ({errs})'}")
+    return 0 if errs == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))
+
+
+def main_cli() -> int:
+    """Console-Script entry (pyproject.toml [project.scripts])."""
+    import sys
+    return main(sys.argv[1:])

--- a/packages/iil-klickdummy/src/iil_klickdummy/check_i3.py
+++ b/packages/iil-klickdummy/src/iil_klickdummy/check_i3.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""I3 Off-Ramp — Doppelquell-Grenze + Status je Screen.
+
+Anforderungen (platform:ADR-211):
+  - Spec hat `off_ramp`-Block mit `doppelquell_grenze: prod-release`
+  - Falls Screens definiert: jeder Screen hat `off_ramp_status` aus
+    {static, parity-staging, parity-green, removed}
+
+Phase 0 ist ein Berichts-Runner, keine echte Parity-Maschinerie — die entsteht,
+sobald der Produkt-Repo Staging hat.
+
+Aufruf:  python3 scripts/klickdummy/check_i3.py <spec>:<schema> [...]
+Exit:    0 = PASS, 1 = FAIL, 2 = Setup-Fehler
+"""
+from __future__ import annotations
+import json, pathlib, sys
+
+try:
+    import yaml
+except ImportError:
+    print("FAIL (setup): PyYAML fehlt. pip install pyyaml")
+    sys.exit(2)
+
+STATUS = ("static", "parity-staging", "parity-green", "removed")
+
+
+def load(path: str):
+    text = pathlib.Path(path).read_text(encoding="utf-8")
+    if path.endswith((".yaml", ".yml")):
+        return yaml.safe_load(text)
+    return json.loads(text)
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("Usage: check_i3.py <spec>:<schema> ...")
+        return 2
+    errs = 0
+    print("== I3 Off-Ramp ==")
+    for pair in argv:
+        spec_path = pair.split(":", 1)[0]
+        print(f"  · {spec_path}")
+        try:
+            spec = load(spec_path) or {}
+            off = spec.get("off_ramp")
+            if not off:
+                print("      ✗ kein 'off_ramp'-Block deklariert")
+                errs += 1
+                continue
+            if off.get("doppelquell_grenze") != "prod-release":
+                print(
+                    f"      ✗ doppelquell_grenze={off.get('doppelquell_grenze')!r} "
+                    "— erwartet 'prod-release'"
+                )
+                errs += 1
+            screens = spec.get("screens") or []
+            if screens:
+                counts: dict[str, int] = {s: 0 for s in STATUS}
+                bad = []
+                for sc in screens:
+                    st = sc.get("off_ramp_status", "static")
+                    if st not in STATUS:
+                        bad.append((sc.get("id", "?"), st))
+                    counts[st] = counts.get(st, 0) + 1
+                if bad:
+                    for sid, st in bad:
+                        print(f"      ✗ screen {sid!r}: off_ramp_status={st!r} unzulässig")
+                    errs += len(bad)
+                summary = ", ".join(f"{k}={v}" for k, v in counts.items() if v)
+                print(f"      ✓ {len(screens)} Screen(s) — {summary}")
+            else:
+                print(f"      ✓ off_ramp-Policy: {off.get('policy', '(unbenannt)')}")
+        except FileNotFoundError as e:
+            print(f"      ✗ Datei fehlt: {e.filename}")
+            errs += 1
+        except Exception as e:  # noqa: BLE001
+            print(f"      ✗ {type(e).__name__}: {e}")
+            errs += 1
+    print(f"I3 → {'PASS' if errs == 0 else f'FAIL ({errs})'}")
+    return 0 if errs == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))
+
+
+def main_cli() -> int:
+    """Console-Script entry (pyproject.toml [project.scripts])."""
+    import sys
+    return main(sys.argv[1:])

--- a/packages/iil-klickdummy/src/iil_klickdummy/check_i4.py
+++ b/packages/iil-klickdummy/src/iil_klickdummy/check_i4.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""I4 Namensraum — Cross-Repo-ADR-Refs nur als repo:ADR-NNN.
+
+Heuristik:
+  - Scannt klickdummy-Dateien (md/html/yaml/yml/json) rekursiv unter dem
+    übergebenen Root-Verzeichnis.
+  - Jeder Treffer auf 'ADR-NNN' muss eine der drei Formen haben:
+      (a) repo-qualifiziert, z. B. `meiki:ADR-021` / `platform:ADR-211`
+      (b) lokale meiki-ADR (Whitelist unten) — unqualifiziert erlaubt
+      (c) in einem Code-/Pre-Block einer Schema-Beispielzeile
+
+Whitelist lokaler ADRs wird aus docs/adr/ADR-NNN-*.md autoermittelt.
+
+Aufruf:  python3 scripts/klickdummy/check_i4.py <root_dir>
+Exit:    0 = PASS, 1 = FAIL, 2 = Setup-Fehler
+"""
+from __future__ import annotations
+import pathlib, re, sys
+
+# Erfasst sowohl 'ADR-021' als auch 'foo:ADR-021'
+ADR_PATTERN = re.compile(r"(?P<prefix>[A-Za-z][A-Za-z0-9_-]*:)?(?P<adr>ADR-\d{3})")
+SCAN_EXT = {".md", ".html", ".yaml", ".yml", ".json"}
+ADR_DIR = pathlib.Path("docs/adr")
+
+
+def local_adr_set() -> set[str]:
+    """Sammelt lokal vorhandene meiki-ADR-Nummern aus docs/adr/ADR-NNN-*.md."""
+    out: set[str] = set()
+    if ADR_DIR.exists():
+        for p in ADR_DIR.glob("ADR-*.md"):
+            m = re.match(r"(ADR-\d{3})", p.name)
+            if m:
+                out.add(m.group(1))
+    return out
+
+
+def check_file(path: pathlib.Path, local: set[str]) -> list[tuple[int, str, str]]:
+    """Gibt (zeilen_nr, treffer, hinweis)-Liste zurück; leer = ok."""
+    findings: list[tuple[int, str, str]] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return findings
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for m in ADR_PATTERN.finditer(line):
+            adr = m.group("adr")
+            prefix = m.group("prefix")
+            if prefix:
+                continue  # repo:ADR-NNN — ok
+            if adr in local:
+                continue  # lokale meiki-ADR — ok
+            findings.append((lineno, adr, f"unqualifiziert (nicht in local-set, nicht repo:ADR-NNN)"))
+    return findings
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("Usage: check_i4.py <root_dir>")
+        return 2
+    root = pathlib.Path(argv[0])
+    if not root.exists():
+        print(f"FAIL: Root fehlt: {root}")
+        return 2
+    local = local_adr_set()
+    print(f"== I4 Namensraum == (root={root}, lokale ADRs: {len(local)})")
+    errs = 0
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix not in SCAN_EXT:
+            continue
+        findings = check_file(path, local)
+        if findings:
+            print(f"  · {path}")
+            for lineno, adr, hint in findings:
+                print(f"      ✗ Zeile {lineno}: {adr} — {hint}")
+                errs += 1
+    if errs == 0:
+        print("I4 → PASS")
+        return 0
+    print(f"I4 → FAIL ({errs}) — Cross-Repo-Refs als 'repo:ADR-NNN' qualifizieren")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))
+
+
+def main_cli() -> int:
+    """Console-Script entry (pyproject.toml [project.scripts])."""
+    import sys
+    return main(sys.argv[1:])

--- a/packages/iil-klickdummy/src/iil_klickdummy/extract_requirements.py
+++ b/packages/iil-klickdummy/src/iil_klickdummy/extract_requirements.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Klickdummy → Requirements-Skeleton (UC/FR/NFR/Lasten-/Pflichtenheft).
+
+Parst eine Klickdummy-Spec (YAML) und generiert Markdown-Skelette für:
+  - requirements/use-cases/UC-NN-<screen>.md       (1 UC pro Screen)
+  - requirements/fr.md                              (Funktionale Requirements)
+  - requirements/nfr.md                             (Nicht-funktionale)
+  - requirements/schnittstellen.md                  (Adapter / Systemgrenzen)
+  - requirements/lastenheft-skeleton.md             (high-level, Auftraggeber-Sicht)
+  - requirements/pflichtenheft-skeleton.md          (concrete, Auftragnehmer-Sicht)
+
+Output ist *Skelett* — Editieren erwartet. Drift gegen Spec via Re-Extract +
+git-diff sichtbar. Eine Quelle wahr: die Spec (analog ADR-211 I1 Spec-first).
+
+Aufruf:
+    python3 scripts/klickdummy/extract_requirements.py <spec.yaml> [<out-dir>]
+
+Exit: 0 ok, 1 Schema-Fehler, 2 Setup-Fehler.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+from datetime import date
+
+try:
+    import yaml
+except ImportError:
+    print("FAIL (setup): PyYAML fehlt. pip install pyyaml")
+    sys.exit(2)
+
+
+# -- Helpers ------------------------------------------------------------------
+
+def slug(s: str) -> str:
+    return re.sub(r"[^a-z0-9-]+", "-", s.lower()).strip("-")
+
+
+def load_spec(path: pathlib.Path) -> dict:
+    if not path.exists():
+        print(f"FAIL: Spec fehlt: {path}")
+        sys.exit(1)
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def write(out_root: pathlib.Path, rel: str, content: str) -> None:
+    p = out_root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    print(f"  ✓ {rel}")
+
+
+# -- Generators ---------------------------------------------------------------
+
+def gen_uc(spec: dict, out: pathlib.Path) -> None:
+    """1 UseCase pro Screen — als RUP/UML-Skelett.
+
+    Räumt veraltete UC-Dateien (`UC-*.md` im Zielordner) vor dem Schreiben weg,
+    damit Re-Extract bei Screen-Reihenfolge- oder Namensänderung nicht zwei
+    parallele UC-Sets stehenlässt.
+    """
+    uc_dir = out / "requirements" / "use-cases"
+    if uc_dir.exists():
+        for stale in uc_dir.glob("UC-*.md"):
+            stale.unlink()
+    screens = spec.get("screens", []) or []
+    spec_id = spec.get("spec_id", "spec")
+    for i, sc in enumerate(screens, start=1):
+        sid = sc.get("id", f"screen-{i}")
+        title = sc.get("title", sid)
+        personas = sc.get("personas", []) or []
+        purpose = sc.get("purpose") or sc.get("title") or ""
+        pa = sc.get("parity_acceptance", []) or []
+        konzept = sc.get("konzept_ref", []) or []
+        targets = sc.get("target_mocks", []) or []
+        datafields = sc.get("datafields", []) or []
+        body = f"""---
+type: use-case
+uc_id: UC-{i:02d}-{slug(sid)}
+source_spec: {spec_id}
+source_screen: {sid}
+extracted_at: {date.today().isoformat()}
+status: draft   # draft | reviewed | approved
+---
+
+# UC-{i:02d} · {title}
+
+> Generiert aus Klickdummy-Spec (Screen `{sid}`). Skelett — bitte editieren.
+
+## Akteure
+{chr(10).join(f"- {a}" for a in personas) or "- _(noch nicht spezifiziert)_"}
+
+## Zweck / Ziel
+{purpose}
+
+## Vorbedingung
+- Aktor ist angemeldet, Persona-Sicht aktiv.
+- _(weitere Vorbedingungen ergänzen — z. B. vorheriger Screen)_
+
+## Hauptablauf
+{chr(10).join(f"{j+1}. {p.get('check','')}" for j, p in enumerate(pa)) or "1. _(noch nicht spezifiziert)_"}
+
+## Nachbedingung
+- _(z. B. Folge-Screen erreicht, Zustand geändert, Audit-Eintrag erzeugt)_
+
+## Beteiligte Systeme / Schnittstellen
+{chr(10).join(f"- {t}" for t in targets) or "- _(keine externen Systeme deklariert)_"}
+
+## Datenfelder
+{chr(10).join(f"- `{d.get('name','?')}` ({d.get('type','?')}) — Quelle: {d.get('source','?')}" for d in datafields) or "- _(keine Datenfelder im Spec deklariert)_"}
+
+## Konzept-Bezug
+{chr(10).join(f"- {k}" for k in konzept) or "- _(kein Konzept-Bezug)_"}
+
+## Abgeleitete FRs
+{chr(10).join(f"- FR-{slug(sid)}-{j+1:02d}: {p.get('check','')}" for j, p in enumerate(pa)) or "- _(keine)_"}
+"""
+        write(out, f"requirements/use-cases/UC-{i:02d}-{slug(sid)}.md", body)
+
+
+def gen_fr(spec: dict, out: pathlib.Path) -> None:
+    rows = []
+    for sc in spec.get("screens", []) or []:
+        sid = sc.get("id", "?")
+        for j, p in enumerate(sc.get("parity_acceptance", []) or [], start=1):
+            rows.append(
+                f"| FR-{slug(sid)}-{j:02d} | {sid} | {p.get('id','')} | {p.get('check','')} |"
+            )
+    body = f"""---
+type: functional-requirements
+source_spec: {spec.get('spec_id','spec')}
+extracted_at: {date.today().isoformat()}
+status: draft
+---
+
+# Funktionale Requirements (FR)
+
+> Aus Klickdummy-Spec `{spec.get('spec_id','?')}` v{spec.get('spec_version','?')} abgeleitet.
+> Jede Zeile entspricht einem `parity_acceptance`-Eintrag eines Screens (= platform:ADR-211 I1-Acceptance).
+> Drift-Check: Re-Extract gegen committeten Stand → `git diff`.
+
+| FR-ID | Screen | Anker | Anforderung |
+|---|---|---|---|
+{chr(10).join(rows) or "| — | — | — | _(keine parity_acceptance im Spec)_ |"}
+"""
+    write(out, "requirements/fr.md", body)
+
+
+def gen_nfr(spec: dict, out: pathlib.Path) -> None:
+    cls = spec.get("class", "?")
+    ev = spec.get("class_evidence", {}) or {}
+    off = spec.get("off_ramp", {}) or {}
+    adr = spec.get("adr", {}) or {}
+
+    nfrs: list[tuple[str, str, str]] = []  # (id, kategorie, anforderung)
+    # Security / Prod-Sicherheit (I2)
+    if cls == "mock":
+        if ev.get("no_backend"):
+            nfrs.append(("NFR-Sec-01", "Security", "Klickdummy darf keinen echten Backend-Code-Pfad enthalten (`class: mock`, `class_evidence.no_backend: true`)."))
+        if ev.get("no_demo_param"):
+            nfrs.append(("NFR-Sec-02", "Security", "Kein `?demo=`-Render in der echten App (`class_evidence.no_demo_param: true`)."))
+        if ev.get("target_mocks_visible"):
+            nfrs.append(("NFR-Sec-03", "Security", "Alle Systemgrenzen müssen als anklickbare Target-Mocks sichtbar sein (kein toter Link)."))
+    elif cls == "spec-demo":
+        pg = ev.get("prod_guard", {}) or {}
+        nfrs.append(("NFR-Sec-01", "Security", f"`?demo=`-Render ist in Produktion nicht erreichbar (Guard: {pg.get('setting','?')} + DEBUG/TESTING; Response: {pg.get('response_in_prod','?')})."))
+        nfrs.append(("NFR-Sec-02", "Security", "Guard ist durch automatisierten Test bewiesen (Demo-Tour-Tests mit `KLICKDUMMY_TOUR_ENABLED=False`)."))
+    elif cls == "stub-demo":
+        nfrs.append(("NFR-Sec-01", "Security", "Dedizierte Demo-Route ist in Produktion nicht erreichbar (404)."))
+    elif cls == "story":
+        nfrs.append(("NFR-Sec-01", "Security", "Component-Catalog (Storybook o. ä.) ist in Produktion nicht erreichbar (404)."))
+
+    # Lifecycle (I3)
+    if off.get("doppelquell_grenze"):
+        nfrs.append(("NFR-Lifecycle-01", "Lifecycle", f"Doppelquellen-Pflege endet bei `{off['doppelquell_grenze']}`."))
+    if off.get("ttl_days"):
+        nfrs.append(("NFR-Lifecycle-02", "Lifecycle", f"Off-Ramp-TTL: max. {off['ttl_days']} Tage nach Parity-grün."))
+
+    # Integration (Systemgrenzen)
+    for i, s in enumerate(ev.get("systemgrenzen", []) or [], start=1):
+        nfrs.append((f"NFR-Integ-{i:02d}", "Integration", f"Schnittstelle: `{s}` (generisch, mandantenkonfigurierbar)."))
+
+    # Namensraum (I4)
+    if adr.get("conforms_to"):
+        nfrs.append(("NFR-Gov-01", "Governance", f"ADR-Konformität: `{adr['conforms_to']}` (Klickdummy-Cross-Repo-Rahmen)."))
+
+    rows = "\n".join(f"| {n[0]} | {n[1]} | {n[2]} |" for n in nfrs) or "| — | — | _(keine NFRs ableitbar)_ |"
+    body = f"""---
+type: non-functional-requirements
+source_spec: {spec.get('spec_id','spec')}
+extracted_at: {date.today().isoformat()}
+status: draft
+---
+
+# Nicht-funktionale Requirements (NFR)
+
+> Aus `class`, `class_evidence`, `off_ramp` und `adr` der Klickdummy-Spec abgeleitet.
+> **Asymmetrische Brücke:** NFRs *dürfen* über den Klickdummy hinausgehen — Performance, Skalierung, Audit etc.
+> sind hier nicht erschöpft und müssen manuell ergänzt werden.
+
+| NFR-ID | Kategorie | Anforderung |
+|---|---|---|
+{rows}
+
+## Manuell zu ergänzen (typisch im Klickdummy nicht abgedeckt)
+
+- **Performance:** Antwortzeiten, Durchsatz, Last-/Stresstest-Schwellen
+- **Verfügbarkeit:** SLA, MTBF, MTTR
+- **Datenschutz:** DSFA-Bezug, Aufbewahrungsfristen, Löschpflichten
+- **Audit / Logging:** Auditpflichtige Aktionen, Retention
+- **Barrierefreiheit:** WCAG-Level, Tastatur-Navigation
+- **Internationalisierung:** Sprachen, Datumsformate, Kalender
+"""
+    write(out, "requirements/nfr.md", body)
+
+
+def gen_schnittstellen(spec: dict, out: pathlib.Path) -> None:
+    ev = spec.get("class_evidence", {}) or {}
+    systemgrenzen = ev.get("systemgrenzen", []) or []
+    # Sammle alle target_mocks aus Screens
+    mocks: set[str] = set()
+    for sc in spec.get("screens", []) or []:
+        for t in sc.get("target_mocks", []) or []:
+            mocks.add(t)
+    body = f"""---
+type: interfaces
+source_spec: {spec.get('spec_id','spec')}
+extracted_at: {date.today().isoformat()}
+status: draft
+---
+
+# Schnittstellen (Adapter / Systemgrenzen)
+
+> Aus `class_evidence.systemgrenzen` (Klassen-Liste) und `screens[].target_mocks` (Pro-Screen-Bezug) abgeleitet.
+
+## Generische Adapter-Familien (aus `class_evidence.systemgrenzen`)
+
+{chr(10).join(f"- **{s}**" for s in systemgrenzen) or "- _(keine deklariert)_"}
+
+## Pro Screen verwendet (aus `screens[].target_mocks`)
+
+{chr(10).join(f"- `{m}`" for m in sorted(mocks)) or "- _(keine deklariert)_"}
+
+## Manuell zu konkretisieren (Pflichtenheft-Übergang)
+
+Pro Adapter:
+- API-Vertrag (Methoden, Payload-Format, Auth)
+- SLA / Verfügbarkeit
+- Fehlerfallverhalten (Timeout, Retry, Fallback)
+- Daten-Mapping zu internem Modell
+"""
+    write(out, "requirements/schnittstellen.md", body)
+
+
+def gen_lastenheft(spec: dict, out: pathlib.Path) -> None:
+    title = spec.get("title", spec.get("spec_id", "Klickdummy"))
+    personas = set()
+    for sc in spec.get("screens", []) or []:
+        for p in sc.get("personas", []) or []:
+            personas.add(p)
+    main_goals = [sc.get("title", "?") for sc in spec.get("screens", []) or []]
+    body = f"""---
+type: lastenheft
+source_spec: {spec.get('spec_id','spec')}
+extracted_at: {date.today().isoformat()}
+status: skeleton
+audience: auftraggeber
+---
+
+# Lastenheft (Skelett) · {title}
+
+> *Was* der Auftraggeber will. Aus Klickdummy abgeleitet — high-level.
+> Vor Verwendung: editieren, priorisieren, fachlich ergänzen.
+
+## 1. Ausgangslage und Motivation
+
+_(Manuell: Warum dieses Vorhaben? Welcher Schmerz wird beseitigt? Welche Strategie wird umgesetzt?)_
+
+## 2. Zielgruppen
+
+{chr(10).join(f"- {p}" for p in sorted(personas)) or "- _(keine Personas deklariert)_"}
+
+## 3. Hauptziele (aus Screens abgeleitet)
+
+{chr(10).join(f"{i+1}. {g}" for i, g in enumerate(main_goals)) or "1. _(keine)_"}
+
+## 4. Funktionale Anforderungen (Übersicht)
+
+Siehe [`fr.md`](fr.md). Jede Zeile dort = eine `parity_acceptance` aus dem Klickdummy.
+
+## 5. Nicht-funktionale Anforderungen (Übersicht)
+
+Siehe [`nfr.md`](nfr.md). **Klickdummy bildet nur Teil ab** — manuell ergänzen:
+Performance, Verfügbarkeit, Datenschutz, Audit, Barrierefreiheit.
+
+## 6. Schnittstellen
+
+Siehe [`schnittstellen.md`](schnittstellen.md).
+
+## 7. Abgrenzung / Out-of-Scope
+
+_(Manuell: Was wird ausdrücklich NICHT geliefert?)_
+
+## 8. Termine / Meilensteine
+
+_(Manuell)_
+
+## 9. Bezug
+
+- Spec: `{spec.get('spec_id','?')}` v{spec.get('spec_version','?')}
+- Klickdummy-Pfad: _(Repo-Pfad der Klickdummy-Implementierung)_
+- ADR-Verankerung: {spec.get('adr',{}).get('local','?')} (`conforms_to: {spec.get('adr',{}).get('conforms_to','?')}`)
+"""
+    write(out, "requirements/lastenheft-skeleton.md", body)
+
+
+def gen_pflichtenheft(spec: dict, out: pathlib.Path) -> None:
+    title = spec.get("title", spec.get("spec_id", "Klickdummy"))
+    body = f"""---
+type: pflichtenheft
+source_spec: {spec.get('spec_id','spec')}
+extracted_at: {date.today().isoformat()}
+status: skeleton
+audience: auftragnehmer
+---
+
+# Pflichtenheft (Skelett) · {title}
+
+> *Wie* der Auftragnehmer das Lastenheft umsetzt. Aus Klickdummy + Lastenheft abzuleiten.
+> Vor Verwendung: technische Architektur ergänzen.
+
+## 1. Bezug zum Lastenheft
+
+Siehe [`lastenheft-skeleton.md`](lastenheft-skeleton.md). Diese Datei konkretisiert dessen Punkte 4–6.
+
+## 2. Architektur-Skizze
+
+_(Manuell: Container-/Component-Diagramm; Ports & Adapter; Datenflüsse.)_
+
+Klickdummy-Klasse: `{spec.get('class','?')}` (platform:ADR-211 I2)
+Off-Ramp-Strategie: `{spec.get('off_ramp',{}).get('doppelquell_grenze','?')}` (TTL {spec.get('off_ramp',{}).get('ttl_days','?')} d)
+
+## 3. UseCases (Verzeichnis)
+
+Siehe [`use-cases/`](use-cases/) — je UC ein Markdown mit Akteur/Ablauf/Nachbedingung/Daten.
+
+## 4. Datenmodell
+
+_(Manuell zu konkretisieren — die Klickdummy-`datafields` sind nur Anker.)_
+
+Klickdummy-Datenfelder (je Screen) siehe `use-cases/`-Skelette unter „Datenfelder".
+
+## 5. Schnittstellen-Verträge
+
+Siehe [`schnittstellen.md`](schnittstellen.md). Pro Adapter zu ergänzen:
+API-Methoden, Payload-Format, Auth-Mechanismus, SLA, Fehlerfallverhalten.
+
+## 6. Nicht-funktionale Realisierung
+
+Siehe [`nfr.md`](nfr.md). Mapping je NFR-ID → technische Maßnahme.
+
+## 7. Test-/Abnahme-Konzept
+
+- **I1 Spec ↔ Render** (platform:ADR-211): Spec-Konformität via `make klickdummy-i1`.
+- **Parity-Test** (bei Demo-Render): Klickdummy ⊆ flow.md ⊆ App.
+- **UC-Tests:** je UC ein E2E-Pfad (Browser/Playwright o. ä.).
+- **NFR-Tests:** Performance/Last/Penetration je nach Kategorie.
+
+## 8. Bezug
+
+- Spec: `{spec.get('spec_id','?')}` v{spec.get('spec_version','?')}
+- ADR (lokal): {spec.get('adr',{}).get('local','?')}
+- ADR (Rahmen): {spec.get('adr',{}).get('conforms_to','?')}
+- Schwester-Implementierungen: {', '.join(spec.get('adr',{}).get('sister_of',[]) or []) or '(keine)'}
+"""
+    write(out, "requirements/pflichtenheft-skeleton.md", body)
+
+
+# -- Main ---------------------------------------------------------------------
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("Usage: extract_requirements.py <spec.yaml> [<out-dir>]")
+        return 2
+    spec_path = pathlib.Path(argv[0])
+    out_root = pathlib.Path(argv[1]) if len(argv) > 1 else spec_path.parent
+    spec = load_spec(spec_path)
+    print(f"== Extract Requirements ==")
+    print(f"  Spec : {spec_path}")
+    print(f"  Out  : {out_root}/requirements/")
+    print()
+    gen_uc(spec, out_root)
+    gen_fr(spec, out_root)
+    gen_nfr(spec, out_root)
+    gen_schnittstellen(spec, out_root)
+    gen_lastenheft(spec, out_root)
+    gen_pflichtenheft(spec, out_root)
+    print()
+    print(f"  Hinweis: alle generierten Dateien tragen `status: draft|skeleton` —")
+    print(f"  manuell editieren, dann committen. Drift gegen Spec via Re-Extract + git diff.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))
+
+
+def main_cli() -> int:
+    """Console-Script entry (pyproject.toml [project.scripts])."""
+    import sys
+    return main(sys.argv[1:])

--- a/packages/iil-klickdummy/src/iil_klickdummy/install_snippets.py
+++ b/packages/iil-klickdummy/src/iil_klickdummy/install_snippets.py
@@ -1,0 +1,74 @@
+"""Install bundled snippets (HTML+JS+templates) into a repo (platform:ADR-211 Rev 13).
+
+Console-Script: `klickdummy-install-snippets [--target <dir>] [--symlink]`
+
+Default target: `./platform-snippets/klickdummy/`. Creates dir if missing.
+Default mode: copy (cross-platform-safe). `--symlink` creates symlinks for
+live-updates during pip-upgrade.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from importlib.resources import files
+from pathlib import Path
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", default="./platform-snippets/klickdummy",
+                        help="Target directory in the consuming repo")
+    parser.add_argument("--symlink", action="store_true",
+                        help="Symlink instead of copy (live-updates on pip-upgrade)")
+    parser.add_argument("--force", action="store_true",
+                        help="Overwrite existing target without backup")
+    args = parser.parse_args(argv)
+
+    src_root = files("iil_klickdummy") / "snippets"
+    tgt = Path(args.target).resolve()
+
+    print(f"== Install klickdummy snippets ==")
+    print(f"  Source : {src_root}")
+    print(f"  Target : {tgt}")
+    print(f"  Mode   : {'symlink' if args.symlink else 'copy'}")
+
+    if tgt.exists() and not args.force:
+        print(f"  ✗ target exists, use --force or remove manually: {tgt}")
+        return 1
+
+    if tgt.exists():
+        shutil.rmtree(tgt) if tgt.is_dir() else tgt.unlink()
+
+    tgt.mkdir(parents=True, exist_ok=True)
+
+    # Iterate package_data files (importlib.resources)
+    def _copy_recursive(src, dst: Path):
+        if src.is_file():
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            if args.symlink:
+                # Resolve the underlying filesystem path of the package resource
+                with files("iil_klickdummy").joinpath("snippets") as base_path:
+                    rel = Path(str(src)).relative_to(base_path)
+                    real = Path(str(base_path)) / rel
+                    dst.symlink_to(real)
+            else:
+                dst.write_bytes(src.read_bytes())
+            print(f"  ✓ {dst.relative_to(tgt)}")
+        else:
+            for child in src.iterdir():
+                _copy_recursive(child, dst / child.name)
+
+    _copy_recursive(src_root, tgt)
+    print(f"\nDone. {tgt} ready. Include in shell.html:")
+    print(f'  <script src="{tgt.name}/feedback-widget/widget.js" defer></script>')
+    return 0
+
+
+def main_cli() -> int:
+    return main(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    sys.exit(main_cli())

--- a/packages/iil-klickdummy/src/iil_klickdummy/inventory.py
+++ b/packages/iil-klickdummy/src/iil_klickdummy/inventory.py
@@ -1,0 +1,90 @@
+"""S11 Cross-Repo Legacy-Class-Inventur (platform:ADR-211 Rev 12 §Migration)."""
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import re
+import sys
+
+DEFAULT_REPOS = ["meiki-hub", "writing-hub", "risk-hub", "pptx-hub", "dev-hub", "ttz-hub"]
+LEGACY_PATTERN = re.compile(r"mock-prototyp|demo-render")
+INCLUDE_EXT = {".yaml", ".yml", ".json", ".md", ".html", ".py"}
+EXCLUDE_PATH_PARTS = {"node_modules", ".venv", "__pycache__", "build", "dist", "_archiv"}
+EXCLUDE_FILES_SUFFIX = ("feedback-log.md",)
+INTENTIONAL_LINE_PATTERNS = [
+    re.compile(r'LEGACY\s*=\s*\{'),
+    re.compile(r'"mock-prototyp"\s*:\s*"mock"'),
+    re.compile(r'"demo-render"\s*:\s*"spec-demo"'),
+    re.compile(r'#\s*vorher\s+(mock-prototyp|demo-render)'),
+    re.compile(r'\(vorher\s+(mock-prototyp|demo-render)'),
+    re.compile(r'in\s+\("mock",\s*"mock-prototyp"\)'),
+    re.compile(r'in\s+\("demo-render",\s*"spec-demo"\)'),
+]
+
+
+def _is_intentional(line: str) -> bool:
+    return any(p.search(line) for p in INTENTIONAL_LINE_PATTERNS)
+
+
+def _scan_repo(repo_root: pathlib.Path) -> list[tuple[str, int, str]]:
+    hits: list[tuple[str, int, str]] = []
+    for p in repo_root.rglob("*"):
+        if not p.is_file() or p.suffix not in INCLUDE_EXT:
+            continue
+        if any(part in EXCLUDE_PATH_PARTS for part in p.parts):
+            continue
+        if p.name.endswith(EXCLUDE_FILES_SUFFIX):
+            continue
+        try:
+            text = p.read_text(encoding="utf-8", errors="replace")
+        except (OSError, UnicodeError):
+            continue
+        for i, line in enumerate(text.splitlines(), start=1):
+            if LEGACY_PATTERN.search(line) and not _is_intentional(line):
+                hits.append((str(p.relative_to(repo_root)), i, line.strip()))
+    return hits
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default=os.path.expanduser("~/github"))
+    parser.add_argument("--repos", default=",".join(DEFAULT_REPOS))
+    parser.add_argument("--strict", action="store_true")
+    args = parser.parse_args(argv)
+    base = pathlib.Path(args.base)
+    repos = [r.strip() for r in args.repos.split(",") if r.strip()]
+
+    print("== S11 Cross-Repo Legacy-Class-Inventur (platform:ADR-211 Rev 12/13) ==")
+    print(f"Base: {base}")
+    total = 0
+    for repo in repos:
+        d = base / repo
+        if not d.exists():
+            print(f"=== {repo}: NOT PRESENT (skip) ===")
+            continue
+        hits = _scan_repo(d)
+        if hits:
+            print(f"=== {repo}: {len(hits)} echte Drift-Treffer ===")
+            for rel, ln, content in hits[:10]:
+                print(f"  {rel}:{ln}  {content[:120]}")
+            total += len(hits)
+            if args.strict:
+                return 1
+        else:
+            print(f"=== {repo}: ✓ clean ===")
+
+    print()
+    if total == 0:
+        print("S11 → 0 echte Drift-Treffer cross-repo.")
+        return 0
+    print(f"S11 → {total} Treffer.")
+    return 1
+
+
+def main_cli() -> int:
+    return main(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    sys.exit(main_cli())

--- a/packages/iil-klickdummy/src/iil_klickdummy/schemas/feedback-payload.schema.json
+++ b/packages/iil-klickdummy/src/iil_klickdummy/schemas/feedback-payload.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/achimdehnert/platform/main/packages/iil-klickdummy/src/iil_klickdummy/schemas/feedback-payload.schema.json",
+  "title": "Klickdummy Feedback-Payload (platform:ADR-211 Rev 13)",
+  "description": "Widget v0.5 Payload. Empirie meiki-Iter. 1-7. Pfad A 'github' = User-Token-Direkt-API.",
+  "type": "object",
+  "required": ["screen", "category", "text", "spec_id", "spec_version", "klickdummy_class", "timestamp"],
+  "additionalProperties": false,
+  "properties": {
+    "screen": { "type": ["string", "null"] },
+    "persona": { "type": ["string", "null"] },
+    "verfahren": { "type": ["string", "null"] },
+    "feedback_scope": { "type": "string", "enum": ["app", "klickdummy-tool"], "default": "app" },
+    "category": { "type": "string", "description": "Repo-konfigurierbar via KLICKDUMMY_CATEGORIES; Default 5: bug|feature|ux|spec|ki" },
+    "text": { "type": "string", "minLength": 1 },
+    "related_screens": { "type": "array", "items": { "type": "string" }, "default": [] },
+    "related_actions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["label"],
+        "properties": { "label": { "type": "string" }, "target": { "type": ["string", "null"] } }
+      },
+      "default": []
+    },
+    "dom_snapshot": { "type": ["string", "null"] },
+    "spec_id": { "type": "string" },
+    "spec_version": { "type": "string" },
+    "klickdummy_class": { "type": "string", "enum": ["mock", "stub-demo", "story", "spec-demo"] },
+    "user_agent": { "type": ["string", "null"] },
+    "viewport": {
+      "type": "object",
+      "properties": { "w": { "type": "integer" }, "h": { "type": "integer" } }
+    },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "url": { "type": "string" }
+  }
+}

--- a/packages/iil-klickdummy/src/iil_klickdummy/schemas/module-manifest.schema.json
+++ b/packages/iil-klickdummy/src/iil_klickdummy/schemas/module-manifest.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MEiKI Klick-Dummy Modul-Manifest",
+  "description": "SSoT fuer Fachverfahren, Querschnitts-Buchungseinheiten und je-LRA-Buchung. Trennt bewusst Schicht A (Fachverfahren = fachliche Sicht) von Schicht B (gebucht = technische Buchungseinheit je LRA).",
+  "type": "object",
+  "required": ["version", "identitaeten", "rollen", "fachverfahren", "querschnitt", "lra", "eingangsquellen", "klickdummy_class", "off_ramp"],
+  "additionalProperties": true,
+  "properties": {
+    "version": { "type": "string" },
+    "stand":   { "type": "string" },
+    "hinweis": { "type": "string" },
+    "klickdummy_class": {
+      "type": "string",
+      "enum": ["mock", "stub-demo", "story", "spec-demo"],
+      "description": "I2 Prod-Sicherheit (platform:ADR-211 Rev 11, 4-Pattern entlang Datenquelle × Code-Pfad-Identität). Genau eine Klasse — kein vacuous pass."
+    },
+    "off_ramp": {
+      "type": "object",
+      "description": "I3 Off-Ramp (platform:ADR-211). Doppelquell-Grenze = prod-release; Staging erlaubt.",
+      "required": ["policy", "unit", "rule", "doppelquell_grenze", "parity_runner"],
+      "properties": {
+        "policy":             { "type": "string" },
+        "unit":               { "type": "string" },
+        "rule":               { "type": "string" },
+        "doppelquell_grenze": { "type": "string", "enum": ["prod-release"] },
+        "staging_doppelquell":{ "type": "string", "enum": ["allowed"] },
+        "parity_runner":      { "type": "string" },
+        "status_overall":     { "type": "string" }
+      }
+    },
+    "identitaeten": {
+      "type": "object",
+      "description": "Schicht D — Identitaetsquellen (Login). Jede Quelle bildet auf genau eine Rolle (Schicht C) ab.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["label", "rolle"],
+        "properties": {
+          "label":        { "type": "string" },
+          "icon":         { "type": "string" },
+          "rolle":        { "type": "string", "description": "Muss ein Schluessel aus rollen sein." },
+          "art":          { "type": "string" },
+          "niveau":       { "type": "string" },
+          "betreiber":    { "type": "string" },
+          "beschreibung": { "type": "string" }
+        }
+      }
+    },
+    "eingangsquellen": {
+      "type": "object",
+      "description": "Kanal des Antragseingangs. cases[].eingangsquelle referenziert genau diese Schluessel.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["label"],
+        "properties": {
+          "label": { "type": "string" },
+          "icon":  { "type": "string" }
+        }
+      }
+    },
+    "rollen": {
+      "type": "object",
+      "description": "Schicht C — Rollen/Rechte. Bestimmt, welche Sicht eine Person auf dieselbe Kachel hat.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["label"],
+        "properties": {
+          "label":        { "type": "string" },
+          "beschreibung": { "type": "string" }
+        }
+      }
+    },
+    "fachverfahren": {
+      "type": "object",
+      "description": "Schicht A — fachliches Vokabular, plattformweit stabil.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["label", "status"],
+        "properties": {
+          "label":          { "type": "string" },
+          "kuerzel":        { "type": "string" },
+          "icon":           { "type": "string" },
+          "rechtsgrundlage":{ "type": "string" },
+          "status":         { "enum": ["ready", "planned"] },
+          "rollen":         { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+        }
+      }
+    },
+    "querschnitt": {
+      "type": "object",
+      "description": "Querschnitts-Buchungseinheiten (z. B. Buergerportal). Kein eigenes Verfahren.",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["label", "status"],
+        "properties": {
+          "label":        { "type": "string" },
+          "icon":         { "type": "string" },
+          "beschreibung": { "type": "string" },
+          "status":       { "enum": ["ready", "planned"] },
+          "rollen":       { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+        }
+      }
+    },
+    "lra": {
+      "type": "object",
+      "description": "Schicht B — was die jeweilige LRA lizenziert/aktiviert hat.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["label", "gebucht"],
+        "properties": {
+          "label":   { "type": "string" },
+          "gebucht": {
+            "type": "array",
+            "description": "Modul-IDs (aus fachverfahren ODER querschnitt). Sichtbar in dieser LRA = genau diese Menge.",
+            "items": { "type": "string" },
+            "uniqueItems": true
+          },
+          "variationspunkte": { "type": "object" }
+        }
+      }
+    }
+  }
+}

--- a/packages/iil-klickdummy/src/iil_klickdummy/schemas/screens-spec.schema.json
+++ b/packages/iil-klickdummy/src/iil_klickdummy/schemas/screens-spec.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "meiki:klickdummy-spec-fristenmanagement.schema",
+  "title": "Klickdummy Screens-Spec (App-Deep-Dive)",
+  "description": "I1 Spec-Schema. Konformität wird via `make klickdummy-i1` geprüft (platform:ADR-211).",
+  "type": "object",
+  "required": ["spec_id", "spec_version", "spec_date", "adr", "class", "grounding", "off_ramp", "personas", "screens"],
+  "additionalProperties": true,
+  "properties": {
+    "$schema":       { "type": "string" },
+    "spec_id":       { "type": "string", "pattern": "^[a-z][a-z0-9_-]*:[a-z][a-z0-9_-]*$" },
+    "spec_version":  { "type": "string", "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$" },
+    "spec_date":     { "type": "string", "format": "date" },
+    "title":         { "type": "string" },
+
+    "adr": {
+      "type": "object",
+      "required": ["local", "conforms_to"],
+      "properties": {
+        "local":       { "type": "string", "pattern": "^[a-z][a-z0-9_-]*:ADR-[0-9]{3}$" },
+        "conforms_to": { "type": "string", "pattern": "^platform:ADR-[0-9]{3}$" },
+        "sister_of": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_-]*:ADR-[0-9]{3}$" }
+        }
+      }
+    },
+
+    "class": {
+      "type": "string",
+      "enum": ["mock", "stub-demo", "story", "spec-demo"],
+      "description": "I2 Prod-Sicherheit (platform:ADR-211 Rev 11, 4-Pattern). Genau eine Klasse — kein vacuous pass."
+    },
+    "class_evidence": { "type": "object" },
+
+    "grounding": {
+      "type": "object",
+      "required": ["konzept", "pilot"],
+      "properties": {
+        "konzept":  { "type": "string" },
+        "konzept_id":     { "type": "string" },
+        "konzept_version":{ "type": "string" },
+        "pilot":          { "type": "string" },
+        "rechtsrahmen_kernnormen": { "type": "object" }
+      }
+    },
+
+    "off_ramp": {
+      "type": "object",
+      "required": ["policy", "unit", "rule", "doppelquell_grenze", "parity_runner"],
+      "properties": {
+        "policy":              { "type": "string" },
+        "unit":                { "type": "string", "enum": ["per-screen", "per-feature"] },
+        "rule":                { "type": "string" },
+        "doppelquell_grenze":  { "type": "string", "enum": ["prod-release"] },
+        "staging_doppelquell": { "type": "string", "enum": ["allowed"] },
+        "parity_runner":       { "type": "string" },
+        "product_repo_planned":{ "type": "string" },
+        "status_overall":      { "type": "string" }
+      }
+    },
+
+    "personas": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["label", "rolle", "sieht"],
+        "properties": {
+          "label": { "type": "string" },
+          "rolle": { "type": "string" },
+          "sieht": { "type": "array", "items": { "type": "string" } },
+          "sieht_eingeschraenkt": { "type": "array", "items": { "type": "string" } },
+          "freigaben": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+
+    "screens": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "title", "personas", "purpose", "parity_acceptance", "off_ramp_status"],
+        "additionalProperties": true,
+        "properties": {
+          "id":        { "type": "string", "pattern": "^[a-z][a-z0-9_-]*$" },
+          "title":     { "type": "string" },
+          "personas":  { "type": "array", "minItems": 1, "items": { "type": "string" } },
+          "purpose":   { "type": "string" },
+          "konzept_ref": { "type": "array", "items": { "type": "string" } },
+          "datafields": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["name"],
+              "additionalProperties": true,
+              "properties": {
+                "name":     { "type": "string" },
+                "type":     { "type": "string" },
+                "source":   { "type": "string" },
+                "semantic": { "type": "string" }
+              }
+            }
+          },
+          "target_mocks": { "type": "array", "items": { "type": "string" } },
+          "parity_acceptance": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["id", "check"],
+              "properties": {
+                "id":    { "type": "string", "pattern": "^[a-z][a-z0-9_.-]*$" },
+                "check": { "type": "string", "minLength": 8 }
+              }
+            }
+          },
+          "off_ramp_status": {
+            "type": "string",
+            "enum": ["static", "parity-staging", "parity-green", "removed"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/iil-klickdummy/src/iil_klickdummy/snippets/feedback-widget/widget.js
+++ b/packages/iil-klickdummy/src/iil_klickdummy/snippets/feedback-widget/widget.js
@@ -1,0 +1,470 @@
+/**
+ * Klickdummy Feedback-Widget v0.5 (platform:ADR-211 Rev 13)
+ * — Standalone, repo-agnostisch, Plugin-Architektur, GitHub-Direkt-API
+ *
+ * Aus meiki-hub v0.4-Stand portiert. v0.5-Neuerungen: Categories-Hook,
+ * Persona-Hook, GitHub-Direkt-API statt zentraler Endpoint (Decider-Pivot B,
+ * 2026-05-20 — Service-Boundary verworfen).
+ *
+ * Konfiguration (vor Widget-Script setzen):
+ *   window.KLICKDUMMY_SPEC = { id, version, klickdummy_class }
+ *   window.KLICKDUMMY_FEEDBACK_REPO = "owner/repo"     // GitHub-Ziel-Repo
+ *   window.KLICKDUMMY_CATEGORIES = [{value,label}]     // optional, default 5
+ *   window.KLICKDUMMY_PERSONA_HOOK = () => string|null // optional
+ *   window.KLICKDUMMY_VERFAHREN_HOOK = () => string|null // optional
+ *   window.KLICKDUMMY_FEEDBACK_FORCE = true             // bypass opt-in
+ *
+ * Mount: opt-in via URL ?feedback=on (Default off — class-erhaltend).
+ * Submit-Modes:
+ *   download   — Markdown-Datei (offline, kein GitHub nötig)
+ *   clipboard  — navigator.clipboard
+ *   github     — POST api.github.com/.../issues (User-PAT in LocalStorage)
+ *                 KEY: localStorage.klickdummy_github_token
+ */
+(function () {
+  'use strict';
+  if (window.__klickdummyFeedbackLoaded) return;
+  window.__klickdummyFeedbackLoaded = true;
+
+  // ---- Configuration ------------------------------------------------------
+  const SPEC = window.KLICKDUMMY_SPEC || { id: 'unknown', version: '0.0', klickdummy_class: 'mock' };
+  const REPO = window.KLICKDUMMY_FEEDBACK_REPO || null;
+  const CATEGORIES = window.KLICKDUMMY_CATEGORIES || [
+    { value: 'bug', label: '🐛 Fehler / Inkonsistenz' },
+    { value: 'feature', label: '💡 Funktionsidee / Anforderung', default: true },
+    { value: 'ux', label: '🎨 UX-/Layout-Vorschlag' },
+    { value: 'spec', label: '📋 Spec-Lücke / Klärungsbedarf' },
+    { value: 'ki', label: '🤖 KI-/Automatisierung-Idee' }
+  ];
+  const FB_ACTION_HANDLERS = ['go', 'ext', 'wizard', 'hemmung', 'hemmungDms', 'hemmungSpeichern',
+    'applyWorklistFilter', 'sortWorklist', 'closeModal', 'toast'];
+  const FB_FILE_MAX_BYTES = 1024 * 1024;
+  const FB_FILE_MAX_COUNT = 5;
+
+  function fbEnabled() {
+    const qs = new URLSearchParams(location.search);
+    return qs.get('feedback') === 'on' || window.KLICKDUMMY_FEEDBACK_FORCE === true;
+  }
+
+  // ---- DOM injection ------------------------------------------------------
+  function injectStyles() {
+    if (document.getElementById('fb-styles')) return;
+    const css = `
+#fb-fab{position:fixed;right:20px;bottom:20px;z-index:200;background:#1a3a6c;color:#fff;width:54px;height:54px;border-radius:50%;border:none;font-size:22px;cursor:pointer;box-shadow:0 4px 16px rgba(0,0,0,.25);display:none;font-family:system-ui,-apple-system,sans-serif}
+#fb-fab:hover{background:#005ea2}
+#fb-panel{position:fixed;right:20px;bottom:84px;z-index:201;width:380px;max-width:calc(100vw - 40px);background:#fff;border:1px solid #d8e0e8;border-radius:10px;box-shadow:0 8px 32px rgba(0,0,0,.25);padding:16px;display:none;font-family:system-ui,-apple-system,sans-serif}
+#fb-panel.open{display:block}
+#fb-panel h3{margin:0 0 8px;font-size:14px;color:#1a3a6c}
+#fb-panel .meta{font-size:11px;color:#6a7888;margin-bottom:10px}
+#fb-panel textarea{width:100%;min-height:120px;border:1px solid #d8e0e8;border-radius:6px;padding:8px;font-family:inherit;font-size:13px;box-sizing:border-box;resize:vertical}
+#fb-panel select{font-family:inherit;font-size:12px;padding:4px 6px;border-radius:6px;border:1px solid #d8e0e8;width:100%;margin-bottom:8px}
+#fb-panel .fb-actions{display:flex;gap:6px;margin-top:10px;flex-wrap:wrap}
+#fb-panel .fb-actions button{flex:1;font-size:12px;padding:7px 10px;border-radius:6px;cursor:pointer;font-family:inherit;font-weight:600;border:1px solid #d8e0e8;background:#fff;color:#3a4a5a}
+#fb-panel .fb-actions button.primary{background:#1a3a6c;border-color:#1a3a6c;color:#fff}
+#fb-panel .fb-actions button:hover{background:#f3f4f6}
+#fb-panel .fb-actions button.primary:hover{background:#005ea2;border-color:#005ea2}
+#fb-panel .fb-foot{font-size:10px;color:#8893a3;margin-top:8px;line-height:1.5}
+#fb-panel details.fb-rel{margin:8px 0 4px;font-size:12px}
+#fb-panel details.fb-rel>summary{cursor:pointer;color:#3a4a5a;padding:4px 0;list-style:none;user-select:none}
+#fb-panel details.fb-rel>summary::-webkit-details-marker{display:none}
+#fb-panel details.fb-rel>summary::before{content:'▸ ';color:#8893a3}
+#fb-panel details.fb-rel[open]>summary::before{content:'▾ '}
+#fb-panel .fb-rel-grid{display:flex;flex-wrap:wrap;gap:4px;margin:6px 0 2px;padding:6px;background:#f8fafc;border:1px solid #e5e9ef;border-radius:6px}
+#fb-panel .fb-rel-chip{display:inline-flex;align-items:center;gap:4px;padding:3px 8px;border:1px solid #d8e0e8;border-radius:12px;background:#fff;cursor:pointer;font-size:11px;color:#3a4a5a;user-select:none}
+#fb-panel .fb-rel-chip:hover{background:#f3f4f6}
+#fb-panel .fb-rel-chip.on{background:#1a3a6c;border-color:#1a3a6c;color:#fff}
+#fb-panel .fb-rel-chip input{display:none}
+#fb-panel .fb-rel-hint{font-size:10px;color:#8893a3;margin-top:4px}
+#fb-panel .fb-rel-empty{font-size:11px;color:#8893a3;font-style:italic;padding:4px 0}
+#fb-panel .fb-rel-chip .fb-action-tgt{opacity:.6;font-size:10px;margin-left:4px}
+`;
+    const s = document.createElement('style');
+    s.id = 'fb-styles';
+    s.textContent = css;
+    document.head.appendChild(s);
+  }
+
+  function categoryOptions() {
+    return CATEGORIES.map(c =>
+      `<option value="${c.value}"${c.default ? ' selected' : ''}>${c.label}</option>`
+    ).join('');
+  }
+
+  function injectMarkup() {
+    if (document.getElementById('fb-fab')) return;
+    const wrap = document.createElement('div');
+    wrap.innerHTML = `
+<button id="fb-fab" title="Feedback geben (Co-Development-Loop)">💬</button>
+<div id="fb-panel">
+  <h3>💬 Feedback zum Klick-Dummy</h3>
+  <div class="meta">Screen <code id="fb-screen">—</code> · Persona <code id="fb-persona">—</code> · Spec <code>${SPEC.id} v${SPEC.version}</code></div>
+  <div style="display:flex;gap:8px">
+    <div style="flex:1">
+      <label class="meta">Scope</label>
+      <select id="fb-scope" title="Worauf bezieht sich das Feedback?">
+        <option value="app" selected>🏛 Fachanwendung</option>
+        <option value="klickdummy-tool">🧰 Klickdummy / Widget selbst</option>
+      </select>
+    </div>
+    <div style="flex:1">
+      <label class="meta">Kategorie</label>
+      <select id="fb-cat">${categoryOptions()}</select>
+    </div>
+  </div>
+  <textarea id="fb-text" placeholder="Was beobachtest, vermisst, schlägst vor? Konkret bitte — Screen-bezogen ist am hilfreichsten."></textarea>
+  <details class="fb-rel">
+    <summary>Bezug zu anderen Screens (optional, Repro-Anker)</summary>
+    <div id="fb-rel-grid" class="fb-rel-grid"></div>
+    <div class="fb-rel-hint">Hilft, das Feedback in Beziehung zu anderen Screens zu lesen. Mehrfachauswahl.</div>
+  </details>
+  <details class="fb-rel">
+    <summary>Bezug zu Aktionen im aktuellen Screen (optional)</summary>
+    <div id="fb-act-grid" class="fb-rel-grid"></div>
+    <div class="fb-rel-hint">Buttons / Aktionen — feinere Repro-Anker als Screen-Bezug allein.</div>
+  </details>
+  <details class="fb-rel">
+    <summary>Anhänge (optional)</summary>
+    <label class="fb-rel-chip" style="cursor:pointer">
+      <input type="checkbox" id="fb-snapshot"> DOM-Snapshot des aktuellen Screens anhängen (HTML, 8 KB)
+    </label>
+    <div style="margin-top:8px">
+      <label class="meta" style="display:block;margin-bottom:4px">Dateien (max. 5, je 1 MB)</label>
+      <input type="file" id="fb-files" multiple accept="image/*,application/pdf,text/markdown,text/plain,application/json" style="font-size:11px">
+      <div id="fb-files-list" class="fb-rel-hint"></div>
+    </div>
+  </details>
+  <div class="fb-actions">
+    <button id="fb-dl">⬇ Download .md</button>
+    <button id="fb-cb">📋 Clipboard</button>
+    <button class="primary" id="fb-gh">🚀 GitHub Issue</button>
+  </div>
+  <div class="fb-foot">
+    <strong>GitHub Issue:</strong> User-PAT in <code>localStorage.klickdummy_github_token</code> (Scope: <code>repo</code> wenn privat, sonst <code>public_repo</code>). Issue-Author = realer GitHub-User; Audit native.
+    ${REPO ? '<br>Repo: <code>' + REPO + '</code>' : '<br><em>Repo nicht konfiguriert — nur Download/Clipboard möglich.</em>'}
+  </div>
+</div>`;
+    document.body.appendChild(wrap);
+    document.getElementById('fb-fab').addEventListener('click', toggle);
+    document.getElementById('fb-dl').addEventListener('click', () => submit('download'));
+    document.getElementById('fb-cb').addEventListener('click', () => submit('clipboard'));
+    document.getElementById('fb-gh').addEventListener('click', () => submit('github'));
+    document.getElementById('fb-files').addEventListener('change', filesListUpdate);
+  }
+
+  // ---- Screen/Action discovery -------------------------------------------
+  function currentScreen() {
+    const s = document.querySelector('section.active[data-screen]') ||
+              document.querySelector('[data-screen]');
+    return s ? s.getAttribute('data-screen') : null;
+  }
+
+  function currentPersona() {
+    if (typeof window.KLICKDUMMY_PERSONA_HOOK === 'function') {
+      return window.KLICKDUMMY_PERSONA_HOOK();
+    }
+    return document.body.getAttribute('data-persona') || null;
+  }
+
+  function currentVerfahren() {
+    if (typeof window.KLICKDUMMY_VERFAHREN_HOOK === 'function') {
+      return window.KLICKDUMMY_VERFAHREN_HOOK();
+    }
+    return document.body.getAttribute('data-verfahren') || null;
+  }
+
+  function allScreens() {
+    return Array.from(document.querySelectorAll('section[data-screen]'))
+      .map(s => s.getAttribute('data-screen'))
+      .filter((v, i, a) => v && a.indexOf(v) === i)
+      .sort();
+  }
+
+  function actionsInCurrentScreen() {
+    const sect = document.querySelector('section.active');
+    if (!sect) return [];
+    const seen = new Set(); const out = [];
+    Array.from(sect.querySelectorAll('[onclick]')).forEach(el => {
+      const onclick = el.getAttribute('onclick') || '';
+      const m = onclick.match(/(?:event\.stopPropagation\(\);)?\s*(\w+)\s*\(([^)]*)\)/);
+      if (!m) return;
+      const fn = m[1];
+      if (!FB_ACTION_HANDLERS.includes(fn)) return;
+      let label = (el.textContent || '').trim().replace(/\s+/g, ' ');
+      if (label.length < 2 || label.length > 60) return;
+      if (/^[←→↑↓]\s*$/.test(label)) return;
+      let target = null;
+      const arg = (m[2] || '').trim();
+      if (fn === 'go') {
+        const t = arg.match(/^['"]([a-z0-9-]+)['"]/);
+        target = t ? t[1] : null;
+      } else if (fn === 'ext') {
+        const t = arg.match(/^['"]([^'"]+)['"]/);
+        target = t ? `target-mock:${t[1]}` : null;
+      } else if (fn === 'wizard' || fn === 'hemmung') {
+        target = `${fn}#step-${arg.replace(/['"]/g, '')}`;
+      } else if (fn === 'applyWorklistFilter') {
+        const t = arg.match(/^['"]([^'"]+)['"]/);
+        target = t ? `worklist#filter:${t[1]}` : null;
+      }
+      const key = label + '|' + (target || fn);
+      if (seen.has(key)) return; seen.add(key);
+      out.push({ label, target, fn });
+    });
+    return out;
+  }
+
+  // ---- Panel population ---------------------------------------------------
+  function populateRelated() {
+    const grid = document.getElementById('fb-rel-grid');
+    if (!grid) return;
+    const cur = currentScreen();
+    const screens = allScreens().filter(s => s !== cur);
+    const prev = new Set(Array.from(grid.querySelectorAll('input:checked')).map(i => i.value));
+    grid.innerHTML = screens.map(s => `
+      <label class="fb-rel-chip${prev.has(s) ? ' on' : ''}" data-screen="${s}">
+        <input type="checkbox" value="${s}"${prev.has(s) ? ' checked' : ''}>${s}
+      </label>`).join('');
+    grid.querySelectorAll('label.fb-rel-chip').forEach(lbl =>
+      lbl.addEventListener('change', () =>
+        lbl.classList.toggle('on', lbl.querySelector('input').checked)));
+  }
+
+  function populateActions() {
+    const grid = document.getElementById('fb-act-grid');
+    if (!grid) return;
+    const actions = actionsInCurrentScreen();
+    const prev = new Set(Array.from(grid.querySelectorAll('input:checked')).map(i => i.value));
+    if (!actions.length) { grid.innerHTML = '<span class="fb-rel-empty">Keine erkannten Aktionen in diesem Screen.</span>'; return; }
+    grid.innerHTML = actions.map(a => {
+      const val = a.target ? `${a.label}→${a.target}` : a.label;
+      const safe = val.replace(/"/g, '&quot;');
+      const tgt = a.target ? `<span class="fb-action-tgt">→ ${a.target}</span>` : '';
+      return `<label class="fb-rel-chip${prev.has(safe) ? ' on' : ''}">
+        <input type="checkbox" value="${safe}"${prev.has(safe) ? ' checked' : ''}>${a.label}${tgt}
+      </label>`;
+    }).join('');
+    grid.querySelectorAll('label.fb-rel-chip').forEach(lbl =>
+      lbl.addEventListener('change', () =>
+        lbl.classList.toggle('on', lbl.querySelector('input').checked)));
+  }
+
+  function getRelated() {
+    const g = document.getElementById('fb-rel-grid');
+    return g ? Array.from(g.querySelectorAll('input:checked')).map(i => i.value) : [];
+  }
+
+  function getActions() {
+    const g = document.getElementById('fb-act-grid');
+    if (!g) return [];
+    return Array.from(g.querySelectorAll('input:checked')).map(i => {
+      const arr = i.value.split('→');
+      return arr.length === 2 ? { label: arr[0], target: arr[1] } : { label: i.value, target: null };
+    });
+  }
+
+  function domSnapshot() {
+    if (!document.getElementById('fb-snapshot')?.checked) return null;
+    const sect = document.querySelector('section.active');
+    if (!sect) return null;
+    const clone = sect.cloneNode(true);
+    clone.querySelectorAll('script, style').forEach(n => n.remove());
+    clone.querySelectorAll('[onclick]').forEach(n => n.removeAttribute('onclick'));
+    let html = clone.outerHTML.replace(/\s{2,}/g, ' ').replace(/>\s+</g, '><');
+    const MAX = 8192;
+    if (html.length > MAX) html = html.slice(0, MAX) + '\n<!-- … gekürzt -->';
+    return html;
+  }
+
+  function readFiles() {
+    const input = document.getElementById('fb-files');
+    if (!input || !input.files || !input.files.length) return Promise.resolve([]);
+    const files = Array.from(input.files).slice(0, FB_FILE_MAX_COUNT);
+    return Promise.all(files.map(f => new Promise(resolve => {
+      if (f.size > FB_FILE_MAX_BYTES) {
+        resolve({ name: f.name, type: f.type, size: f.size, skipped: 'too-large', data_url: null });
+        return;
+      }
+      const r = new FileReader();
+      r.onload = () => resolve({ name: f.name, type: f.type, size: f.size, data_url: r.result });
+      r.onerror = () => resolve({ name: f.name, type: f.type, size: f.size, skipped: 'read-error', data_url: null });
+      r.readAsDataURL(f);
+    })));
+  }
+
+  function filesListUpdate() {
+    const input = document.getElementById('fb-files');
+    const list = document.getElementById('fb-files-list');
+    if (!input || !list) return;
+    const files = Array.from(input.files || []);
+    if (!files.length) { list.textContent = ''; return; }
+    list.innerHTML = files.slice(0, FB_FILE_MAX_COUNT).map(f => {
+      const big = f.size > FB_FILE_MAX_BYTES;
+      const sz = (f.size / 1024).toFixed(1) + ' KB';
+      return `<div>${big ? '⚠️ zu groß' : '✓'} <code>${f.name}</code> · ${sz}${big ? ' (übersprungen)' : ''}</div>`;
+    }).join('');
+  }
+
+  function toggle() {
+    const p = document.getElementById('fb-panel');
+    p.classList.toggle('open');
+    if (p.classList.contains('open')) {
+      document.getElementById('fb-screen').textContent = currentScreen() || '—';
+      document.getElementById('fb-persona').textContent = currentPersona() || '—';
+      populateRelated();
+      populateActions();
+    }
+  }
+
+  function payload() {
+    return {
+      screen: currentScreen(),
+      persona: currentPersona(),
+      verfahren: currentVerfahren(),
+      feedback_scope: document.getElementById('fb-scope')?.value || 'app',
+      category: document.getElementById('fb-cat').value,
+      text: document.getElementById('fb-text').value.trim(),
+      related_screens: getRelated(),
+      related_actions: getActions(),
+      dom_snapshot: domSnapshot(),
+      spec_id: SPEC.id,
+      spec_version: SPEC.version,
+      klickdummy_class: SPEC.klickdummy_class,
+      user_agent: navigator.userAgent,
+      viewport: { w: window.innerWidth, h: window.innerHeight },
+      timestamp: new Date().toISOString(),
+      url: location.href
+    };
+  }
+
+  function asMarkdown(p, attachments) {
+    const scopeLbl = p.feedback_scope === 'klickdummy-tool' ? 'Klickdummy/Widget' : 'Fachanwendung';
+    const relYaml = p.related_screens.length
+      ? 'related_screens: [' + p.related_screens.map(s => `"${s}"`).join(', ') + ']\n'
+      : 'related_screens: []\n';
+    const actYaml = p.related_actions.length
+      ? 'related_actions:\n' + p.related_actions.map(a =>
+          `  - { label: "${a.label.replace(/"/g, '\\"')}", target: ${a.target ? '"' + a.target + '"' : 'null'} }`).join('\n') + '\n'
+      : 'related_actions: []\n';
+    const relSec = p.related_screens.length ? `\n**Bezug zu Screens:** ${p.related_screens.map(s => '`' + s + '`').join(', ')}\n` : '';
+    const actSec = p.related_actions.length ? `**Bezug zu Aktionen:** ${p.related_actions.map(a => '`' + a.label + (a.target ? ' → ' + a.target : '') + '`').join(', ')}\n` : '';
+    const snap = p.dom_snapshot ? `\n<details><summary>DOM-Snapshot (${p.dom_snapshot.length} Zeichen)</summary>\n\n\`\`\`html\n${p.dom_snapshot}\n\`\`\`\n</details>\n` : '';
+    const att = (attachments && attachments.length)
+      ? '\n## Anhänge\n\n' + attachments.map(a =>
+          a.skipped
+            ? `- ⚠️ \`${a.name}\` (${a.type || '?'}, ${a.size} B) — ${a.skipped}`
+            : `<details><summary>📎 ${a.name} · ${(a.size / 1024).toFixed(1)} KB</summary>\n\n\`\`\`\n${a.data_url}\n\`\`\`\n</details>`).join('\n') + '\n'
+      : '';
+    return `---
+type: klickdummy-feedback
+spec_id: ${p.spec_id}
+spec_version: ${p.spec_version}
+klickdummy_class: ${p.klickdummy_class}
+feedback_scope: ${p.feedback_scope}
+screen: ${p.screen || '(n/a)'}
+persona: ${p.persona || '(n/a)'}
+verfahren: ${p.verfahren || '(n/a)'}
+category: ${p.category}
+${relYaml}${actYaml}timestamp: ${p.timestamp}
+viewport: { w: ${p.viewport.w}, h: ${p.viewport.h} }
+attachments: ${attachments && attachments.length ? attachments.length : 0}
+---
+
+## [${p.category}] ${scopeLbl}-Feedback · Screen \`${p.screen || '?'}\` · Persona \`${p.persona || '?'}\`
+${relSec}${actSec}
+${p.text}
+${snap}${att}
+---
+*Erfasst via Feedback-Widget v0.5 (platform:ADR-211 Rev 13). Quelle: \`${p.url}\`*
+`;
+  }
+
+  function reset() {
+    document.getElementById('fb-text').value = '';
+    ['fb-rel-grid', 'fb-act-grid'].forEach(id => {
+      const g = document.getElementById(id);
+      if (g) g.querySelectorAll('input:checked').forEach(i => {
+        i.checked = false; i.closest('label')?.classList.remove('on');
+      });
+    });
+    const snap = document.getElementById('fb-snapshot'); if (snap) snap.checked = false;
+    const files = document.getElementById('fb-files'); if (files) { files.value = ''; filesListUpdate(); }
+  }
+
+  function toast(msg) {
+    if (typeof window.toast === 'function') return window.toast(msg);
+    console.log('[klickdummy-feedback]', msg);
+  }
+
+  // ---- Submit -------------------------------------------------------------
+  async function submit(mode) {
+    const p = payload();
+    if (!p.text) { toast('Bitte Text eingeben'); return; }
+    const attachments = await readFiles();
+    const md = asMarkdown(p, attachments);
+    if (mode === 'download') {
+      const blob = new Blob([md], { type: 'text/markdown;charset=utf-8' });
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = `klickdummy-feedback-${p.screen || 'unknown'}-${Date.now()}.md`;
+      document.body.appendChild(a); a.click(); a.remove();
+      toast('Markdown heruntergeladen');
+    } else if (mode === 'clipboard') {
+      try { await navigator.clipboard.writeText(md); toast('In Clipboard'); }
+      catch (e) { toast('Clipboard nicht verfügbar — Download wählen'); }
+    } else if (mode === 'github') {
+      await submitGithub(p, md);
+    }
+  }
+
+  async function submitGithub(p, md) {
+    if (!REPO) { toast('window.KLICKDUMMY_FEEDBACK_REPO nicht gesetzt'); return; }
+    let token = localStorage.getItem('klickdummy_github_token');
+    if (!token) {
+      token = prompt(
+        'GitHub Personal Access Token (Scope: repo wenn privat, sonst public_repo).\n\n' +
+        'Erstellen unter: https://github.com/settings/tokens?type=beta\n' +
+        'Token wird nur in localStorage gespeichert (klickdummy_github_token).'
+      );
+      if (!token) return;
+      localStorage.setItem('klickdummy_github_token', token);
+    }
+    const title = `[Klickdummy-Feedback] ${p.category} · ${p.screen || 'n/a'}`;
+    try {
+      const r = await fetch(`https://api.github.com/repos/${REPO}/issues`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Accept': 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28'
+        },
+        body: JSON.stringify({ title, body: md, labels: ['klickdummy-feedback'] })
+      });
+      if (r.status === 401 || r.status === 403) {
+        localStorage.removeItem('klickdummy_github_token');
+        toast('Token ungültig — bitte erneut beim nächsten Submit eingeben');
+        return;
+      }
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const issue = await r.json();
+      toast('Issue erstellt: ' + issue.html_url);
+      reset();
+      toggle();
+    } catch (e) {
+      toast('GitHub-Submit fehlgeschlagen — ' + e.message + '. Fallback: Download.');
+      submit('download');
+    }
+  }
+
+  function init() {
+    if (!fbEnabled()) return;
+    injectStyles();
+    injectMarkup();
+    document.getElementById('fb-fab').style.display = 'block';
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/packages/iil-klickdummy/src/iil_klickdummy/snippets/issue-template/klickdummy-feedback.md
+++ b/packages/iil-klickdummy/src/iil_klickdummy/snippets/issue-template/klickdummy-feedback.md
@@ -1,0 +1,37 @@
+---
+name: 💬 Klickdummy-Feedback
+about: Feedback aus dem Klickdummy-Feedback-Widget (Co-Development-Loop)
+title: "[Klickdummy-Feedback] "
+labels: ["klickdummy-feedback"]
+assignees: []
+---
+
+<!--
+Vorlage für Issues, die das Klickdummy-Feedback-Widget per GitHub-Direkt-API
+erzeugt (Submit-Mode 'github', User-PAT in localStorage.klickdummy_github_token).
+Issue-Author ist der reale GitHub-User. Coding-Agent (z. B. GitHub-Action mit
+Claude-Code-Action) reagiert auf das Label `klickdummy-feedback`.
+-->
+
+## Kontext
+
+- **Spec:** _(aus payload.spec_id)_
+- **Klasse:** _(aus payload.klickdummy_class)_
+- **Scope:** _(app | klickdummy-tool — aus payload.feedback_scope)_
+- **Screen:** _(aus payload.screen)_
+- **Kategorie:** _(bug | feature | ux | spec | ki — konfigurierbar via KLICKDUMMY_CATEGORIES)_
+
+## Feedback
+
+_(Markdown aus dem Widget — vom Widget direkt eingefügt.)_
+
+## Erwartetes Vorgehen
+
+1. Issue lesen, Klassifikation übernehmen (Kategorie + Screen + Scope).
+2. Bei `scope: klickdummy-tool` → Widget/Snippet-Anpassung in `iil-klickdummy`.
+3. Bei `scope: app` → Spec-Anpassung im Repo, dann Render.
+4. PR mit Änderungen ODER Klärungs-Kommentar.
+
+## Bezug
+
+- `platform:ADR-211` Rev 13 (Konvention + Distribution + Co-Creation-Pfade)

--- a/packages/iil-klickdummy/src/iil_klickdummy/snippets/shell-bootstrap/inject-widget.html
+++ b/packages/iil-klickdummy/src/iil_klickdummy/snippets/shell-bootstrap/inject-widget.html
@@ -1,0 +1,26 @@
+<!--
+Klickdummy-Widget-Bootstrap (platform:ADR-211 Rev 13).
+Include in shell.html. Snippet kommt via `make klickdummy-install-snippets`
+aus dem iil-klickdummy pip-Paket nach <repo>/platform-snippets/klickdummy/.
+
+Voraussetzung im Host:
+  - section.active[data-screen] oder mind. ein [data-screen]-Element
+  - optional window.toast(msg) (sonst Console-Fallback)
+
+Submit-Modes:
+  - download   (Default-Fallback, offline)
+  - clipboard
+  - github     (direkter POST an api.github.com mit User-PAT in localStorage)
+-->
+<script>
+  window.KLICKDUMMY_SPEC = {
+    id: "REPO:klickdummy-spec-NAME",        // ← anpassen (repo:klickdummy-spec-<name>)
+    version: "0.1",                          // ← anpassen
+    klickdummy_class: "mock"                 // ← anpassen (mock|stub-demo|story|spec-demo)
+  };
+  window.KLICKDUMMY_FEEDBACK_REPO = "OWNER/REPO";   // ← anpassen (GitHub-Zielrepo)
+  // optional:
+  // window.KLICKDUMMY_CATEGORIES = [...];          // Default 5: bug|feature|ux|spec|ki
+  // window.KLICKDUMMY_PERSONA_HOOK = () => '...';  // sonst body[data-persona]
+</script>
+<script src="platform-snippets/klickdummy/feedback-widget/widget.js" defer></script>

--- a/packages/iil-klickdummy/src/iil_klickdummy/snippets/spec-templates/screens-spec-template.yaml
+++ b/packages/iil-klickdummy/src/iil_klickdummy/snippets/spec-templates/screens-spec-template.yaml
@@ -1,0 +1,28 @@
+# Template — platform:ADR-211 Rev 13. Kopieren + Felder mit ↳ anpassen.
+$schema: https://raw.githubusercontent.com/achimdehnert/platform/main/packages/iil-klickdummy/src/iil_klickdummy/schemas/screens-spec.schema.json
+spec_id: REPO:klickdummy-spec-NAME        # ↳ anpassen
+spec_version: "0.1"
+spec_date: "YYYY-MM-DD"
+title: NAME — Klickdummy
+adr:
+  local: repo:ADR-NNN
+  conforms_to: platform:ADR-211
+  sister_of: []
+class: mock                               # ↳ wählen: mock | stub-demo | story | spec-demo
+class_evidence:
+  no_backend: true
+  no_demo_param: true
+  target_mocks_visible: true
+  systemgrenzen: []
+off_ramp:
+  policy: platform:ADR-211 Static→Echt-Migrationspfad
+  unit: per-screen
+  rule: "Parity-grün pro Screen ⇒ Screen aus statischer Quelle entfernen"
+  doppelquell_grenze: prod-release
+  parity_runner: make klickdummy-i3
+screens:
+  - id: example
+    title: Example Screen
+    parity_acceptance:
+      - { id: example.first-check, check: "Erste Acceptance-Behauptung" }
+    off_ramp_status: static

--- a/packages/iil-klickdummy/tests/test_smoke.py
+++ b/packages/iil-klickdummy/tests/test_smoke.py
@@ -1,0 +1,83 @@
+"""Smoke tests for iil-klickdummy package — every public surface importable + callable."""
+from __future__ import annotations
+
+import json
+from importlib.resources import files
+
+
+def test_package_version():
+    import iil_klickdummy
+    assert iil_klickdummy.__version__ == "1.0.0"
+
+
+def test_all_modules_present():
+    import iil_klickdummy
+    for mod in ("check_i1", "check_i2", "check_i3", "check_i4",
+                "extract_requirements", "inventory", "install_snippets"):
+        assert hasattr(iil_klickdummy, mod), f"missing module: {mod}"
+
+
+def test_all_main_cli_endpoints():
+    import iil_klickdummy
+    for mod_name in ("check_i1", "check_i2", "check_i3", "check_i4",
+                     "extract_requirements", "inventory", "install_snippets"):
+        mod = getattr(iil_klickdummy, mod_name)
+        assert callable(getattr(mod, "main_cli", None)), f"{mod_name}.main_cli missing"
+
+
+def test_schemas_resource():
+    names = sorted(p.name for p in files("iil_klickdummy.schemas").iterdir())
+    assert {"screens-spec.schema.json", "module-manifest.schema.json",
+            "feedback-payload.schema.json"}.issubset(set(names))
+
+
+def test_screens_spec_schema_strict_mode():
+    schema = json.loads(files("iil_klickdummy.schemas").joinpath("screens-spec.schema.json").read_text())
+    assert schema["properties"]["class"]["enum"] == ["mock", "stub-demo", "story", "spec-demo"]
+
+
+def test_check_i2_strict_mode():
+    from iil_klickdummy import check_i2
+    assert check_i2.LEGACY == {}, "Strict-Mode: LEGACY must be empty per ADR-211 Rev 12/13"
+    assert check_i2.ALLOWED == {"mock", "stub-demo", "story", "spec-demo"}
+
+
+def test_snippets_resource():
+    snippets = files("iil_klickdummy") / "snippets"
+    names = []
+    for d in snippets.iterdir():
+        for f in d.iterdir():
+            names.append(f.name)
+    assert "widget.js" in names
+    assert "klickdummy-feedback.md" in names
+    assert "inject-widget.html" in names
+    assert "screens-spec-template.yaml" in names
+
+
+def test_widget_js_v05_features():
+    """Widget v0.5 must have all v0.2-v0.4 features + GitHub-Direct-API."""
+    js = (files("iil_klickdummy") / "snippets" / "feedback-widget" / "widget.js").read_text()
+    # v0.2 features
+    assert "populateRelated" in js
+    assert "fb-rel-grid" in js
+    # v0.3 features
+    assert "domSnapshot" in js
+    assert "FB_FILE_MAX_BYTES" in js
+    assert "actionsInCurrentScreen" in js
+    assert "fb-act-grid" in js
+    # v0.4 features
+    assert "feedback_scope" in js
+    assert "fb-scope" in js
+    assert "KLICKDUMMY_VERFAHREN_HOOK" in js
+    # v0.5 (Rev 13 pivot B): GitHub-Direkt-API
+    assert "submitGithub" in js
+    assert "api.github.com" in js
+    assert "klickdummy_github_token" in js
+    # v0.5: Plugin-Hooks
+    assert "KLICKDUMMY_CATEGORIES" in js
+    assert "KLICKDUMMY_PERSONA_HOOK" in js
+
+
+def test_inventory_runs_clean_on_nonexistent_base():
+    from iil_klickdummy import inventory
+    assert inventory.main(["--base", "/nonexistent/path"]) == 0

--- a/scripts/checks/klickdummy_legacy_class_inventory.sh
+++ b/scripts/checks/klickdummy_legacy_class_inventory.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Bash-Bootstrap-Fallback. Kanonisch: `klickdummy-inventory` (iil-klickdummy pip-Paket).
+set -euo pipefail
+REPOS_BASE="${REPOS_BASE:-$HOME/github}"
+REPOS="${REPOS:-meiki-hub writing-hub risk-hub pptx-hub dev-hub ttz-hub}"
+FOUND=0
+for repo in $REPOS; do
+  d="$REPOS_BASE/$repo"
+  [[ -d "$d" ]] || { echo "=== $repo: NOT PRESENT ==="; continue; }
+  matches=$(grep -rEn --include='*.yaml' --include='*.yml' --include='*.json' \
+            --include='*.md' --include='*.html' --include='*.py' 'mock-prototyp|demo-render' "$d" 2>/dev/null | \
+            grep -v 'node_modules\|\.venv\|__pycache__\|/build/\|/dist/\|feedback-log\|_archiv' | \
+            grep -Ev 'LEGACY|"mock-prototyp": "mock"|"demo-render": "spec-demo"|# vorher|\(vorher ' || true)
+  if [[ -n "$matches" ]]; then echo "=== $repo ==="; echo "$matches" | head -10; FOUND=1
+  else echo "=== $repo: ✓ clean ==="; fi
+done
+[[ $FOUND -eq 0 ]] && echo -e "\nS11 → 0 echte Drift-Treffer cross-repo."
+exit $FOUND


### PR DESCRIPTION
**Decider-Pivot post Pass-3-Review.** Initial-Vorschlag PR #273 (eigenständiges ADR-214 + zentraler Service `feedback.iil.pet`) wurde als advocatus diabolus zurückgezogen — 4 🔴-Findings:

| # | Finding | Wirkung |
|---|---|---|
| K1 | 0 produktive Endpoint-Iterationen in 7 meiki-Iter. | Hypothese, nicht Empirie |
| K3 | Coding-Agent existiert nicht | Service ohne automatischen Konsument |
| K6/K12 | 24/7-Wartung + PAT-Rotation + PII-Filter | ROI negativ |
| K10 | Datenschutz-Default falsch herum | 4/6 Repos sensibel |

Ohne Service-Boundary entfällt die `adr-threshold.md`-Begründung für eigenständigen ADR → **Distribution-Mechanik wandert in ADR-211 Rev 13**.

## Was Rev 13 macht

### (a) §Distribution — pip-Paket `iil-klickdummy` v1.0.0

- Schemas + Skripte + Snippets (Widget v0.5, Issue-Template, Spec-Template, Bootstrap) als `package_data`
- Distribution: `pip install "iil-klickdummy @ git+https://github.com/achimdehnert/platform.git@v1.0.0#subdirectory=packages/iil-klickdummy"` (bis privates PyPI aufgesetzt)
- 7 Console-Scripts: `klickdummy-i1..i4`, `klickdummy-extract-requirements`, `klickdummy-inventory`, `klickdummy-install-snippets`
- 9 Smoke-Tests grün (incl. v0.5-Feature-Check + Strict-Mode-Beleg)

### (b) §Co-Creation Pfade A neu strukturiert

| Pfad | Was | Status |
|---|---|---|
| **A-light** | download/clipboard | Default. Empirisch validiert (meiki Iter. 1-7). |
| **A-User-Direct** | Widget → `api.github.com` mit User-PAT in localStorage | **Erlaubt + Default für GitHub-Workflows.** Audit/Rate-Limit GitHub-native. |
| **A-Agent** | GitHub-Action pro Repo auf Label | Voraussetzung nachweisbar (Workflow im Repo). |
| **A-Bridge / B / C** | (zentraler Service / Direkt-LLM / Browser-LLM) | **Gestrichen bzw. verboten** in Rev 13. |

### (c) Widget v0.5 — Plugin-Architektur

```js
window.KLICKDUMMY_CATEGORIES = [...];        // override Default 5
window.KLICKDUMMY_PERSONA_HOOK = () => ...;
window.KLICKDUMMY_VERFAHREN_HOOK = () => ...;
window.KLICKDUMMY_FEEDBACK_REPO = "owner/repo";
```

Repo-Customization ohne Fork — ttz-hub kann eigene `datenschutz`-Kategorie ergänzen.

### (d) Voller v0.4-Stand portiert

Widget v0.5 enthält ALLE v0.2-v0.4-Features (Action-Liste, DOM-Snapshot, File-Upload, Scope-Selector, Verfahrens-Kontext). **K17 vermieden** — kein Iterations-Rückschritt bei Adoption.

## ADR-Policy-Konformität

`adr-threshold.md`-Pre-Check bestanden:
- Distribution-Mechanik allein = „following an existing pattern" → **keine ADR-Pflicht** für separates ADR → ADR-211 Rev 13 ist die richtige Heimat.
- Was ADR-214 als „neue Service-Boundary" begründet hätte, ist mit Pivot weggefallen.

## Tests

```
9 passed in 0.11s
S11 → 0 echte Drift-Treffer cross-repo (6 Repos)
```

## Vor Acceptance noch zu tun

- [ ] Decider ratifiziert Rev 13
- [ ] v1.0.0 Git-Tag setzen auf platform-main (nach Merge)
- [ ] Pilot-Migration meiki-hub → verwendet `iil-klickdummy` statt lokaler Kopien
- [ ] ttz-hub Erst-Adoption (Migrations-Cookbook §Migration anwenden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
