### PR TITLE
feat(klickdummy-host): Per-Repo-Auth + Home-Button + Picker-Patch (Iter. 31-32)

### DIFF
--- a/docs/adr/ADR-216-klickdummy-hosting-iil-pet.md
+++ b/docs/adr/ADR-216-klickdummy-hosting-iil-pet.md
@@ -525,6 +525,56 @@ staging-platform:
    bleibt, Traefik wird Sidecar bei nginx)
 
 Geschätzte Migration: 15 Min.
+## Per-Repo-Auth ohne Authentik (Iter. 32 Patch)
+
+Folge zu User-Anforderung 2026-05-21 (Iter. 31/32):
+
+> „Rollenkonzept: user/password per repo notwendig — user sieht nur sein repo/dummies"
+
+Realisiert ADR-217 §Auth Phase 2 OHNE Authentik (das fehlt auf staging-platform) durch **BasicAuth-Variante mit per-Owner htpasswd-Files + nginx location-Blöcke**.
+
+### Architektur
+
+| File | Zweck | User |
+|---|---|---|
+| `/etc/nginx/htpasswd-default` | Landing + Discovery + Widget | alle 8 |
+| `/etc/nginx/htpasswd-sqf` | `/bahn-sqf/sqf-hub/*` | raphael + admin + klickdummy-viewer |
+| `/etc/nginx/htpasswd-pg` | `/bahn-sqf/pg-hub/*` | ilja + grinninger + admin + klickdummy-viewer |
+| `/etc/nginx/htpasswd-meiki` | `/meiki-lra/meiki-hub/*` | lra-meiki + admin + klickdummy-viewer |
+| `/etc/nginx/htpasswd-ttz` | `/ttz-lif/ttz-hub/*` | ttz-pilot + admin + klickdummy-viewer |
+| `/etc/nginx/htpasswd-risk` | `/achimdehnert/risk-hub/*` | risk-pilot + admin + klickdummy-viewer |
+
+**Realm überall `Klickdummy Demo`** → Browser cached die Credentials einmalig. Wenn Owner-User auf fremde Repos zugreift, kommt 401 (kein Re-Auth-Loop weil gleicher Realm).
+
+### Plus: Picker-Aktivierung via sub_filter
+
+Same-Origin-Hint via nginx-injected JS in jeder HTML-Response:
+
+```javascript
+if (location.hostname === "staging-klickdummy.iil.pet") {
+  CROSS_REPO_INDEX.forEach(e => { e.local = true; e.reachable = true;
+    if (!e.path_rel && e.url) e.path_rel = e.url; });
+  renderCrossRepoCard(crpSelect.value);
+}
+```
+
+Behebt: User-Bug-Report "klickdummy auswahl leitet nicht in den dummy (readonly)".
+
+### Plus: Home-Button via sub_filter
+
+`<a href="/" id="kd-home-btn" style="…">⌂ Übersicht</a>` vor `</body>` in jede HTML-Response — kein Repo-Eingriff.
+
+### Migration zu Authentik (ADR-217 Phase 2)
+
+Sobald Authentik deployed (ADR-142 + ADR-217):
+1. nginx-Per-Owner-Locations entfernen → eine `location /` mit forwardAuth
+2. htpasswd-Files weg → Authentik-Groups übernehmen
+3. Authentik-Application-Bindings: `klickdummy-<org>-viewers` → Path-Pattern
+4. Plus: `klickdummy-viewer` Übergangs-User auslaufen lassen
+
+Geschätzt: 30 Min nach Authentik-Setup.
+
+
 
 ## Provenance
 

--- a/infra/klickdummy-host/deploy-klausel2.sh
+++ b/infra/klickdummy-host/deploy-klausel2.sh
@@ -22,8 +22,19 @@ SRV_DIR="${SRV_DIR:-/srv/klickdummy}"
 WORK_DIR="${WORK_DIR:-/var/lib/klickdummy-sync}"
 BUNDLE_DIR="${BUNDLE_DIR:-/tmp/klickdummy-host-bundle}"
 DEPLOY_KEY="$WORK_DIR/.ssh/klickdummy-deploy_ed25519"
