### PR TITLE
feat(adr,infra): ADR-216 Klickdummy-Hosting auf iil.pet (Traefik + Authentik-SSO)

### DIFF
--- a/docs/adr/ADR-216-klickdummy-hosting-iil-pet.md
+++ b/docs/adr/ADR-216-klickdummy-hosting-iil-pet.md
@@ -1,0 +1,426 @@
+---
+id: ADR-216
+title: "Klickdummy-Hosting auf iil.pet (Self-Hosted Stakeholder-Demos)"
+status: proposed
+date: 2026-05-21
+deciders: [Achim Dehnert]
+consulted: []
+informed: [meiki-lra, bahn-sqf, ttz-lif, iilgmbh]
+domains: [infrastructure, deployment, klickdummy, hosting]
+supersedes: []
+amends: []
+depends_on: [ADR-142, ADR-198, ADR-210, ADR-212, ADR-215]
+related: [ADR-211, ADR-113]
+tags: [klickdummy, hosting, traefik, staging, iil-pet, self-hosted]
+scope:
+  include_paths:
+    - "infra/klickdummy-host/"
+    - "docs/adr/ADR-216-*"
+---
+
+# ADR-216 — Klickdummy-Hosting auf `iil.pet` (Self-Hosted Stakeholder-Demos)
+
+## Status
+
+**proposed** — Konkretisiert Stage 2 aus der Klickdummy-Hosting-Frage
+(meiki-hub-Session Iter. 24, User-Entscheidung Pfad D: „alles unter
+meiner Kontrolle"). Tritt in Kraft mit erstem Container-Deployment.
+
+## Kontext
+
+### Stage 1.5 ist live (ADR-215)
+
+`platform:ADR-215` (proposed, PR #283) etabliert pgvector-Discovery für
+Cross-Repo-Klickdummies. Cross-Repo-Picker in den Klickdummies fetcht
+beim Page-Load aus `orchestrator.iil.pet/api/discovery/klickdummy/list`,
+mit Inline-Fallback. **Empirie #1 läuft in `meiki-hub` PR #38 (merged).**
+
+### Pre-Pilot-Reviews brauchen URLs (Stage 2)
+
+Stakeholder-Reviews mit Raphael Bayer (sqf), Ilja Lerch + Grinninger (pg),
+TTZ-Pilot brauchen **klick-bare URLs**, nicht lokales `python3 -m http.server`.
+Iter. 24 versuchte GitHub Pages für alle 4 Klickdummy-Repos — scheiterte am
+Free-Plan-Limit für private Repos (siehe Drift-Memory
+`github-pages-private-repo-plan`).
+
+### User-Entscheidung 2026-05-21
+
+> „D, da ich alles unter meiner Kontrolle will!"
+
+Pfad D = self-hosted auf `iil.pet`-Infrastruktur, statt Plan-Upgrades bei
+GitHub oder Drittanbietern wie Cloudflare Pages.
+
+## Entscheidung
+
+**Statisches Klickdummy-Hosting via Traefik-Reverse-Proxy auf
+`klickdummy.iil.pet`.** Konkret:
+
+1. **Hostname:** `klickdummy.iil.pet` (production, nicht `staging-*` — Stakeholder-Demos sind Pre-Pilot, aber Domain ist stabil)
+2. **Reverse-Proxy:** existierender Traefik v3 (`platform:ADR-212` Klausel 3)
+3. **Backend:** ein **nginx-Container** mit Volume-Mount auf `/srv/klickdummy/`
+4. **URL-Schema:** `https://klickdummy.iil.pet/<org>/<repo>/<klickdummy>/`
+5. **Content-Sync:** **Pull-Mode** via Cron — Server pullt alle Klickdummy-Repos täglich (`git pull --ff-only`) und kopiert `klickdummy/<name>/` und `docs/01-architektur/mockups/<name>/` ins nginx-DocRoot
+
+## Warum Pull statt Push
+
+| Push (CI) | Pull (Server) |
+|---|---|
+| Pro Repo eine GitHub Action mit `ssh staging-platform rsync ...` | Server-seitiger Cron-Job mit Deploy-Key pro Repo |
+| Token auf jeder Org/Repo-Seite | Ein Deploy-Key zentral |
+| Latenz: nahezu sofort nach Merge | Latenz: bis zu 24h (Cron-Intervall tunbar) |
+| Sicherheits-Risiko: Token-Spread (vgl. Drift-Memory `pat-in-remote-url-leak`) | Sicherheits-Risiko: SSH-Key-Verwaltung server-seitig |
+| 4× Workflow-Files in 4 Orgs | 1× Cron-Job + Repo-Liste |
+
+**Pull-Mode passt zu „alles unter meiner Kontrolle":** keine Tokens in
+GitHub, keine externen Push-Trigger, alles in einer Server-Verantwortung.
+
+Latenz von 24h ist für Pre-Pilot-Demos ausreichend; bei Bedarf
+`workflow_dispatch`-Trigger auf den Cron via SSH.
+
+## Architektur-Skizze
+
+```
+                       Cloudflare Edge
+                       (klickdummy.iil.pet)
+                              │
+                              ▼ Tunnel: bf-staging (ADR-198)
+                              │
+                       ┌──────┴───────────┐
+                       │  178.104.184.168 │
+                       │  staging-platform│
+                       └──────┬───────────┘
+                              │
+                              ▼
+                       ┌──────────────┐
+                       │   Traefik    │  ADR-212
+                       │   :80/:443   │
+                       └──────┬───────┘
+              traefik_public  │
+                              │
+                       ┌──────▼──────────┐
+                       │   nginx         │
+                       │   (klickdummy)  │
+                       └──────┬──────────┘
+                              │ Volume-Mount
+                       ┌──────▼──────────┐
+                       │ /srv/klickdummy/│
+                       │  meiki-lra/     │
+                       │    meiki-hub/   │
+                       │      fristen.../│
+                       │      modul/     │
+                       │  bahn-sqf/      │
+                       │    sqf-hub/...  │
+                       │    pg-hub/...   │
+                       │  ttz-lif/       │
+                       │    ttz-hub/...  │
+                       └─────────────────┘
+                              ▲
+                              │ rsync von Git-Repos via Cron
+                       ┌──────┴──────────┐
+                       │ /opt/klickdummy/│
+                       │    sync.sh      │   ← Pull-Job, deploy-key auth
+                       │    repos.yaml   │   ← Repo-Liste
+                       └─────────────────┘
+```
+
+## Konkret deploybar (Compose-Snippet)
+
+`infra/klickdummy-host/docker-compose.yml`:
+
+```yaml
+services:
+  klickdummy:
+    image: nginx:alpine
+    container_name: klickdummy
+    restart: always
+    volumes:
+      - /srv/klickdummy:/usr/share/nginx/html:ro
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    networks:
+      - traefik_public
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.klickdummy.rule=Host(`klickdummy.iil.pet`)"
+      - "traefik.http.routers.klickdummy.entrypoints=websecure"
+      - "traefik.http.routers.klickdummy.tls.certresolver=letsencrypt"
+      - "traefik.http.services.klickdummy.loadbalancer.server.port=80"
+
+networks:
+  traefik_public:
+    external: true
+```
+
+`infra/klickdummy-host/nginx.conf`:
+
+```nginx
+server {
+  listen 80 default_server;
+  server_name klickdummy.iil.pet;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # CORS-Headers für Cross-Repo-Picker-Fetch zu orchestrator.iil.pet
+  # (nicht zwingend, der Picker fetcht ja den orchestrator, nicht uns)
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header X-Frame-Options "SAMEORIGIN" always;
+
+  # Auto-Index der org/repo/klickdummy-Verzeichnisse
+  location / { autoindex on; autoindex_exact_size off; autoindex_localtime on; }
+  location ~ \.(html|css|js|json|yaml|svg|png|jpg)$ { try_files $uri =404; }
+}
+```
+
+`infra/klickdummy-host/sync.sh` (cron-job, `/opt/klickdummy/`):
+
+```bash
+#!/bin/bash
+# Klickdummy-Pull-Job — täglich oder via systemd-timer
+set -euo pipefail
+
+WORK=/var/lib/klickdummy-sync
+TARGET=/srv/klickdummy
+REPOS=(
+  "meiki-lra/meiki-hub:docs/01-architektur/mockups"
+  "bahn-sqf/sqf-hub:klickdummy"
+  "bahn-sqf/pg-hub:klickdummy"
+  "ttz-lif/ttz-hub:klickdummy"
+)
+
+for entry in "${REPOS[@]}"; do
+  repo="${entry%:*}"
+  subdir="${entry#*:}"
+  owner="${repo%/*}"
+  name="${repo#*/}"
+
+  clone_dir="$WORK/$owner/$name"
+  if [ ! -d "$clone_dir" ]; then
+    mkdir -p "$WORK/$owner"
+    git clone --depth 1 "git@github.com:$repo.git" "$clone_dir"
+  else
+    git -C "$clone_dir" fetch --depth 1 origin main
+    git -C "$clone_dir" reset --hard origin/main
+  fi
+
+  target_dir="$TARGET/$owner/$name"
+  mkdir -p "$target_dir"
+  rsync -av --delete "$clone_dir/$subdir/" "$target_dir/"
+done
+
+# Landing-Page generieren
+python3 /opt/klickdummy/generate_landing.py > "$TARGET/index.html"
+```
+
+`infra/klickdummy-host/generate_landing.py` — generiert
+`klickdummy.iil.pet/index.html` mit Auto-Discovery aller `<org>/<repo>/<kd>/shell.html`-
+oder `chat-simulator.html`-Pfade. Verlinkt zu jedem direkt.
+
+## I1–I4 Konsequenzen
+
+### I2 Prod-Sicherheit — wichtig
+
+Klickdummies bleiben `class: mock`. **Aber:** `klickdummy.iil.pet` ist eine
+**öffentlich-erreichbare URL**. Das ist **kein I2-Verstoß**, weil:
+
+- Klickdummies sind self-contained Mock-Renderer, kein Code-Pfad in eine
+  Produktiv-App (siehe `class: mock` Definition: separater Wegwerf-Code-Pfad)
+- `klickdummy_prod_guard.sh` (`platform:ADR-211` I2-Probe) prüft `mock`
+  als **N/A** — Klickdummies dürfen public sein
+- DSFA-Klärung 2026-05-21 (User): nicht kritisch (nur Funktionsrollen-Namen
+  öffentlich, synthetische Operativ-Daten)
+
+### I3 Off-Ramp — Phase A bleibt
+
+Klickdummies sind weiterhin Phase A. Hosting auf `iil.pet` ändert nicht den
+Phase-Status — es macht Phase A nur **demonstrationsfähig** für Stakeholder.
+
+### I4 Namensraum — kein Eingriff
+
+URL-Pattern `<org>/<repo>/<klickdummy>` ist mit `repo:ADR-NNN`-Konvention
+konsistent (gleicher Diskriminator).
+
+## DSGVO
+
+DSFA-Klärung 2026-05-21 (User):
+
+- Klickdummies enthalten ausschließlich Funktionsrollen-Bezeichnungen
+  (Persona-Labels) und synthetische Operativ-Daten
+- Echte Personendaten kommen erst in Phase B/C (in den jeweiligen Off-Ramp-
+  Zielsystemen, nicht im Klickdummy selbst)
+- **Klassifikation: nicht kritisch**
+
+Public-Hosting auf `klickdummy.iil.pet` ist DSGVO-konform.
+
+## Stakeholder-Compliance-Zustimmung (2026-05-21, Iter. 25)
+
+User-Update: Konzern-Compliance-Klärung **erteilt** für alle relevanten
+Klickdummy-Repos:
+
+| Klickdummy | Stakeholder | Status |
+|---|---|---|
+| `bahn-sqf/sqf-hub` (AF1 Lost Units) | Raphael Bayer | ✅ zugestimmt |
+| `bahn-sqf/pg-hub` (Pocket Governance) | Ilja Lerch + Grinninger (Stab) | ✅ zugestimmt |
+| `meiki-lra/meiki-hub` (Fristen + Modul) | LRA | ✅ zugestimmt |
+| `ttz-lif/ttz-hub` (Werkleitung + Schicht) | LRA-TTZ | ✅ zugestimmt |
+
+## Authentifizierung (User-Anforderung Iter. 25)
+
+User-Updates 2026-05-21:
+
+> „Anforderung: https://klickdummy.iil.pet/<owner>/<repo>/ mit login
+>  (1 login für alle repos für den anfang) später owner-login..?"
+>
+> ergänzt: „authenticate SSO?"
+
+**Antwort: ja, SSO via Authentik** (`platform:ADR-142` etabliert
+Authentik als Plattform-IdP). Sauberer als BasicAuth, skaliert direkt
+zu Phase 2 (Owner-Login via Authentik-Gruppen-Mapping).
+
+### Phase 1 (heute, deploy-fertig): Authentik-OIDC + Traefik forwardAuth
+
+```
+Browser → Cloudflare → Traefik → forwardAuth → Authentik (/application/o/...)
+                                       ↓ (Session-OK)
+                                     nginx
+```
+
+**Konkret:**
+
+1. **Authentik OAuth2-Provider** anlegen (analog `risk-hub-staging`,
+   siehe `platform/scripts/authentik-staging-oidc.sh` — Pattern aus
+   ADR-142):
+   ```bash
+   scripts/authentik-staging-oidc.sh \
+     --app-slug klickdummy \
+     --redirect-uri https://klickdummy.iil.pet/outpost.goauthentik.io/callback?X-authentik-auth-callback=true \
+     --scopes openid,profile,email
+   ```
+
+2. **Authentik-Outpost (forwardAuth-Endpoint)** deployen — eine
+   leichtgewichtige Sidecar-Instanz, die `/outpost.goauthentik.io/auth/traefik`
+   bereitstellt.
+
+3. **Traefik-Middleware** `klickdummy-sso`:
+   ```yaml
+   labels:
+     - "traefik.http.middlewares.klickdummy-sso.forwardauth.address=http://authentik-outpost:9000/outpost.goauthentik.io/auth/traefik"
+     - "traefik.http.middlewares.klickdummy-sso.forwardauth.trustForwardHeader=true"
+     - "traefik.http.middlewares.klickdummy-sso.forwardauth.authResponseHeaders=X-authentik-username,X-authentik-groups,X-authentik-email"
+     - "traefik.http.routers.klickdummy.middlewares=klickdummy-sso,klickdummy-headers"
+   ```
+
+4. **User-Konten in Authentik** anlegen — Phase 1: alle Stakeholder in
+   einer Gruppe `klickdummy-viewers` (kein Owner-Routing):
+   - `raphael.bayer@db.de` → Gruppe `klickdummy-viewers`
+   - `ilja.lerch@bahn-sqf` → `klickdummy-viewers`
+   - `grinninger@bahn-sqf` → `klickdummy-viewers`
+   - `lra-pilot@meiki-lra` → `klickdummy-viewers`
+   - `ttz-pilot@ttz-lif` → `klickdummy-viewers`
+
+### Phase 2 (Folge-Iteration): Owner-spezifischer Login via Authentik-Gruppen
+
+Pro Org eine Gruppe; Traefik-Middleware-Chain hängt vom Pfad ab:
+
+```yaml
+# Pseudo: pro Owner eine eigene Router-Rule + Gruppen-Check
+traefik.http.routers.klickdummy-sqf.rule=Host(`klickdummy.iil.pet`) && PathPrefix(`/bahn-sqf/`)
+traefik.http.routers.klickdummy-sqf.middlewares=klickdummy-sso,klickdummy-sqf-group-check
+# klickdummy-sqf-group-check: forwardAuth mit Gruppen-Filter ?required_group=sqf-viewers
+```
+
+**Authentik-Gruppen:**
+- `klickdummy-sqf-viewers` → Zugriff auf `/bahn-sqf/*`
+- `klickdummy-pg-viewers` → Zugriff auf `/bahn-sqf/pg-hub/` (Sperrvermerk-aware)
+- `klickdummy-ttz-viewers` → `/ttz-lif/*`
+- `klickdummy-meiki-viewers` → `/meiki-lra/*`
+- `klickdummy-admin` → alle Pfade
+
+Phase 2 ist eine separate ADR (ADR-217 oder Erweiterung dieser ADR) und
+folgt nach Phase-1-Pilot.
+
+### Warum SSO statt BasicAuth
+
+| Punkt | BasicAuth | SSO (Authentik) |
+|---|---|---|
+| Setup | 10 Min (htpasswd) | 30–60 Min (OIDC-App + Outpost) |
+| User-Mgmt | manuell pro Passwort | Web-UI in Authentik |
+| Audit-Log | Traefik-Access-Log only | Authentik Event-Log + Traefik |
+| Logout | nicht möglich (Browser-Cache) | Authentik /logout |
+| Owner-spezifisch | nicht skalierbar | Phase-2-fähig via Gruppen |
+| Bestehende Plattform | nein | ja (ADR-142 Authentik etabliert) |
+| User-Erfahrung | unschön (Browser-Native-Dialog) | sauberer Login-Screen |
+
+User-Erlaubnis „alles unter meiner Kontrolle" ist erfüllt — Authentik
+ist self-hosted Teil der Plattform.
+
+### Warum trotz Stakeholder-Compliance-Zustimmung
+
+User-Compliance-Zustimmung erlaubt **Public-Hosting**. SSO ist
+**zusätzlicher Schutz**:
+
+- Verhindert Crawling / Indexing durch Suchmaschinen
+- Verhindert versehentliches Teilen der URL
+- Schafft Audit-Spur (welcher User wann auf welchen KD)
+- Sauberer für künftig sensiblere Klickdummies in Phase B/C ohne
+  Architektur-Wechsel
+- Phase-2-Owner-Login ist direkter Folgeschritt — keine Re-Architektur
+
+## Trotz Compliance-Zustimmung: warum Login
+
+User-Compliance-Zustimmung der 4 Stakeholder (siehe oben) erlaubt
+**Public-Hosting**. Login ist **zusätzlicher Schutz**:
+
+- Verhindert Crawling / Indexing der Pre-Pilot-Demos durch Suchmaschinen
+- Verhindert versehentliches Teilen der URL (jeder braucht das Passwort)
+- Schafft Audit-Spur via Traefik Access-Log (welcher User wann auf welchen KD)
+- Sauberer für künftig sensiblere Klickdummies in Phase B/C ohne Architektur-Wechsel
+
+## Konsequenzen
+
+### Positiv
+
+- **Volle Kontrolle**: keine Drittanbieter-Pages, keine Plan-Upgrades, keine Tokens auf GitHub
+- **Stabile URL-Pattern**: `klickdummy.iil.pet/<org>/<repo>/<kd>/` bleibt über Repo-Visibility-Änderungen stabil
+- **Auth-fähig** in Phase 2 (Traefik forwardAuth)
+- **Cross-Repo-Picker Discovery-Test-fertig**: CORS-Whitelist für `klickdummy.iil.pet` in Orchestrator-Issue #62 vorgesehen
+- **Konsolidiert mit ADR-212**: dieselbe Traefik-Instanz, kein zusätzlicher Ingress
+
+### Negativ
+
+- **Server-Maintenance**: nginx + cron + sync-script-Pflege. Mitigation: simpel, standardisiert, kein zustandsbehaftetes Backend
+- **Pull-Latenz** bis zu 24h (oder beliebig kürzer per cron-Frequenz)
+- **SSH-Deploy-Key-Verwaltung**: pro Repo ein Deploy-Key oder ein globaler User-Key. Mitigation: read-only Keys, eine Cluster-Identität
+
+### Neutral
+
+- **klickdummy.iil.pet ist ein neuer Hostname** — separater Cloudflare-DNS-Record nötig (Wildcard `*.iil.pet` deckt das ggf. schon)
+
+## Phase-Bauauftrag
+
+### Phase 1 (heute, ADR-216 Initial)
+
+1. ✅ ADR-216 schreiben (diese ADR)
+2. ⏳ `infra/klickdummy-host/`-Verzeichnis mit Compose + nginx-conf + sync.sh + repos.yaml
+3. ⏳ DNS-Record `klickdummy.iil.pet` → Cloudflare Tunnel `bf-staging`
+4. ⏳ Deployment-Test: `docker compose up -d` + ersten Klickdummy-Aufruf
+5. ⏳ Cross-Repo-Picker (meiki-hub PR #38) testet die URL als alternative `path_rel`-Quelle
+
+### Phase 2 (optional, nach Stakeholder-Review)
+
+6. Auth via Traefik forwardAuth (für pg-hub Sperrvermerk-Compliance)
+7. Webhook-Trigger statt Cron (post-merge in jedem Klickdummy-Repo)
+8. Sub-Domains pro Org (`sqf.klickdummy.iil.pet`, `meiki.klickdummy.iil.pet`)
+
+## Alternativen
+
+1. **GitHub Pages mit Plan-Upgrade** ($16+/Monat) — verworfen, nicht „unter eigener Kontrolle"
+2. **Cloudflare Pages** — verworfen, externer Anbieter
+3. **Repos public stellen** — verworfen, Compliance-Risiko pro Repo (Sperrvermerk pg-hub, Gov ttz/meiki)
+4. **Push-Mode (CI rsync)** — verworfen, Token-Spread-Risiko (vgl. Drift-Memory)
+
+## Provenance
+
+- meiki-hub-Session 2026-05-21 Iter. 24: GitHub Pages für alle 4 Repos
+  blockiert (Free-Plan + privat)
+- User-Entscheidung Iter. 25: D — iil.pet self-hosted
+- Drift-Memories: `pat-in-remote-url-leak`, `github-pages-private-repo-plan`
+- Schwester-ADRs: 198 (Tunnel), 210 (3-Stufen), 212 (Traefik), 215 (Discovery)

--- a/docs/adr/ADR-216-klickdummy-hosting-iil-pet.md
+++ b/docs/adr/ADR-216-klickdummy-hosting-iil-pet.md
@@ -53,13 +53,17 @@ GitHub oder Drittanbietern wie Cloudflare Pages.
 ## Entscheidung
 
 **Statisches Klickdummy-Hosting via Traefik-Reverse-Proxy auf
-`klickdummy.iil.pet`.** Konkret:
+`staging-klickdummy.iil.pet`.** Konkret:
 
-1. **Hostname:** `klickdummy.iil.pet` (production, nicht `staging-*` — Stakeholder-Demos sind Pre-Pilot, aber Domain ist stabil)
+1. **Hostname:** `staging-klickdummy.iil.pet` — folgt `platform:ADR-212` Klausel 3 (`staging-<slug>.iil.pet` via `bf-staging`-Tunnel + Traefik auf `178.104.184.168`). Spätere Migration zu `klickdummy.iil.pet` (Klausel 1, Prod nach `platform:ADR-198`) ist eigene Operation nach Pilot-Akzeptanz und nicht Inhalt dieser ADR.
 2. **Reverse-Proxy:** existierender Traefik v3 (`platform:ADR-212` Klausel 3)
-3. **Backend:** ein **nginx-Container** mit Volume-Mount auf `/srv/klickdummy/`
-4. **URL-Schema:** `https://klickdummy.iil.pet/<org>/<repo>/<klickdummy>/`
-5. **Content-Sync:** **Pull-Mode** via Cron — Server pullt alle Klickdummy-Repos täglich (`git pull --ff-only`) und kopiert `klickdummy/<name>/` und `docs/01-architektur/mockups/<name>/` ins nginx-DocRoot
+3. **Backend:** ein **nginx-Container** mit read-only-Symlink-Tree (`/srv/klickdummy/`) auf die geclonten Klickdummy-Repos in `/var/lib/klickdummy-sync/` — kein doppelter rsync-Datenpfad (Drift-Vermeidung)
+4. **URL-Schema:** `https://staging-klickdummy.iil.pet/<org>/<repo>/<klickdummy>/`
+5. **Content-Sync:** **Pull-Mode** via Cron (15-Minuten-Intervall, nicht 24h — Pre-Pilot-Iteration läuft schneller). Server pullt alle Klickdummy-Repos und legt Symlinks ins `/srv/klickdummy/`-DocRoot.
+6. **Auth:** SSO via Authentik forwardAuth (`platform:ADR-142` IdP); siehe §Authentifizierung unten
+7. **Discovery-Endpoint same-origin:** `/api/list` (statisches JSON, vom Sync-Job generiert) — vermeidet CORS-Konfig für Cross-Repo-Picker-Fetch
+8. **Sync-User:** `klickdummy-sync` (dediziert, nicht root), `/srv/klickdummy` und `/var/lib/klickdummy-sync` gehören diesem User; nginx-Container liest read-only
+9. **Robots-Block:** `robots.txt` mit `User-agent: * Disallow: /` zusätzlich zu SSO (Search-Engine-Robust)
 
 ## Warum Pull statt Push
 
@@ -81,7 +85,7 @@ Latenz von 24h ist für Pre-Pilot-Demos ausreichend; bei Bedarf
 
 ```
                        Cloudflare Edge
-                       (klickdummy.iil.pet)
+                       (staging-klickdummy.iil.pet)
                               │
                               ▼ Tunnel: bf-staging (ADR-198)
                               │
@@ -140,7 +144,7 @@ services:
       - traefik_public
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.klickdummy.rule=Host(`klickdummy.iil.pet`)"
+      - "traefik.http.routers.klickdummy.rule=Host(`staging-klickdummy.iil.pet`)"
       - "traefik.http.routers.klickdummy.entrypoints=websecure"
       - "traefik.http.routers.klickdummy.tls.certresolver=letsencrypt"
       - "traefik.http.services.klickdummy.loadbalancer.server.port=80"
@@ -155,7 +159,7 @@ networks:
 ```nginx
 server {
   listen 80 default_server;
-  server_name klickdummy.iil.pet;
+  server_name staging-klickdummy.iil.pet;
   root /usr/share/nginx/html;
   index index.html;
 
@@ -211,14 +215,14 @@ python3 /opt/klickdummy/generate_landing.py > "$TARGET/index.html"
 ```
 
 `infra/klickdummy-host/generate_landing.py` — generiert
-`klickdummy.iil.pet/index.html` mit Auto-Discovery aller `<org>/<repo>/<kd>/shell.html`-
+`staging-klickdummy.iil.pet/index.html` mit Auto-Discovery aller `<org>/<repo>/<kd>/shell.html`-
 oder `chat-simulator.html`-Pfade. Verlinkt zu jedem direkt.
 
 ## I1–I4 Konsequenzen
 
 ### I2 Prod-Sicherheit — wichtig
 
-Klickdummies bleiben `class: mock`. **Aber:** `klickdummy.iil.pet` ist eine
+Klickdummies bleiben `class: mock`. **Aber:** `staging-klickdummy.iil.pet` ist eine
 **öffentlich-erreichbare URL**. Das ist **kein I2-Verstoß**, weil:
 
 - Klickdummies sind self-contained Mock-Renderer, kein Code-Pfad in eine
@@ -248,7 +252,7 @@ DSFA-Klärung 2026-05-21 (User):
   Zielsystemen, nicht im Klickdummy selbst)
 - **Klassifikation: nicht kritisch**
 
-Public-Hosting auf `klickdummy.iil.pet` ist DSGVO-konform.
+Public-Hosting auf `staging-klickdummy.iil.pet` ist DSGVO-konform.
 
 ## Stakeholder-Compliance-Zustimmung (2026-05-21, Iter. 25)
 
@@ -266,7 +270,7 @@ Klickdummy-Repos:
 
 User-Updates 2026-05-21:
 
-> „Anforderung: https://klickdummy.iil.pet/<owner>/<repo>/ mit login
+> „Anforderung: https://staging-klickdummy.iil.pet/<owner>/<repo>/ mit login
 >  (1 login für alle repos für den anfang) später owner-login..?"
 >
 > ergänzt: „authenticate SSO?"
@@ -291,7 +295,7 @@ Browser → Cloudflare → Traefik → forwardAuth → Authentik (/application/o
    ```bash
    scripts/authentik-staging-oidc.sh \
      --app-slug klickdummy \
-     --redirect-uri https://klickdummy.iil.pet/outpost.goauthentik.io/callback?X-authentik-auth-callback=true \
+     --redirect-uri https://staging-klickdummy.iil.pet/outpost.goauthentik.io/callback?X-authentik-auth-callback=true \
      --scopes openid,profile,email
    ```
 
@@ -322,7 +326,7 @@ Pro Org eine Gruppe; Traefik-Middleware-Chain hängt vom Pfad ab:
 
 ```yaml
 # Pseudo: pro Owner eine eigene Router-Rule + Gruppen-Check
-traefik.http.routers.klickdummy-sqf.rule=Host(`klickdummy.iil.pet`) && PathPrefix(`/bahn-sqf/`)
+traefik.http.routers.klickdummy-sqf.rule=Host(`staging-klickdummy.iil.pet`) && PathPrefix(`/bahn-sqf/`)
 traefik.http.routers.klickdummy-sqf.middlewares=klickdummy-sso,klickdummy-sqf-group-check
 # klickdummy-sqf-group-check: forwardAuth mit Gruppen-Filter ?required_group=sqf-viewers
 ```
@@ -379,9 +383,9 @@ User-Compliance-Zustimmung der 4 Stakeholder (siehe oben) erlaubt
 ### Positiv
 
 - **Volle Kontrolle**: keine Drittanbieter-Pages, keine Plan-Upgrades, keine Tokens auf GitHub
-- **Stabile URL-Pattern**: `klickdummy.iil.pet/<org>/<repo>/<kd>/` bleibt über Repo-Visibility-Änderungen stabil
+- **Stabile URL-Pattern**: `staging-klickdummy.iil.pet/<org>/<repo>/<kd>/` bleibt über Repo-Visibility-Änderungen stabil
 - **Auth-fähig** in Phase 2 (Traefik forwardAuth)
-- **Cross-Repo-Picker Discovery-Test-fertig**: CORS-Whitelist für `klickdummy.iil.pet` in Orchestrator-Issue #62 vorgesehen
+- **Cross-Repo-Picker Discovery-Test-fertig**: CORS-Whitelist für `staging-klickdummy.iil.pet` in Orchestrator-Issue #62 vorgesehen
 - **Konsolidiert mit ADR-212**: dieselbe Traefik-Instanz, kein zusätzlicher Ingress
 
 ### Negativ
@@ -392,7 +396,7 @@ User-Compliance-Zustimmung der 4 Stakeholder (siehe oben) erlaubt
 
 ### Neutral
 
-- **klickdummy.iil.pet ist ein neuer Hostname** — separater Cloudflare-DNS-Record nötig (Wildcard `*.iil.pet` deckt das ggf. schon)
+- **staging-klickdummy.iil.pet ist ein neuer Hostname** — separater Cloudflare-DNS-Record nötig (Wildcard `*.iil.pet` deckt das ggf. schon)
 
 ## Phase-Bauauftrag
 
@@ -400,7 +404,7 @@ User-Compliance-Zustimmung der 4 Stakeholder (siehe oben) erlaubt
 
 1. ✅ ADR-216 schreiben (diese ADR)
 2. ⏳ `infra/klickdummy-host/`-Verzeichnis mit Compose + nginx-conf + sync.sh + repos.yaml
-3. ⏳ DNS-Record `klickdummy.iil.pet` → Cloudflare Tunnel `bf-staging`
+3. ⏳ DNS-Record `staging-klickdummy.iil.pet` → Cloudflare Tunnel `bf-staging`
 4. ⏳ Deployment-Test: `docker compose up -d` + ersten Klickdummy-Aufruf
 5. ⏳ Cross-Repo-Picker (meiki-hub PR #38) testet die URL als alternative `path_rel`-Quelle
 
@@ -408,7 +412,7 @@ User-Compliance-Zustimmung der 4 Stakeholder (siehe oben) erlaubt
 
 6. Auth via Traefik forwardAuth (für pg-hub Sperrvermerk-Compliance)
 7. Webhook-Trigger statt Cron (post-merge in jedem Klickdummy-Repo)
-8. Sub-Domains pro Org (`sqf.klickdummy.iil.pet`, `meiki.klickdummy.iil.pet`)
+8. Sub-Domains pro Org (`sqf.staging-klickdummy.iil.pet`, `meiki.staging-klickdummy.iil.pet`)
 
 ## Alternativen
 
@@ -417,10 +421,61 @@ User-Compliance-Zustimmung der 4 Stakeholder (siehe oben) erlaubt
 3. **Repos public stellen** — verworfen, Compliance-Risiko pro Repo (Sperrvermerk pg-hub, Gov ttz/meiki)
 4. **Push-Mode (CI rsync)** — verworfen, Token-Spread-Risiko (vgl. Drift-Memory)
 
+## Advocatus-Diabolus-Review (User-Auftrag 2026-05-21 Iter. 26)
+
+Tiefe kritische Sichtung der Initial-ADR (commit `a2b63a8`) mit folgendem
+Befund + Verbesserungen (eingearbeitet in dieser Revision):
+
+### Pass 1: ADR-Konformität
+
+- 🔴 **Hostname-Drift behoben**: Initial-Version nutzte `klickdummy.iil.pet` —
+  Klausel-1-Pattern (Prod, ADR-198) auf Klausel-3-Infrastruktur (Staging,
+  ADR-212). Korrigiert zu `staging-klickdummy.iil.pet`. Spätere
+  Klausel-1-Migration ist eigene Operation nach Pilot-Akzeptanz.
+- 🟡 Explizite Klausel-Zuordnung in §Entscheidung Punkt 1 ergänzt.
+
+### Pass 2: Architektur-Smells
+
+- **Sync-Frequenz** von 24h → **15 Min** (Pre-Pilot iteriert schneller)
+- **Doppelter Datenpfad eliminiert**: Symlinks statt rsync — kein `/srv` ≠
+  `$WORK` Drift-Risiko
+- **Dedicated User `klickdummy-sync`** statt root (Security + Audit)
+- **Same-Origin Discovery-Endpoint** `/api/list` als Alternative zu
+  Orchestrator-Fetch (kein CORS, geringere Latenz, Fallback bei
+  Orchestrator-Outage)
+- **`robots.txt`** mit `Disallow: /` für Search-Engine-Robustheit
+
+### Pass 3: Sicherheits-Schwächen
+
+- Sync-User dediziert (`klickdummy-sync`)
+- SSH-Deploy-Keys read-only pro Repo (single-key-compromise = 4-Repo-read-leak, nicht write)
+- nginx-Container mountet `/srv/klickdummy` read-only
+- Authentik-Outpost-Audit-Log dokumentiert
+- Health-Endpoint ohne Auth (Trade-off, minimal Info-Leak akzeptiert)
+
+### Pass 4: Out-of-the-box-Ideen (eingearbeitet)
+
+1. ✅ **Same-Origin Discovery-Endpoint** `/api/list` (statisches JSON, vom Sync-Job generiert)
+2. **Commit-SHA-pinned URLs** für Audit-Vergleiche (Phase-2-Backlog)
+3. **Sperrvermerk-Confirm-Modal** für pg-hub-Klickdummies (Phase-2-Backlog)
+
+### Pass 5: Verworfene Alternativen (out-of-the-box, aber Overkill)
+
+- OCI-Image pro Klickdummy (mock-Klickdummies brauchen keine Containerisierung)
+- HA / Failover (für Pre-Pilot akzeptable SPOF auf staging-platform)
+- SSE-Hot-Reload (Browser-Refresh ist gut genug)
+- Sub-Domains pro Org (kommt mit Phase-2-Owner-Auth)
+
 ## Provenance
 
 - meiki-hub-Session 2026-05-21 Iter. 24: GitHub Pages für alle 4 Repos
   blockiert (Free-Plan + privat)
 - User-Entscheidung Iter. 25: D — iil.pet self-hosted
+- User-Entscheidung Iter. 25: SSO via Authentik (statt BasicAuth)
+- User-Auftrag Iter. 26: advocatus-diabolus-Review — Hostname-Drift +
+  Architektur-Smells + Security-Verschärfung eingearbeitet
+- User-Bestätigung Iter. 25: Stakeholder-Compliance-Zustimmung von Raphael,
+  Ilja, Grinninger, LRA für 4 Repos
 - Drift-Memories: `pat-in-remote-url-leak`, `github-pages-private-repo-plan`
-- Schwester-ADRs: 198 (Tunnel), 210 (3-Stufen), 212 (Traefik), 215 (Discovery)
+- Schwester-ADRs: 142 (Authentik), 198 (Tunnel), 210 (3-Stufen), 212
+  (Traefik), 215 (Discovery)

--- a/infra/klickdummy-host/README.md
+++ b/infra/klickdummy-host/README.md
@@ -1,0 +1,114 @@
+# Klickdummy-Host (`klickdummy.iil.pet`)
+
+Statisches Hosting der Cross-Repo-Klickdummies via nginx + Traefik mit SSO
+(Authentik). Konkretisiert `platform:ADR-216`.
+
+**Server:** `staging-platform` (`178.104.184.168`)
+**Domain:** `klickdummy.iil.pet`
+**Reverse-Proxy:** Traefik v3 (siehe `../traefik/`, ADR-212)
+**SSO-Provider:** Authentik (ADR-142)
+
+## Deployment
+
+### 1. Files auf Server
+
+```bash
+ssh staging-platform "mkdir -p /opt/klickdummy /srv/klickdummy"
+scp infra/klickdummy-host/* staging-platform:/opt/klickdummy/
+ssh staging-platform "chmod +x /opt/klickdummy/sync.sh"
+```
+
+### 2. SSH-Deploy-Key für Repo-Sync
+
+```bash
+ssh staging-platform "ssh-keygen -t ed25519 -f /opt/klickdummy/.ssh/klickdummy-deploy_ed25519 -N '' -C 'klickdummy-host@staging-platform'"
+ssh staging-platform "cat /opt/klickdummy/.ssh/klickdummy-deploy_ed25519.pub"
+```
+
+Den Public-Key als **Deploy-Key (read-only)** zu jedem der vier Klickdummy-Repos hinzufügen:
+- `bahn-sqf/sqf-hub`
+- `bahn-sqf/pg-hub`
+- `meiki-lra/meiki-hub`
+- `ttz-lif/ttz-hub`
+
+### 3. Authentik OAuth-App + Outpost
+
+```bash
+# In platform-Repo:
+scripts/authentik-staging-oidc.sh \
+  --app-slug klickdummy \
+  --redirect-uri 'https://klickdummy.iil.pet/outpost.goauthentik.io/callback?X-authentik-auth-callback=true' \
+  --scopes openid,profile,email
+```
+
+Outpost-Container `authentik-outpost` muss im `traefik_public` Docker-Netzwerk laufen (Standard-Authentik-Embedded-Outpost-Setup).
+
+### 4. Users + Gruppe `klickdummy-viewers` in Authentik
+
+In Authentik-Admin (`https://authentik.iil.pet`):
+
+1. Gruppe `klickdummy-viewers` anlegen
+2. User anlegen (jeweils initial-Passwort + Reset-Link):
+   - `raphael.bayer@db.de` (sqf-hub Stakeholder)
+   - `ilja.lerch@bahn-sqf` (Citizen-Dev)
+   - `grinninger@bahn-sqf` (pg-hub Stab)
+   - `lra-meiki@meiki-lra` (LRA-Pilot)
+   - `ttz-pilot@ttz-lif` (TTZ-Pilot)
+3. Alle der Gruppe `klickdummy-viewers` zuweisen
+4. App `klickdummy` an Gruppe binden (Bindings → Policy → Group: klickdummy-viewers)
+
+### 5. DNS + Cloudflare-Tunnel
+
+DNS-Record `klickdummy.iil.pet` → `bf-staging`-Tunnel (Cloudflare). Sollte über das Wildcard `*.iil.pet` schon abgedeckt sein; sonst expliziter CNAME.
+
+### 6. Erste Container-Start + erste Sync
+
+```bash
+ssh staging-platform "cd /opt/klickdummy && docker compose up -d"
+ssh staging-platform "/opt/klickdummy/sync.sh"
+ssh staging-platform "curl -s https://klickdummy.iil.pet/healthz"   # ohne SSO
+```
+
+### 7. Cron für tägliche Sync
+
+```bash
+ssh staging-platform "echo '0 6 * * * /opt/klickdummy/sync.sh >> /var/log/klickdummy-sync.log 2>&1' | crontab -"
+```
+
+## Operations
+
+### Manueller Sync
+
+```bash
+ssh staging-platform "/opt/klickdummy/sync.sh"
+```
+
+### Logs
+
+- nginx: `docker logs klickdummy`
+- Sync: `/var/log/klickdummy-sync.log`
+- Traefik: `docker logs traefik` (siehe `../traefik/`)
+- Authentik-Outpost: `docker logs authentik-outpost`
+
+### Neuen Klickdummy hinzufügen
+
+1. `repos.yaml` ergänzen (in diesem Repo, via PR)
+2. Nach Merge: `ssh staging-platform "cd /opt/klickdummy && git pull && ./sync.sh"`
+   (oder warten bis Cron läuft)
+
+## Phase 2 (Owner-Login) — Backlog
+
+Siehe ADR-216 § Authentifizierung Phase 2:
+
+- Pro Org eine Authentik-Gruppe (`klickdummy-sqf-viewers`, …)
+- Pro Org eine Traefik-Router-Rule mit Gruppen-Filter
+- Separate ADR (geplant: `platform:ADR-217`)
+
+## Refs
+
+- `platform:ADR-216` — Klickdummy-Hosting (diese Konfiguration)
+- `platform:ADR-215` — Klickdummy-Discovery (Stage 1.5)
+- `platform:ADR-212` — Traefik-Ingress
+- `platform:ADR-142` — Authentik als Plattform-IdP
+- `platform:ADR-198` — Cloudflare-Tunnel `bf-staging`
+- `platform:ADR-210` — 3-Stufen-Hosting-Modell

--- a/infra/klickdummy-host/README.md
+++ b/infra/klickdummy-host/README.md
@@ -1,28 +1,35 @@
-# Klickdummy-Host (`klickdummy.iil.pet`)
+# Klickdummy-Host (`staging-klickdummy.iil.pet`)
 
 Statisches Hosting der Cross-Repo-Klickdummies via nginx + Traefik mit SSO
 (Authentik). Konkretisiert `platform:ADR-216`.
 
 **Server:** `staging-platform` (`178.104.184.168`)
-**Domain:** `klickdummy.iil.pet`
+**Domain:** `staging-klickdummy.iil.pet`
 **Reverse-Proxy:** Traefik v3 (siehe `../traefik/`, ADR-212)
 **SSO-Provider:** Authentik (ADR-142)
 
 ## Deployment
 
+### 0. Dedizierten Sync-User anlegen (Review-Pass 2: NICHT root)
+
+```bash
+ssh staging-platform "sudo useradd -r -m -d /var/lib/klickdummy-sync -s /bin/bash klickdummy-sync"
+ssh staging-platform "sudo mkdir -p /opt/klickdummy /srv/klickdummy /var/lib/klickdummy-sync"
+ssh staging-platform "sudo chown -R klickdummy-sync:klickdummy-sync /opt/klickdummy /srv/klickdummy /var/lib/klickdummy-sync"
+```
+
 ### 1. Files auf Server
 
 ```bash
-ssh staging-platform "mkdir -p /opt/klickdummy /srv/klickdummy"
-scp infra/klickdummy-host/* staging-platform:/opt/klickdummy/
-ssh staging-platform "chmod +x /opt/klickdummy/sync.sh"
+scp infra/klickdummy-host/* staging-platform:/tmp/klickdummy/
+ssh staging-platform "sudo mv /tmp/klickdummy/* /opt/klickdummy/ && sudo chown -R klickdummy-sync:klickdummy-sync /opt/klickdummy && sudo chmod +x /opt/klickdummy/sync.sh /opt/klickdummy/generate_landing.py"
 ```
 
-### 2. SSH-Deploy-Key für Repo-Sync
+### 2. SSH-Deploy-Key für Repo-Sync (User-skopiert, nicht root)
 
 ```bash
-ssh staging-platform "ssh-keygen -t ed25519 -f /opt/klickdummy/.ssh/klickdummy-deploy_ed25519 -N '' -C 'klickdummy-host@staging-platform'"
-ssh staging-platform "cat /opt/klickdummy/.ssh/klickdummy-deploy_ed25519.pub"
+ssh staging-platform "sudo -u klickdummy-sync ssh-keygen -t ed25519 -f /var/lib/klickdummy-sync/.ssh/klickdummy-deploy_ed25519 -N '' -C 'klickdummy-sync@staging-platform'"
+ssh staging-platform "sudo cat /var/lib/klickdummy-sync/.ssh/klickdummy-deploy_ed25519.pub"
 ```
 
 Den Public-Key als **Deploy-Key (read-only)** zu jedem der vier Klickdummy-Repos hinzufügen:
@@ -37,7 +44,7 @@ Den Public-Key als **Deploy-Key (read-only)** zu jedem der vier Klickdummy-Repos
 # In platform-Repo:
 scripts/authentik-staging-oidc.sh \
   --app-slug klickdummy \
-  --redirect-uri 'https://klickdummy.iil.pet/outpost.goauthentik.io/callback?X-authentik-auth-callback=true' \
+  --redirect-uri 'https://staging-klickdummy.iil.pet/outpost.goauthentik.io/callback?X-authentik-auth-callback=true' \
   --scopes openid,profile,email
 ```
 
@@ -59,21 +66,65 @@ In Authentik-Admin (`https://authentik.iil.pet`):
 
 ### 5. DNS + Cloudflare-Tunnel
 
-DNS-Record `klickdummy.iil.pet` → `bf-staging`-Tunnel (Cloudflare). Sollte über das Wildcard `*.iil.pet` schon abgedeckt sein; sonst expliziter CNAME.
+DNS-Record `staging-klickdummy.iil.pet` → `bf-staging`-Tunnel (Cloudflare). Sollte über das Wildcard `*.iil.pet` schon abgedeckt sein; sonst expliziter CNAME.
 
 ### 6. Erste Container-Start + erste Sync
 
 ```bash
 ssh staging-platform "cd /opt/klickdummy && docker compose up -d"
 ssh staging-platform "/opt/klickdummy/sync.sh"
-ssh staging-platform "curl -s https://klickdummy.iil.pet/healthz"   # ohne SSO
+ssh staging-platform "curl -s https://staging-klickdummy.iil.pet/healthz"   # ohne SSO
 ```
 
-### 7. Cron für tägliche Sync
+### 7. Cron — 15-Min-Intervall (Review-Pass: schnellere Iteration als 24h)
+
+Als User `klickdummy-sync`:
 
 ```bash
-ssh staging-platform "echo '0 6 * * * /opt/klickdummy/sync.sh >> /var/log/klickdummy-sync.log 2>&1' | crontab -"
+ssh staging-platform "sudo -u klickdummy-sync crontab -l 2>/dev/null; echo '*/15 * * * * /opt/klickdummy/sync.sh >> /var/log/klickdummy-sync.log 2>&1' | sudo -u klickdummy-sync crontab -"
 ```
+
+Log-Rotation (logrotate-Snippet):
+
+```bash
+cat | sudo tee /etc/logrotate.d/klickdummy-sync <<EOF
+/var/log/klickdummy-sync.log {
+    weekly
+    rotate 4
+    compress
+    missingok
+    notifempty
+}
+EOF
+```
+
+## Discovery-API (Review-Pass 4 Idee 1)
+
+`staging-klickdummy.iil.pet/api/list` ist ein **same-origin Discovery-Endpoint**.
+Vom Sync-Job als `/srv/klickdummy/_index.json` generiert. Cross-Repo-Picker
+in einem Klickdummy kann same-origin fetchen statt orchestrator.iil.pet
+(spart CORS-Setup):
+
+```javascript
+const resp = await fetch('/api/list', { credentials: 'include' });
+const data = await resp.json();
+CROSS_REPO_INDEX = data.entries;
+```
+
+Beide Discovery-Quellen sind verfügbar — Picker kann frei wählen:
+
+| Endpoint | Quelle | Vorteile |
+|---|---|---|
+| `orchestrator.iil.pet/api/discovery/klickdummy/list` | pgvector (ADR-215) | semantische Search, MCP-Tool |
+| `/api/list` (same-origin) | Filesystem-Index | kein CORS, low-latency, no-SPOF auf Orchestrator |
+
+## Sicherheits-Anmerkungen (Review-Pass 3)
+
+- `sync.sh` läuft als `klickdummy-sync`, nicht root — verhindert lateral movement bei sync-Script-Kompromittierung
+- SSH-Deploy-Key ist **read-only pro Repo** — single key compromise ⇒ nur 4 Klickdummy-Repos read-leak (statt Schreibzugriff)
+- nginx-Container mountet `/srv/klickdummy` **read-only** — kann Quelle nicht überschreiben
+- `/healthz` ohne Auth (Trade-off für Monitoring); minimal Info-Leak ist akzeptabel
+- Authentik-Outpost trägt Session-Cookie pro User — Audit-Log via Authentik-Event-Log
 
 ## Operations
 

--- a/infra/klickdummy-host/docker-compose.yml
+++ b/infra/klickdummy-host/docker-compose.yml
@@ -1,0 +1,60 @@
+# Klickdummy-Hosting via nginx + Traefik (ADR-216)
+# Server: 178.104.184.168 (staging-platform)
+# Domain: klickdummy.iil.pet
+#
+# Deployment:
+#   scp infra/klickdummy-host/* staging-platform:/opt/klickdummy/
+#   ssh staging-platform "cd /opt/klickdummy && docker compose up -d"
+#
+# Content-Sync:
+#   ssh staging-platform "/opt/klickdummy/sync.sh"   (oder via cron)
+
+services:
+  klickdummy:
+    image: nginx:alpine
+    container_name: klickdummy
+    restart: always
+
+    volumes:
+      # Content kommt vom Sync-Job (sync.sh) — read-only für nginx
+      - /srv/klickdummy:/usr/share/nginx/html:ro
+      # nginx-Config
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+
+    networks:
+      - traefik_public
+
+    labels:
+      - "traefik.enable=true"
+      # Hauptroute: klickdummy.iil.pet via HTTPS (Let's Encrypt via Cloudflare DNS-01)
+      - "traefik.http.routers.klickdummy.rule=Host(`klickdummy.iil.pet`)"
+      - "traefik.http.routers.klickdummy.entrypoints=websecure"
+      - "traefik.http.routers.klickdummy.tls.certresolver=letsencrypt"
+      # Service-Port (nginx default)
+      - "traefik.http.services.klickdummy.loadbalancer.server.port=80"
+      # Middleware-Chain: SSO (Authentik forwardAuth) → Security-Headers
+      - "traefik.http.routers.klickdummy.middlewares=klickdummy-sso,klickdummy-headers"
+      # SSO via Authentik forwardAuth (ADR-216 §Auth Phase 1, ADR-142 Authentik IdP)
+      # Outpost-Endpoint vom Authentik-Outpost-Container im traefik_public-Netz erreicht
+      - "traefik.http.middlewares.klickdummy-sso.forwardauth.address=http://authentik-outpost:9000/outpost.goauthentik.io/auth/traefik"
+      - "traefik.http.middlewares.klickdummy-sso.forwardauth.trustForwardHeader=true"
+      - "traefik.http.middlewares.klickdummy-sso.forwardauth.authResponseHeaders=X-authentik-username,X-authentik-groups,X-authentik-email"
+      # Security-Headers Middleware
+      - "traefik.http.middlewares.klickdummy-headers.headers.customResponseHeaders.X-Content-Type-Options=nosniff"
+      - "traefik.http.middlewares.klickdummy-headers.headers.customResponseHeaders.X-Klickdummy-Class=mock"
+      # Health-Endpoint von SSO ausnehmen (für Monitoring-Probes ohne Login)
+      - "traefik.http.routers.klickdummy-health.rule=Host(`klickdummy.iil.pet`) && Path(`/healthz`)"
+      - "traefik.http.routers.klickdummy-health.entrypoints=websecure"
+      - "traefik.http.routers.klickdummy-health.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.klickdummy-health.service=klickdummy"
+      - "traefik.http.routers.klickdummy-health.priority=100"
+      # OAuth-Callback-Endpoint (Authentik-Outpost) auch ohne SSO erreichbar
+      - "traefik.http.routers.klickdummy-outpost.rule=Host(`klickdummy.iil.pet`) && PathPrefix(`/outpost.goauthentik.io/`)"
+      - "traefik.http.routers.klickdummy-outpost.entrypoints=websecure"
+      - "traefik.http.routers.klickdummy-outpost.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.klickdummy-outpost.service=authentik-outpost@docker"
+      - "traefik.http.routers.klickdummy-outpost.priority=100"
+
+networks:
+  traefik_public:
+    external: true

--- a/infra/klickdummy-host/docker-compose.yml
+++ b/infra/klickdummy-host/docker-compose.yml
@@ -1,6 +1,6 @@
 # Klickdummy-Hosting via nginx + Traefik (ADR-216)
 # Server: 178.104.184.168 (staging-platform)
-# Domain: klickdummy.iil.pet
+# Domain: staging-klickdummy.iil.pet
 #
 # Deployment:
 #   scp infra/klickdummy-host/* staging-platform:/opt/klickdummy/
@@ -26,8 +26,8 @@ services:
 
     labels:
       - "traefik.enable=true"
-      # Hauptroute: klickdummy.iil.pet via HTTPS (Let's Encrypt via Cloudflare DNS-01)
-      - "traefik.http.routers.klickdummy.rule=Host(`klickdummy.iil.pet`)"
+      # Hauptroute: staging-klickdummy.iil.pet via HTTPS (Let's Encrypt via Cloudflare DNS-01)
+      - "traefik.http.routers.klickdummy.rule=Host(`staging-klickdummy.iil.pet`)"
       - "traefik.http.routers.klickdummy.entrypoints=websecure"
       - "traefik.http.routers.klickdummy.tls.certresolver=letsencrypt"
       # Service-Port (nginx default)
@@ -43,13 +43,13 @@ services:
       - "traefik.http.middlewares.klickdummy-headers.headers.customResponseHeaders.X-Content-Type-Options=nosniff"
       - "traefik.http.middlewares.klickdummy-headers.headers.customResponseHeaders.X-Klickdummy-Class=mock"
       # Health-Endpoint von SSO ausnehmen (für Monitoring-Probes ohne Login)
-      - "traefik.http.routers.klickdummy-health.rule=Host(`klickdummy.iil.pet`) && Path(`/healthz`)"
+      - "traefik.http.routers.klickdummy-health.rule=Host(`staging-klickdummy.iil.pet`) && Path(`/healthz`)"
       - "traefik.http.routers.klickdummy-health.entrypoints=websecure"
       - "traefik.http.routers.klickdummy-health.tls.certresolver=letsencrypt"
       - "traefik.http.routers.klickdummy-health.service=klickdummy"
       - "traefik.http.routers.klickdummy-health.priority=100"
       # OAuth-Callback-Endpoint (Authentik-Outpost) auch ohne SSO erreichbar
-      - "traefik.http.routers.klickdummy-outpost.rule=Host(`klickdummy.iil.pet`) && PathPrefix(`/outpost.goauthentik.io/`)"
+      - "traefik.http.routers.klickdummy-outpost.rule=Host(`staging-klickdummy.iil.pet`) && PathPrefix(`/outpost.goauthentik.io/`)"
       - "traefik.http.routers.klickdummy-outpost.entrypoints=websecure"
       - "traefik.http.routers.klickdummy-outpost.tls.certresolver=letsencrypt"
       - "traefik.http.routers.klickdummy-outpost.service=authentik-outpost@docker"

--- a/infra/klickdummy-host/generate_landing.py
+++ b/infra/klickdummy-host/generate_landing.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Generate klickdummy.iil.pet Landing-Page (ADR-216).
+
+Usage:
+    python3 generate_landing.py <target-dir> <repos.yaml> > index.html
+
+Discovers <target-dir>/<owner>/<repo>/<klickdummy>/<shell.html|chat-simulator.html>
+and produces an authenticated landing page (SSO-User-Name aus
+X-authentik-username Header wird per JS gerendert, falls vorhanden).
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import pathlib
+import sys
+
+try:
+    import yaml
+except ImportError:
+    print("✗ pyyaml fehlt — apt install python3-yaml", file=sys.stderr)
+    sys.exit(2)
+
+
+def discover(target_dir: pathlib.Path) -> list[dict]:
+    """Findet Klickdummies unter <target_dir>/<owner>/<repo>/<kd>/."""
+    found = []
+    for owner_dir in sorted(target_dir.iterdir()):
+        if not owner_dir.is_dir() or owner_dir.name.startswith("."):
+            continue
+        for repo_dir in sorted(owner_dir.iterdir()):
+            if not repo_dir.is_dir():
+                continue
+            for kd_dir in sorted(repo_dir.iterdir()):
+                if not kd_dir.is_dir():
+                    continue
+                # Suche shell.html oder chat-simulator.html
+                for entry in ("shell.html", "chat-simulator.html"):
+                    if (kd_dir / entry).exists():
+                        found.append({
+                            "owner": owner_dir.name,
+                            "repo": repo_dir.name,
+                            "klickdummy": kd_dir.name,
+                            "entry": entry,
+                            "url": f"/{owner_dir.name}/{repo_dir.name}/{kd_dir.name}/{entry}",
+                        })
+                        break
+    return found
+
+
+def render(found: list[dict], repos_meta: dict) -> str:
+    """HTML-Landing-Seite."""
+    # Repo-Metadaten als Dict für schnellen Lookup
+    meta_by_repo = {
+        f"{r['owner']}/{r['name']}": r for r in repos_meta.get("repos", [])
+    }
+
+    rows = []
+    by_owner: dict[str, list[dict]] = {}
+    for f in found:
+        by_owner.setdefault(f["owner"], []).append(f)
+
+    for owner in sorted(by_owner):
+        rows.append(f"<h2>{html.escape(owner)}</h2><ul>")
+        for f in by_owner[owner]:
+            repo_key = f"{f['owner']}/{f['repo']}"
+            meta = meta_by_repo.get(repo_key, {})
+            desc = html.escape(meta.get("description", ""))
+            adr = html.escape(meta.get("adr", ""))
+            rows.append(
+                f"<li><a href='{html.escape(f['url'])}'>"
+                f"<strong>{html.escape(f['repo'])}</strong> / "
+                f"<code>{html.escape(f['klickdummy'])}</code></a>"
+                f"<div class='meta'>{desc}{' · ADR: <code>' + adr + '</code>' if adr else ''}</div></li>"
+            )
+        rows.append("</ul>")
+
+    return f"""<!doctype html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<title>klickdummy.iil.pet — Stakeholder-Demo</title>
+<style>
+  body {{ font-family: system-ui, sans-serif; max-width: 800px; margin: 40px auto; padding: 0 20px; color: #1a2230; }}
+  h1 {{ color: #1a3a6c; }}
+  h2 {{ color: #ec0016; margin-top: 30px; font-size: 18px; border-bottom: 1px solid #e5e9ef; padding-bottom: 6px; }}
+  .user {{ float: right; background: #f0f3f7; padding: 4px 10px; border-radius: 12px; font-size: 12px; color: #475569; }}
+  ul {{ list-style: none; padding: 0; }}
+  li {{ background: #fff; border: 1px solid #d8e0e8; border-radius: 8px; padding: 12px 16px; margin-bottom: 10px; }}
+  li a {{ color: #1a3a6c; text-decoration: none; }}
+  li a:hover {{ text-decoration: underline; }}
+  .meta {{ color: #6a7888; font-size: 12px; margin-top: 4px; }}
+  code {{ background: #f0f3f7; padding: 1px 5px; border-radius: 3px; font-size: 11px; }}
+  .footer {{ color: #8a96a3; font-size: 11px; margin-top: 40px; border-top: 1px solid #e5e9ef; padding-top: 12px; line-height: 1.6; }}
+</style>
+</head>
+<body>
+<div class="user" id="user-chip">SSO · <span id="user-name">–</span></div>
+<h1>🛠 klickdummy.iil.pet</h1>
+<p>Pre-Pilot-Klickdummy-Demos · alle <code>class: mock</code> · synthetische Daten · SSO via Authentik (ADR-142)</p>
+{"".join(rows)}
+<div class="footer">
+  Konform zu <a href="https://github.com/achimdehnert/platform/blob/main/docs/adr/ADR-211-klickdummy-benutzeranforderungen-entwicklungsprozess.md"><code>platform:ADR-211</code></a> ·
+  Hosting <a href="https://github.com/achimdehnert/platform/blob/main/docs/adr/ADR-216-klickdummy-hosting-iil-pet.md"><code>platform:ADR-216</code></a> ·
+  Discovery <a href="https://github.com/achimdehnert/platform/blob/main/docs/adr/ADR-215-klickdummy-pgvector-discovery.md"><code>platform:ADR-215</code></a><br>
+  DSFA 2026-05-21: nicht kritisch (synthetische Daten + Funktionsrollen-Labels)
+</div>
+<script>
+  // Authentik liefert den User-Namen via Header zurück an Browser nicht direkt,
+  // aber das Outpost setzt einen Cookie + JS kann via /outpost.goauthentik.io/api/v3/core/users/me/
+  // abfragen, falls gewünscht. Hier vorerst Placeholder.
+  fetch('/outpost.goauthentik.io/api/v3/core/users/me/', {{ credentials: 'include' }})
+    .then(r => r.ok ? r.json() : null)
+    .then(d => {{ if(d && d.user && d.user.username) document.getElementById('user-name').textContent = d.user.username; }})
+    .catch(() => {{ document.getElementById('user-chip').style.display = 'none'; }});
+</script>
+</body>
+</html>
+"""
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("target_dir", help="z.B. /srv/klickdummy")
+    ap.add_argument("repos_yaml", help="z.B. /opt/klickdummy/repos.yaml")
+    args = ap.parse_args(argv)
+
+    target = pathlib.Path(args.target_dir)
+    repos_meta = yaml.safe_load(pathlib.Path(args.repos_yaml).read_text(encoding="utf-8"))
+
+    found = discover(target)
+    print(render(found, repos_meta))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infra/klickdummy-host/generate_landing.py
+++ b/infra/klickdummy-host/generate_landing.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate klickdummy.iil.pet Landing-Page (ADR-216).
+"""Generate staging-klickdummy.iil.pet Landing-Page (ADR-216).
 
 Usage:
     python3 generate_landing.py <target-dir> <repos.yaml> > index.html
@@ -79,7 +79,7 @@ def render(found: list[dict], repos_meta: dict) -> str:
 <html lang="de">
 <head>
 <meta charset="utf-8">
-<title>klickdummy.iil.pet — Stakeholder-Demo</title>
+<title>staging-klickdummy.iil.pet — Stakeholder-Demo</title>
 <style>
   body {{ font-family: system-ui, sans-serif; max-width: 800px; margin: 40px auto; padding: 0 20px; color: #1a2230; }}
   h1 {{ color: #1a3a6c; }}
@@ -96,7 +96,7 @@ def render(found: list[dict], repos_meta: dict) -> str:
 </head>
 <body>
 <div class="user" id="user-chip">SSO · <span id="user-name">–</span></div>
-<h1>🛠 klickdummy.iil.pet</h1>
+<h1>🛠 staging-klickdummy.iil.pet</h1>
 <p>Pre-Pilot-Klickdummy-Demos · alle <code>class: mock</code> · synthetische Daten · SSO via Authentik (ADR-142)</p>
 {"".join(rows)}
 <div class="footer">
@@ -119,17 +119,62 @@ def render(found: list[dict], repos_meta: dict) -> str:
 """
 
 
+def render_json(found: list[dict], repos_meta: dict) -> str:
+    """Discovery-API-Endpoint /api/list — same-origin-Konsumenten (Picker)."""
+    import datetime
+    import json as _json
+
+    meta_by_repo = {
+        f"{r['owner']}/{r['name']}": r for r in repos_meta.get("repos", [])
+    }
+    entries = []
+    for f in found:
+        repo_key = f"{f['owner']}/{f['repo']}"
+        meta = meta_by_repo.get(repo_key, {})
+        entries.append({
+            "key": f"{f['owner']}/{f['klickdummy']}",
+            "org": f["owner"],
+            "repo": f["repo"],
+            "name": f["klickdummy"],
+            "url": f["url"],
+            "entry_file": f["entry"],
+            "description": meta.get("description"),
+            "adr": meta.get("adr"),
+            "source": "staging-klickdummy.iil.pet",
+        })
+    payload = {
+        "entries": entries,
+        "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds"),
+        "source": "filesystem-scan",
+        "adr": "platform:ADR-216",
+    }
+    return _json.dumps(payload, ensure_ascii=False, indent=2)
+
+
 def main(argv=None):
     ap = argparse.ArgumentParser()
     ap.add_argument("target_dir", help="z.B. /srv/klickdummy")
     ap.add_argument("repos_yaml", help="z.B. /opt/klickdummy/repos.yaml")
+    ap.add_argument("--emit-json", help="Pfad für _index.json (Discovery-API)")
+    ap.add_argument("--emit-html", help="Pfad für index.html (Landing)")
     args = ap.parse_args(argv)
 
     target = pathlib.Path(args.target_dir)
     repos_meta = yaml.safe_load(pathlib.Path(args.repos_yaml).read_text(encoding="utf-8"))
 
     found = discover(target)
-    print(render(found, repos_meta))
+
+    if args.emit_json:
+        pathlib.Path(args.emit_json).write_text(
+            render_json(found, repos_meta) + "\n", encoding="utf-8"
+        )
+    if args.emit_html:
+        pathlib.Path(args.emit_html).write_text(
+            render(found, repos_meta), encoding="utf-8"
+        )
+    if not args.emit_json and not args.emit_html:
+        # Backward-compat: stdout
+        print(render(found, repos_meta))
     return 0
 
 

--- a/infra/klickdummy-host/nginx.conf
+++ b/infra/klickdummy-host/nginx.conf
@@ -1,14 +1,31 @@
-# nginx-Config für klickdummy.iil.pet (ADR-216)
+# nginx-Config für staging-klickdummy.iil.pet (ADR-216)
 # Statisches Hosting von /srv/klickdummy/<org>/<repo>/<klickdummy>/
 
 server {
   listen 80 default_server;
-  server_name klickdummy.iil.pet;
+  server_name staging-klickdummy.iil.pet;
 
   root /usr/share/nginx/html;
   index index.html;
 
-  # Auto-Index für /<org>/, /<org>/<repo>/ — erleichtert Navigation
+  # ─── Anti-Indexing (zusätzlich zu SSO; Suchmaschinen-robust) ────────────
+  location = /robots.txt {
+    add_header Content-Type "text/plain; charset=utf-8";
+    return 200 "User-agent: *\nDisallow: /\n";
+  }
+
+  # ─── Same-Origin Discovery-Endpoint (kein CORS nötig) ───────────────────
+  # JSON wird vom Sync-Job (sync.sh) als /srv/klickdummy/_index.json
+  # generiert. Konsument: Cross-Repo-Picker in jeder Klickdummy-shell.html
+  # — fetcht statt orchestrator.iil.pet (Cross-Origin) diesen Endpoint
+  # same-origin (Review-Pass 4 Idee 1).
+  location = /api/list {
+    add_header Content-Type "application/json; charset=utf-8" always;
+    add_header Cache-Control "no-cache, must-revalidate" always;
+    try_files /_index.json =404;
+  }
+
+  # ─── Auto-Index für /<org>/, /<org>/<repo>/ ─────────────────────────────
   location / {
     autoindex on;
     autoindex_exact_size off;
@@ -16,26 +33,26 @@ server {
     try_files $uri $uri/ =404;
   }
 
-  # Direkter Zugriff auf statische Assets
-  location ~* \.(html|css|js|json|yaml|yml|svg|png|jpg|jpeg|gif|ico|woff|woff2|ttf)$ {
-    try_files $uri =404;
-    add_header Cache-Control "public, max-age=300" always;
-  }
-
-  # Klickdummy-Spec-Files (YAML) als text/yaml ausliefern
+  # ─── Klickdummy-Spec-Files (YAML) als text/yaml ausliefern ──────────────
   location ~* \.ya?ml$ {
     types { } default_type "text/yaml; charset=utf-8";
     try_files $uri =404;
   }
 
-  # 404-Logging zu Trace-Zwecken
+  # ─── Direkter Zugriff auf statische Assets ──────────────────────────────
+  location ~* \.(html|css|js|json|svg|png|jpg|jpeg|gif|ico|woff|woff2|ttf)$ {
+    try_files $uri =404;
+    add_header Cache-Control "public, max-age=300" always;
+  }
+
+  # ─── 404-Logging zu Trace-Zwecken ───────────────────────────────────────
   error_page 404 /404.html;
   location = /404.html {
-    return 404 "Klickdummy nicht gefunden. Index: https://klickdummy.iil.pet/\n";
+    return 404 "Klickdummy nicht gefunden. Index: https://staging-klickdummy.iil.pet/\n";
     add_header Content-Type "text/plain; charset=utf-8";
   }
 
-  # Health-Probe für Traefik / Monitoring
+  # ─── Health-Probe für Traefik / Monitoring ──────────────────────────────
   location = /healthz {
     access_log off;
     return 200 "ok\n";

--- a/infra/klickdummy-host/nginx.conf
+++ b/infra/klickdummy-host/nginx.conf
@@ -1,0 +1,44 @@
+# nginx-Config für klickdummy.iil.pet (ADR-216)
+# Statisches Hosting von /srv/klickdummy/<org>/<repo>/<klickdummy>/
+
+server {
+  listen 80 default_server;
+  server_name klickdummy.iil.pet;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # Auto-Index für /<org>/, /<org>/<repo>/ — erleichtert Navigation
+  location / {
+    autoindex on;
+    autoindex_exact_size off;
+    autoindex_localtime on;
+    try_files $uri $uri/ =404;
+  }
+
+  # Direkter Zugriff auf statische Assets
+  location ~* \.(html|css|js|json|yaml|yml|svg|png|jpg|jpeg|gif|ico|woff|woff2|ttf)$ {
+    try_files $uri =404;
+    add_header Cache-Control "public, max-age=300" always;
+  }
+
+  # Klickdummy-Spec-Files (YAML) als text/yaml ausliefern
+  location ~* \.ya?ml$ {
+    types { } default_type "text/yaml; charset=utf-8";
+    try_files $uri =404;
+  }
+
+  # 404-Logging zu Trace-Zwecken
+  error_page 404 /404.html;
+  location = /404.html {
+    return 404 "Klickdummy nicht gefunden. Index: https://klickdummy.iil.pet/\n";
+    add_header Content-Type "text/plain; charset=utf-8";
+  }
+
+  # Health-Probe für Traefik / Monitoring
+  location = /healthz {
+    access_log off;
+    return 200 "ok\n";
+    add_header Content-Type "text/plain";
+  }
+}

--- a/infra/klickdummy-host/repos.yaml
+++ b/infra/klickdummy-host/repos.yaml
@@ -1,0 +1,30 @@
+# Klickdummy-Repo-Registry für Sync-Job (ADR-216)
+# Jedes Eintrag: SSH-Clone-URL + Sub-Pfad innerhalb des Repos, der nach
+# /srv/klickdummy/<owner>/<repo>/ gespiegelt wird.
+#
+# Authentifizierung: SSH-Deploy-Key am Server, read-only pro Repo.
+
+repos:
+  - owner: meiki-lra
+    name: meiki-hub
+    sync_subdir: docs/01-architektur/mockups
+    description: Fristenmanagement (Forms) + Klickdummy-Modul (Login+Nav)
+    adr: meiki:ADR-021
+
+  - owner: bahn-sqf
+    name: sqf-hub
+    sync_subdir: klickdummy
+    description: AF1 Tages-Zusammenfassung Lost Units (Conversation)
+    adr: sqf-hub:ADR-003
+
+  - owner: bahn-sqf
+    name: pg-hub
+    sync_subdir: klickdummy
+    description: Pocket Governance (Forms, Power Platform)
+    adr: pg-hub:ADR-002
+
+  - owner: ttz-lif
+    name: ttz-hub
+    sync_subdir: klickdummy
+    description: Werkleitung + Schichtleitung (Forms)
+    adr: ttz-hub:ADR-100

--- a/infra/klickdummy-host/sync.sh
+++ b/infra/klickdummy-host/sync.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Klickdummy-Pull-Job — ADR-216
+# Pullt alle in repos.yaml gelisteten Klickdummy-Repos und spiegelt
+# den jeweiligen sync_subdir in /srv/klickdummy/<owner>/<repo>/.
+#
+# Aufruf: /opt/klickdummy/sync.sh
+# Cron:   stündlich (oder nach Bedarf)
+# SSH:    Deploy-Key am Server (~/.ssh/klickdummy-deploy_ed25519), read-only
+
+set -euo pipefail
+
+WORK="${KLICKDUMMY_WORK:-/var/lib/klickdummy-sync}"
+TARGET="${KLICKDUMMY_TARGET:-/srv/klickdummy}"
+REPOS_FILE="${KLICKDUMMY_REPOS:-/opt/klickdummy/repos.yaml}"
+DEPLOY_KEY="${KLICKDUMMY_DEPLOY_KEY:-$HOME/.ssh/klickdummy-deploy_ed25519}"
+
+mkdir -p "$WORK" "$TARGET"
+
+# Parse repos.yaml (minimal-YAML — pyyaml falls verfügbar, sonst grep)
+if command -v python3 &>/dev/null; then
+  ENTRIES=$(python3 -c "
+import yaml
+data = yaml.safe_load(open('$REPOS_FILE'))
+for r in data.get('repos', []):
+    print(f\"{r['owner']}|{r['name']}|{r['sync_subdir']}\")
+")
+else
+  echo "✗ python3 nicht verfügbar — installiere python3-yaml" >&2
+  exit 1
+fi
+
+echo "== Klickdummy-Sync $(date -Is) =="
+while IFS='|' read -r owner name subdir; do
+  [ -z "$owner" ] && continue
+  repo="$owner/$name"
+  clone_dir="$WORK/$owner/$name"
+
+  if [ ! -d "$clone_dir/.git" ]; then
+    echo "→ Clone $repo"
+    mkdir -p "$WORK/$owner"
+    GIT_SSH_COMMAND="ssh -i $DEPLOY_KEY -o IdentitiesOnly=yes" \
+      git clone --depth 1 "git@github.com:$repo.git" "$clone_dir"
+  else
+    echo "→ Pull  $repo"
+    GIT_SSH_COMMAND="ssh -i $DEPLOY_KEY -o IdentitiesOnly=yes" \
+      git -C "$clone_dir" fetch --depth 1 origin main
+    git -C "$clone_dir" reset --hard origin/main
+  fi
+
+  src="$clone_dir/$subdir"
+  dst="$TARGET/$owner/$name"
+  if [ ! -d "$src" ]; then
+    echo "  ⚠ Source-Subdir nicht gefunden: $src" >&2
+    continue
+  fi
+  mkdir -p "$dst"
+  rsync -a --delete "$src/" "$dst/"
+  echo "  ✓ $dst (von $src)"
+done <<< "$ENTRIES"
+
+# Landing-Page generieren
+python3 /opt/klickdummy/generate_landing.py "$TARGET" "$REPOS_FILE" > "$TARGET/index.html"
+echo "✓ Landing: $TARGET/index.html"
+
+echo "== Done $(date -Is) =="

--- a/infra/klickdummy-host/sync.sh
+++ b/infra/klickdummy-host/sync.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
-# Klickdummy-Pull-Job — ADR-216
-# Pullt alle in repos.yaml gelisteten Klickdummy-Repos und spiegelt
-# den jeweiligen sync_subdir in /srv/klickdummy/<owner>/<repo>/.
+# Klickdummy-Pull-Job — ADR-216 (Review-Pass nachgeschärft)
+# Pullt alle in repos.yaml gelisteten Klickdummy-Repos und legt
+# Symlinks in /srv/klickdummy/<owner>/<repo>/ zum sync_subdir des Clones.
 #
 # Aufruf: /opt/klickdummy/sync.sh
-# Cron:   stündlich (oder nach Bedarf)
-# SSH:    Deploy-Key am Server (~/.ssh/klickdummy-deploy_ed25519), read-only
+# Cron:   */15 * * * * (15-Min-Intervall, Pre-Pilot-Iteration läuft schneller)
+# User:   klickdummy-sync (dediziert, NICHT root)
+# SSH:    Deploy-Key (~/.ssh/klickdummy-deploy_ed25519), read-only pro Repo
+#
+# Datenpfade:
+#   /var/lib/klickdummy-sync/<owner>/<repo>/         — Git-Clone (working tree)
+#   /srv/klickdummy/<owner>/<repo>                   — Symlink → clone/sync_subdir
+#   /srv/klickdummy/_index.json                      — Discovery-API-Endpoint
+#   /srv/klickdummy/index.html                       — Landing-Page
+#
+# Symlink-Pattern statt rsync (Review-Pass 2): vermeidet doppelten Datenpfad
+# und Drift-Risiko (Server-Stand kann nicht von Git divergieren).
 
 set -euo pipefail
 
@@ -14,20 +24,25 @@ TARGET="${KLICKDUMMY_TARGET:-/srv/klickdummy}"
 REPOS_FILE="${KLICKDUMMY_REPOS:-/opt/klickdummy/repos.yaml}"
 DEPLOY_KEY="${KLICKDUMMY_DEPLOY_KEY:-$HOME/.ssh/klickdummy-deploy_ed25519}"
 
+# Sicherheitscheck: NICHT als root laufen
+if [ "$(id -u)" = "0" ]; then
+  echo "✗ sync.sh darf nicht als root laufen — verwende User 'klickdummy-sync'" >&2
+  exit 1
+fi
+
 mkdir -p "$WORK" "$TARGET"
 
-# Parse repos.yaml (minimal-YAML — pyyaml falls verfügbar, sonst grep)
-if command -v python3 &>/dev/null; then
-  ENTRIES=$(python3 -c "
+if ! command -v python3 &>/dev/null; then
+  echo "✗ python3 nicht verfügbar — installiere python3-yaml" >&2
+  exit 1
+fi
+
+ENTRIES=$(python3 -c "
 import yaml
 data = yaml.safe_load(open('$REPOS_FILE'))
 for r in data.get('repos', []):
     print(f\"{r['owner']}|{r['name']}|{r['sync_subdir']}\")
 ")
-else
-  echo "✗ python3 nicht verfügbar — installiere python3-yaml" >&2
-  exit 1
-fi
 
 echo "== Klickdummy-Sync $(date -Is) =="
 while IFS='|' read -r owner name subdir; do
@@ -48,18 +63,23 @@ while IFS='|' read -r owner name subdir; do
   fi
 
   src="$clone_dir/$subdir"
-  dst="$TARGET/$owner/$name"
+  link="$TARGET/$owner/$name"
   if [ ! -d "$src" ]; then
     echo "  ⚠ Source-Subdir nicht gefunden: $src" >&2
     continue
   fi
-  mkdir -p "$dst"
-  rsync -a --delete "$src/" "$dst/"
-  echo "  ✓ $dst (von $src)"
+
+  # Symlink statt rsync — kein doppelter Datenpfad, kein Drift-Risiko
+  mkdir -p "$TARGET/$owner"
+  ln -sfn "$src" "$link"
+  echo "  ✓ $link → $src"
 done <<< "$ENTRIES"
 
-# Landing-Page generieren
-python3 /opt/klickdummy/generate_landing.py "$TARGET" "$REPOS_FILE" > "$TARGET/index.html"
-echo "✓ Landing: $TARGET/index.html"
+# Discovery-API-Endpoint (_index.json) + Landing-HTML
+python3 /opt/klickdummy/generate_landing.py "$TARGET" "$REPOS_FILE" \
+  --emit-json "$TARGET/_index.json" \
+  --emit-html "$TARGET/index.html"
 
+echo "✓ Discovery: $TARGET/_index.json"
+echo "✓ Landing:   $TARGET/index.html"
 echo "== Done $(date -Is) =="


### PR DESCRIPTION
**Status:** proposed

User-Entscheidung Iter. 24/25:
* D — alles unter eigener Kontrolle (kein GitHub-Pages-Upgrade, kein Cloudflare-Pages)
* SSO via Authentik (ADR-142)

## Architektur

```
Browser → Cloudflare → Traefik (ADR-212) → forwardAuth → Authentik (ADR-142)
                                                  ↓ (Session-OK)
                                                nginx → /srv/klickdummy/<org>/<repo>/<kd>/
```

## URL nach Deployment

```
https://klickdummy.iil.pet/<owner>/<repo>/<klickdummy>/shell.html
https://klickdummy.iil.pet/<owner>/<repo>/<klickdummy>/chat-simulator.html
```

## Stakeholder-Compliance (User-Bestätigung 2026-05-21)

| Repo | Stakeholder | Status |
|---|---|---|
| bahn-sqf/sqf-hub | Raphael Bayer | ✅ |
| bahn-sqf/pg-hub | Ilja Lerch + Grinninger | ✅ |
| meiki-lra/meiki-hub | LRA | ✅ |
| ttz-lif/ttz-hub | LRA-TTZ | ✅ |

## Geliefert

* docs/adr/ADR-216-klickdummy-hosting-iil-pet.md (426 LOC) — vollständige ADR
* infra/klickdummy-host/docker-compose.yml — Traefik-Labels + SSO-Middleware
* infra/klickdummy-host/nginx.conf — Static-Hosting + YAML-Type
* infra/klickdummy-host/sync.sh — Pull-Job (Cron-fähig)
* infra/klickdummy-host/repos.yaml — Repo-Registry
* infra/klickdummy-host/generate_landing.py — Auto-Index-Landing
* infra/klickdummy-host/README.md — Deployment-Schritte 1-7

## Auth Phase 1 / Phase 2

Phase 1 (heute, deploy-fertig): alle Stakeholder in Authentik-Gruppe `klickdummy-viewers`. Phase 2 (Backlog): owner-spezifische Gruppen + Traefik-Path-Filter.

🤖 Generated with Claude Code