-HTPASSWD_FILE="/etc/nginx/.htpasswd-klickdummy"
-HTPASSWD_USER="${HTPASSWD_USER:-klickdummy-viewer}"
+HTPASSWD_FILE="/etc/nginx/.htpasswd-klickdummy"     # deprecated, ADR-216-initial
+HTPASSWD_USER="${HTPASSWD_USER:-klickdummy-viewer}"  # Übergangs-User (Backward-Kompat)
+
+# ADR-217 Klausel-2 Per-Repo-Auth: pro Owner ein htpasswd-File
+# (Default = Landing/Discovery, owner-spezifische enthalten User + admin + viewer)
+HTPASSWD_DIR="/etc/nginx"
+declare -A OWNER_USERS=(
+  [sqf]="raphael"
+  [pg]="ilja grinninger"
+  [meiki]="lra-meiki"
+  [ttz]="ttz-pilot"
+  [risk]="risk-pilot"
+)
 
 CRON_INTERVAL="${CRON_INTERVAL:-*/15 * * * *}"
 
@@ -85,26 +96,69 @@ install_files() {
   ok "Files installiert"
 }
 
-# 5. htpasswd erzeugen
+# 5. Per-Repo BasicAuth (ADR-217 Klausel-2-Variante)
 setup_htpasswd() {
-  log "BasicAuth htpasswd…"
-  if [ ! -f "$HTPASSWD_FILE" ]; then
-    # Generiere Passwort (16 Zeichen alphanumerisch)
-    PASSWORD=$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 16)
-    htpasswd -bcB "$HTPASSWD_FILE" "$HTPASSWD_USER" "$PASSWORD"
-    chmod 640 "$HTPASSWD_FILE"
-    chown root:www-data "$HTPASSWD_FILE" 2>/dev/null || chown root:nginx "$HTPASSWD_FILE" 2>/dev/null || true
-    echo
-    echo "════════════════════════════════════════════════════════════════════"
-    echo " BASIC-AUTH CREDENTIALS — bitte sicher aufbewahren + verteilen"
-    echo "   URL:        https://staging-klickdummy.iil.pet/"
-    echo "   User:       $HTPASSWD_USER"
-    echo "   Password:   $PASSWORD"
-    echo "════════════════════════════════════════════════════════════════════"
-    echo
-  else
-    ok "htpasswd existiert bereits"
+  log "Per-Repo BasicAuth htpasswd-Files…"
+  local creds="/root/klickdummy-credentials.txt"
+  if [ -f "$creds" ]; then
+    ok "Credentials existieren bereits → htpasswd-Files belassen"
+    return
   fi
+  # Passwörter generieren (openssl, kein SIGPIPE-Issue mit set -o pipefail)
+  local PW_ADMIN=$(openssl rand -base64 18 | tr -d "=+/" | head -c 14)
+  local PW_VIEWER=$(openssl rand -base64 18 | tr -d "=+/" | head -c 14)
+  declare -A PWS
+  for u in raphael ilja grinninger lra-meiki ttz-pilot risk-pilot; do
+    PWS[$u]=$(openssl rand -base64 18 | tr -d "=+/" | head -c 14)
+  done
+
+  # htpasswd-default: alle User können Landing/Discovery sehen
+  > /tmp/hp-default
+  for u in raphael ilja grinninger lra-meiki ttz-pilot risk-pilot; do
+    htpasswd -bB /tmp/hp-default "$u" "${PWS[$u]}" 2>/dev/null
+  done
+  htpasswd -bB /tmp/hp-default admin "$PW_ADMIN" 2>/dev/null
+  htpasswd -bB /tmp/hp-default klickdummy-viewer "$PW_VIEWER" 2>/dev/null
+  mv /tmp/hp-default "$HTPASSWD_DIR/htpasswd-default"
+
+  # Per-Owner htpasswd: nur eigene User + admin + viewer (allow-all)
+  for owner in sqf pg meiki ttz risk; do
+    > /tmp/hp-$owner
+    for u in ${OWNER_USERS[$owner]}; do
+      htpasswd -bB /tmp/hp-$owner "$u" "${PWS[$u]}" 2>/dev/null
+    done
+    htpasswd -bB /tmp/hp-$owner admin "$PW_ADMIN" 2>/dev/null
+    htpasswd -bB /tmp/hp-$owner klickdummy-viewer "$PW_VIEWER" 2>/dev/null
+    mv /tmp/hp-$owner "$HTPASSWD_DIR/htpasswd-$owner"
+  done
+
+  chmod 640 "$HTPASSWD_DIR"/htpasswd-*
+  chown root:www-data "$HTPASSWD_DIR"/htpasswd-* 2>/dev/null || chown root:nginx "$HTPASSWD_DIR"/htpasswd-* 2>/dev/null || true
+
+  # Credentials-Datei
+  cat > "$creds" <<EOF
+═══ Klickdummy Credentials (ADR-216 + ADR-217 Klausel-2-Variante) ═══
+URL:   https://staging-klickdummy.iil.pet/
+Realm: Klickdummy Demo  (browserseitig 1× gecached)
+
+PER-REPO-USER (sehen NUR ihren Repo):
+  raphael      / ${PWS[raphael]}   → bahn-sqf/sqf-hub
+  ilja         / ${PWS[ilja]}   → bahn-sqf/pg-hub
+  grinninger   / ${PWS[grinninger]}   → bahn-sqf/pg-hub
+  lra-meiki    / ${PWS[lra-meiki]}   → meiki-lra/meiki-hub
+  ttz-pilot    / ${PWS[ttz-pilot]}   → ttz-lif/ttz-hub
+  risk-pilot   / ${PWS[risk-pilot]}   → achimdehnert/risk-hub
+
+ALL-ACCESS-USER (sehen ALLE Repos):
+  admin             / $PW_ADMIN
+  klickdummy-viewer / $PW_VIEWER   (Übergangs-User aus Init-Phase)
+EOF
+  chmod 600 "$creds"
+  echo
+  echo "════════════════════════════════════════════════════════════════════"
+  echo " CREDENTIALS gespeichert: $creds (root-only)"
+  cat "$creds"
+  echo "════════════════════════════════════════════════════════════════════"
 }
 
 # 6. nginx-vhost

--- a/infra/klickdummy-host/host-nginx-staging-klickdummy.conf
+++ b/infra/klickdummy-host/host-nginx-staging-klickdummy.conf
@@ -1,5 +1,5 @@
-# Host-nginx-vhost für staging-klickdummy.iil.pet (ADR-216 Klausel-2-Patch)
-# Pattern: identisch zu staging-devhub.iil.pet (Bestand)
+# Host-nginx-vhost staging-klickdummy.iil.pet
+# ADR-216 (Klausel 2) + ADR-217 (Per-Repo-Auth BasicAuth-Variante) + Home-Button + Picker-Patch
 
 server {
     listen 80;
@@ -13,45 +13,82 @@ server {
     listen [::]:443 ssl http2;
     server_name staging-klickdummy.iil.pet;
 
-    # Wildcard *.iil.pet (acme.sh, Bestand)
     ssl_certificate     /etc/letsencrypt/wildcard.iil.pet/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/wildcard.iil.pet/privkey.pem;
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers off;
 
-    # Anti-Indexing
+    # Inject: Picker-Aktivierung (alle KDs auf staging-klickdummy klickbar) + Home-Button
+    sub_filter_once on;
+    sub_filter "</body>" '<script>(function(){if(location.hostname!=="staging-klickdummy.iil.pet")return;function patch(){if(typeof CROSS_REPO_INDEX!=="undefined"&&Array.isArray(CROSS_REPO_INDEX)&&CROSS_REPO_INDEX.length){CROSS_REPO_INDEX.forEach(function(e){e.local=true;e.reachable=true;if(!e.path_rel&&e.url)e.path_rel=e.url;});if(typeof renderCrossRepoCard==="function"){var s=document.getElementById("crpSelect");if(s)renderCrossRepoCard(s.value);}}}setTimeout(patch,200);setTimeout(patch,1500);setTimeout(patch,3500);})();</script><a href="/" id="kd-home-btn" style="position:fixed;top:12px;left:12px;z-index:9999;background:#1a3a6c;color:#fff;padding:6px 12px;border-radius:18px;font-family:system-ui,sans-serif;font-size:12px;text-decoration:none;box-shadow:0 2px 8px rgba(0,0,0,.2);" title="Zur Klickdummy-Übersicht">⌂ Übersicht</a></body>';
+
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Klickdummy-Class "mock" always;
+    add_header Referrer-Policy "no-referrer" always;
+
     location = /robots.txt {
-        add_header Content-Type "text/plain; charset=utf-8";
+        auth_basic off;
         return 200 "User-agent: *\nDisallow: /\n";
+        add_header Content-Type "text/plain; charset=utf-8";
     }
-
-    # BasicAuth-Schutz für alle Pfade (außer /healthz + /api/list)
-    auth_basic "Klickdummy Pre-Pilot Demo";
-    auth_basic_user_file /etc/nginx/.htpasswd-klickdummy;
-
-    # Health-Endpoint OHNE Auth
     location = /healthz {
         auth_basic off;
         access_log off;
         proxy_pass http://127.0.0.1:8081/healthz;
     }
-
-    # Discovery-Endpoint OHNE Auth (same-origin für Cross-Repo-Picker)
+    location ^~ /_widget/ {
+        auth_basic "Klickdummy Demo";
+        auth_basic_user_file /etc/nginx/htpasswd-default;
+        proxy_pass http://127.0.0.1:8081;
+        proxy_set_header Host $host;
+    }
     location = /api/list {
-        auth_basic off;
+        auth_basic "Klickdummy Demo";
+        auth_basic_user_file /etc/nginx/htpasswd-default;
         proxy_pass http://127.0.0.1:8081/api/list;
-        add_header Cache-Control "no-cache, must-revalidate" always;
+    }
+
+    location ^~ /bahn-sqf/sqf-hub/ {
+        auth_basic "Klickdummy Demo";
+        auth_basic_user_file /etc/nginx/htpasswd-sqf;
+        proxy_pass http://127.0.0.1:8081;
+        proxy_set_header Host $host;
+        proxy_set_header X-Klickdummy-User $remote_user;
+    }
+    location ^~ /bahn-sqf/pg-hub/ {
+        auth_basic "Klickdummy Demo";
+        auth_basic_user_file /etc/nginx/htpasswd-pg;
+        proxy_pass http://127.0.0.1:8081;
+        proxy_set_header Host $host;
+        proxy_set_header X-Klickdummy-User $remote_user;
+    }
+    location ^~ /meiki-lra/meiki-hub/ {
+        auth_basic "Klickdummy Demo";
+        auth_basic_user_file /etc/nginx/htpasswd-meiki;
+        proxy_pass http://127.0.0.1:8081;
+        proxy_set_header Host $host;
+        proxy_set_header X-Klickdummy-User $remote_user;
+    }
+    location ^~ /ttz-lif/ttz-hub/ {
+        auth_basic "Klickdummy Demo";
+        auth_basic_user_file /etc/nginx/htpasswd-ttz;
+        proxy_pass http://127.0.0.1:8081;
+        proxy_set_header Host $host;
+        proxy_set_header X-Klickdummy-User $remote_user;
+    }
+    location ^~ /achimdehnert/risk-hub/ {
+        auth_basic "Klickdummy Demo";
+        auth_basic_user_file /etc/nginx/htpasswd-risk;
+        proxy_pass http://127.0.0.1:8081;
+        proxy_set_header Host $host;
+        proxy_set_header X-Klickdummy-User $remote_user;
     }
 
     location / {
+        auth_basic "Klickdummy Demo";
+        auth_basic_user_file /etc/nginx/htpasswd-default;
         proxy_pass http://127.0.0.1:8081;
         proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Klickdummy-User $remote_user;
     }
-
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Klickdummy-Class "mock" always;
-    add_header Referrer-Policy "no-referrer" always;
 }

--- a/infra/klickdummy-host/sync.sh
+++ b/infra/klickdummy-host/sync.sh
@@ -67,8 +67,8 @@ done <<< "$ENTRIES"
 
 # Discovery + Landing generieren
 # o+rx für nginx-Container-Read (klickdummy-sync-Dir hat 750 default)
-find "$WORK" -type d -exec chmod o+rx {} + 2>/dev/null || true
-find "$WORK" -type f -exec chmod o+r {} + 2>/dev/null || true
+find "$WORK" -mindepth 1 -maxdepth 1 -type d ! -name .ssh -exec sh -c 'find "$1" -type d -exec chmod o+rx {} +' _ {} + 2>/dev/null || true
+find "$WORK" -mindepth 1 -maxdepth 1 -type d ! -name .ssh -exec sh -c 'find "$1" -type f -exec chmod o+r {} +' _ {} + 2>/dev/null || true
 
 python3 /opt/klickdummy/generate_landing.py "$TARGET" "$REPOS_FILE" \
   --emit-json "$TARGET/_index.json" \


### PR DESCRIPTION
User-Anforderungen Iter. 31-32 umgesetzt (Per-Repo-User, Home-Button, Picker-Aktivierung). ADR-217-Phase-2 ohne Authentik via BasicAuth-Variante (5 htpasswd-Files + Realm 'Klickdummy Demo'). Live deployed + 7/7 Tests grün.