### PR TITLE
feat(adr,governance): ADR-218 Doc-Profile als Plattform-Konvention

### DIFF
--- a/docs/adr/ADR-218-doc-profile-konvention.md
+++ b/docs/adr/ADR-218-doc-profile-konvention.md
@@ -1,0 +1,176 @@
+---
+id: ADR-218
+title: "Doc-Profile als Plattform-Konvention (Doku-Pflicht-Katalog je Projekttyp)"
+status: proposed
+date: 2026-05-21
+deciders: [Achim Dehnert]
+consulted: [self-advocatus-diabolus]
+informed: [meiki-lra, bahn-sqf, ttz-lif, iilgmbh, achimdehnert]
+domains: [governance, documentation, compliance, klickdummy]
+supersedes: []
+amends: []
+depends_on: [ADR-211, ADR-213]
+related: [ADR-207, ADR-209]
+tags: [doc-profile, documentation, governance, lastenheft, pflichtenheft, compliance, dsfa, ozg, bsi, wibe, bitv]
+---
+
+# ADR-218 — Doc-Profile als Plattform-Konvention
+
+## Status
+
+**proposed** — mit pre-integriertem advocatus-diabolus-Review (Pattern aus
+ADR-216/-217). Tritt mit erster Repo-Instanziierung (geplant: meiki-hub) in
+Kraft.
+
+## Kontext
+
+Die 6 Klickdummy-Repos (meiki-hub, bahn-sqf/sqf-hub, bahn-sqf/pg-hub,
+ttz-hub, risk-hub, plus künftige) und Plattform-Apps brauchen Dokumentation,
+deren *Pflicht-Katalog je Projekttyp variiert*:
+
+- **LRA-Pilot** (meiki-hub) — DSGVO + BayDSG + OZG + BITV + BSI-Grundschutz
+  Pflicht; EVB-IT-Vergabe oder intern offen.
+- **Konzern-Pilot** (bahn-sqf) — KRITIS-Schutzbedarf, interne
+  Compliance-Reviews, Investitionsrechnung Pflicht; keine OZG-Bindung.
+- **Forschung** (ttz-hub) — Förderauflagen, Daten-Anonymisierung statt
+  Personenbezug-DSFA; keine Vergabe.
+- **Kommerzielles SaaS** (risk-hub) — ROI-Case, ISO 27001 statt BSI, ggf.
+  EU-Kunden → BITV-relevant.
+
+Ohne deklariertes Profil tritt ein typisches Anti-Pattern auf:
+
+- **Compliance-Lücke nach Audit**: „BSI-Schutzbedarf fehlt" wird erst bei
+  Audit-Termin gemerkt.
+- **Doku-Overengineering**: alle Repos schreiben ein WiBe, auch wenn keine
+  Investitionsrechnung nötig.
+- **Inkonsistenz zwischen Klickdummy und Doku**: Use-Cases laufen aus der
+  Spec, Spec aus der Doku.
+- **Stakeholder-Frust**: „Ich kriege Pflichtenheft-Skelett, aber das passt
+  nicht zu meinem Projekt."
+
+### Trigger für diese ADR
+
+User-Frage 2026-05-21:
+
+> „ich kann mir vorstellen, dass die dokumentation je nach projekt typ,
+> kunde, … variiert. sollen wir das vorab festlegen oder als task parallel
+> mit festlegen?"
+
+Antwort als Entscheidung: **beides** — Profil vorab, Inhalte parallel.
+
+## Entscheidungs-Vorschlag
+
+**Repo-deklariertes `doc-profile.yaml` mit plattform-globalem
+Pflicht-Katalog-Schema und externem Check.**
+
+### Drei Bestandteile
+
+1. **`platform/docs/conventions/doc-profile-schema.yaml`** — Plattform-Schema:
+   - Definition von 4 Initial-Profilen (`lra-pilot`, `konzern-pilot`,
+     `forschung`, `saas`)
+   - Pro Profil: Pflicht-Tiers (A0, A, A-api, B, C, D, 08-Betrieb) ×
+     Pflicht-Status (`required` / `optional` / `na`)
+   - Pflicht-Frontmatter-Felder je Tier (z.B. `dsfa.kategorie`,
+     `bsi.schutzbedarf`)
+   - SSoT: Plattform; gepinnter Worktree gleicher Mechanik wie
+     `klickdummy.md`-Policy
+
+2. **Repo-lokales `<repo>/docs/doc-profile.yaml`** — Instanz:
+   ```yaml
+   profile: lra-pilot
+   projektphase: discovery        # discovery | spec | build | rollout | maintain
+   auftraggeber: lra
+   stakeholder_extern: [guenzburg, traunstein]
+   vergabe:
+     modus: offen                  # intern | evb-it | offen | freihaendig
+     wibe_pflicht: true
+   ```
+   Überschreibungen einzelner Tier-Pflichten möglich (`overrides.<tier>`)
+   mit Begründung — `doc-profile-check.sh` warnt bei Override ohne `reason`.
+
+3. **`platform/scripts/checks/doc_profile_check.sh`** — externer
+   Adversarial-Check (analog `klickdummy_registry.sh`):
+   - Liest `registry/repos.yaml` + `<repo>/docs/doc-profile.yaml`
+   - Verifiziert je deklariertem Profil die Pflicht-Tiers existieren
+     (Datei + Mindestinhalt)
+   - Exit 0 = konform, 1 = Verstoß, 2 = Setup-Fehler
+   - Nightly-Job + PR-Hook im jeweiligen Repo
+
+### Vier Initial-Profile (Schema-Auszug)
+
+| Tier / Pflicht | `lra-pilot` | `konzern-pilot` | `forschung` | `saas` |
+|---|---|---|---|---|
+| A0 Spec-Basis | ✅ | ✅ | ✅ | ✅ |
+| A Use-Cases | ✅ | ✅ | ✅ | ✅ |
+| A-api OpenAPI | ✅ | ✅ | ⚠ optional | ✅ |
+| B Lastenheft | ✅ | ✅ | Projekt-Antrag | Product-Spec |
+| B Pflichtenheft | wenn evb-it | wenn extern | – | – |
+| C C4-Diagramme | ✅ | ✅ | ✅ | ✅ |
+| C SLOs (RPO/RTO) | ✅ | ✅ KRITIS | ⚠ | ✅ |
+| C BITV 2.0 | ✅ | wenn Endkunden-UI | ⚠ | wenn EU-Kunden |
+| D DSFA | ✅ je FV | ✅ Mitarbeiter | ⚠ Anonymisierung | ✅ |
+| D OZG | ✅ | – | – | – |
+| D BSI-Schutzbedarf | ✅ | ✅ KRITIS | ⚠ | ISO 27001 |
+| D WiBe | wenn >Schwelle | ✅ Invest. | – | ROI-Case |
+| 08 Betrieb | ✅ vor GoLive | ✅ | ⚠ | ✅ |
+
+### Profile sind erweiterbar
+
+Neue Profile (z.B. `polit-stiftung`, `kommune-klein`) per Plattform-PR auf
+das Schema. Repo-spezifische *Abweichung* ohne neues Profil:
+`overrides.<tier>` mit `reason:`.
+
+## Advocatus-Diabolus-Review (pre-integriert)
+
+| Einwand | Antwort |
+|---|---|
+| „Variantenexplosion: 4 Profile sind zu wenig / zu viel" | 4 ist die heute beobachtete Stakeholder-Streuung. Schema ist erweiterbar; Plattform-PR-Threshold = `klickdummy.md`-Pattern (Changelog-bump). |
+| „Was, wenn ein Repo zwischen Profilen pendelt?" | `projektphase` ist orthogonal zum Profil — Phasenwechsel löst kein Profil-Wechsel aus. Profil-Wechsel nur per ADR (cross-cutting). |
+| „Doppelt geschriebene Doku — Spec im Klickdummy + Use-Cases in Tier A" | Tier A0/A sind **auto-generiert** aus Klickdummy-Spec (`gen-doc-from-spec.py`). Pflicht-Check prüft nur Existenz + Mindestinhalt, nicht manuelle Pflege. |
+| „Compliance-Tiers können nicht aus Spec abgeleitet werden" | Korrekt — D ist *handgeschrieben*. Schema markiert D-Tiers als `auto_generatable: false`. |
+| „Wer pflegt das Schema?" | Plattform-Ebene, gleiches Modell wie `klickdummy.md`-Policy: Symlink in gepinnten Worktree, PR-getrieben, Changelog-bump. |
+| „Drift Profil-Schema vs. Repo-Instanz" | Schema-Version in `doc-profile.yaml` (`schema_version: 1`); Check prüft Kompatibilität. |
+| „Wann gilt es?" | Sobald `<repo>/docs/doc-profile.yaml` existiert. Repos ohne Profil sind aus dem Check ausgenommen (kein Vacuous Pass — sondern keine Pflicht). |
+| „Was passiert in monorepo-artigen Repos (mehrere Projekte)?" | `doc-profile.yaml` ist mehrfach erlaubt unter `<repo>/projects/<projektname>/doc-profile.yaml`. Schema unterstützt das (`monorepo: true`). |
+| „Konflikt mit klickdummy.md-Policy?" | Nein — `klickdummy.md` regelt Klickdummy-Spec-Cores, `doc-profile.yaml` regelt die *darüber-/daneben* liegenden Doku-Schichten. Beide referenzieren A0/A. |
+
+## Konsequenzen
+
+- ✅ **Compliance-Lücke verhindert**: Profil-Pflicht erzwingt vorab die
+  rechtlich nötigen Tiers (DSFA, BSI, OZG, BITV, WiBe je nach Profil).
+- ✅ **Kein Overengineering**: optional/n.a.-markierte Tiers bleiben weg.
+- ✅ **Wiederverwendbar** über alle 6+ Klickdummy- und Plattform-Repos.
+- ✅ **Drift-sicher**: externer Adversarial-Check `doc_profile_check.sh`
+  meldet fehlende Pflicht-Artefakte (ADR-211-Pattern).
+- ⚠ **Plattform-Wartungsaufwand**: Schema lebt zentral, Änderungen brauchen
+  Plattform-PR. Mitigation: Profile sind orthogonal zu Repos — Schema-Edits
+  selten.
+- ⚠ **Bootstrap-Phase**: Repos ohne Profil bleiben aus dem Check raus
+  (kein Big-Bang-Enforcement). Migration repo-by-repo.
+- ⚠ **Profil-Wahl ist Entscheidung**: ein Repo, das fälschlich `forschung`
+  deklariert, bekommt keine OZG-Pflicht aufgedrückt. Mitigation: Profil-Wahl
+  ist im ADR-Threshold-Bereich (vgl. Adv.D.: „Profil-Wechsel nur per ADR").
+
+## Implementierungsplan
+
+1. **Plattform-PR (diese ADR)**:
+   - `docs/adr/ADR-218-doc-profile-konvention.md`
+   - `docs/conventions/doc-profile-schema.yaml`
+   - `scripts/checks/doc_profile_check.sh`
+   - `policies/doc-profile.md` (für `~/.claude/policies/`-Sync via
+     ADR-209)
+2. **meiki-hub-PR (Pilot-Instanziierung)**:
+   - `docs/doc-profile.yaml` (profile: `lra-pilot`, vergabe.modus: `offen`)
+   - `docs/05-spezifikation/A0/`-Skeleton (Tier A0 vorbereitet,
+     Mindestdateien angelegt — Inhalt iterativ)
+3. **Rollout nach Pilot-Stabilität**: bahn-sqf/sqf-hub + bahn-sqf/pg-hub
+   (konzern-pilot), ttz-hub (forschung), risk-hub (saas) — pro Repo
+   eigener PR mit Profil-Instanz + Skeleton.
+
+## Refs
+
+- ADR-211 Klickdummy-Rahmen (Spec-Basis Tier A0/A)
+- ADR-213 Cross-Repo-ADR-Ref-Format (für Profil-Referenzen)
+- ADR-207 Cross-Repo-Doku-Konvention (orthogonal)
+- ADR-209 Policy-Auto-Sync (Mechanismus für `policies/doc-profile.md`)
+- `policies/klickdummy.md` (Schwester-Policy)

--- a/docs/adr/ADR-218-doc-profile-konvention.md
+++ b/docs/adr/ADR-218-doc-profile-konvention.md
@@ -13,8 +13,11 @@ implementation_evidence:
   - "platform PR #290 — ADR + Schema + Check + Policy (dieser PR)"
   - "meiki-hub PR #41 — Pilot-Instanziierung lra-pilot + A0-Skeleton"
 scope:
-  repos: [platform, meiki-hub, sqf-hub, pg-hub, ttz-hub, risk-hub, iil-klickdummy]
-  inkraft_ab: "erste Repo-Instanziierung (meiki-hub PR #41)"
+  include_paths:
+    - "docs/conventions/doc-profile-schema.yaml"
+    - "scripts/checks/doc_profile_check.sh"
+    - "policies/doc-profile.md"
+    - "docs/adr/ADR-218-*"
 supersedes: []
 amends: []
 depends_on: [ADR-211, ADR-213]

--- a/docs/adr/ADR-218-doc-profile-konvention.md
+++ b/docs/adr/ADR-218-doc-profile-konvention.md
@@ -1,26 +1,36 @@
 ---
 id: ADR-218
-title: "Doc-Profile als Plattform-Konvention (Doku-Pflicht-Katalog je Projekttyp)"
+title: "Adopt projekttyp-spezifisches Doc-Profile mit plattform-globalem Pflicht-Katalog-Schema"
 status: proposed
 date: 2026-05-21
+amended: 2026-05-21
 deciders: [Achim Dehnert]
-consulted: [self-advocatus-diabolus]
+consulted: [self-advocatus-diabolus, /adr-challenger, /adr-review]
 informed: [meiki-lra, bahn-sqf, ttz-lif, iilgmbh, achimdehnert]
 domains: [governance, documentation, compliance, klickdummy]
+implementation_status: partial
+implementation_evidence:
+  - "platform PR #290 — ADR + Schema + Check + Policy (dieser PR)"
+  - "meiki-hub PR #41 — Pilot-Instanziierung lra-pilot + A0-Skeleton"
+scope:
+  repos: [platform, meiki-hub, sqf-hub, pg-hub, ttz-hub, risk-hub, iil-klickdummy]
+  inkraft_ab: "erste Repo-Instanziierung (meiki-hub PR #41)"
 supersedes: []
 amends: []
 depends_on: [ADR-211, ADR-213]
-related: [ADR-207, ADR-209]
+related: [ADR-077, ADR-138, ADR-207, ADR-209]
 tags: [doc-profile, documentation, governance, lastenheft, pflichtenheft, compliance, dsfa, ozg, bsi, wibe, bitv]
 ---
 
-# ADR-218 — Doc-Profile als Plattform-Konvention
+# ADR-218 — Adopt projekttyp-spezifisches Doc-Profile mit plattform-globalem Pflicht-Katalog-Schema
 
 ## Status
 
 **proposed** — mit pre-integriertem advocatus-diabolus-Review (Pattern aus
-ADR-216/-217). Tritt mit erster Repo-Instanziierung (geplant: meiki-hub) in
-Kraft.
+ADR-216/-217) und zwei externen Pässen (`/adr-challenger`, `/adr-review`,
+2026-05-21). Tritt mit erster Repo-Instanziierung (meiki-hub PR #41) in
+Kraft. Übergang zu `accepted` nach 30 Tagen Pilot ohne Schema-Wechsel
+(analog ADR-211).
 
 ## Kontext
 
@@ -37,6 +47,18 @@ deren *Pflicht-Katalog je Projekttyp variiert*:
 - **Kommerzielles SaaS** (risk-hub) — ROI-Case, ISO 27001 statt BSI, ggf.
   EU-Kunden → BITV-relevant.
 
+### Trigger für diese ADR
+
+User-Frage 2026-05-21:
+
+> „ich kann mir vorstellen, dass die dokumentation je nach projekt typ,
+> kunde, … variiert. sollen wir das vorab festlegen oder als task parallel
+> mit festlegen?"
+
+Antwort als Entscheidung: **beides** — Profil vorab, Inhalte parallel.
+
+## Decision Drivers
+
 Ohne deklariertes Profil tritt ein typisches Anti-Pattern auf:
 
 - **Compliance-Lücke nach Audit**: „BSI-Schutzbedarf fehlt" wird erst bei
@@ -48,20 +70,77 @@ Ohne deklariertes Profil tritt ein typisches Anti-Pattern auf:
 - **Stakeholder-Frust**: „Ich kriege Pflichtenheft-Skelett, aber das passt
   nicht zu meinem Projekt."
 
-### Trigger für diese ADR
+## Considered Options
 
-User-Frage 2026-05-21:
+### Option A — Freihändiges Doku-Schema je Repo (Status quo)
 
-> „ich kann mir vorstellen, dass die dokumentation je nach projekt typ,
-> kunde, … variiert. sollen wir das vorab festlegen oder als task parallel
-> mit festlegen?"
+Jedes Repo strukturiert seine `docs/` selbst, ohne Plattform-Vorgabe.
 
-Antwort als Entscheidung: **beides** — Profil vorab, Inhalte parallel.
+**Pros:**
+- Keine Plattform-Wartung
+- Maximale Repo-Autonomie
 
-## Entscheidungs-Vorschlag
+**Cons:**
+- Compliance-Lücken werden erst bei Audit sichtbar (LRA-Pilot ohne BSI-Schutzbedarf, SaaS ohne ROI)
+- Cross-Repo-Vergleichbarkeit unmöglich (jedes Repo erfindet eigene Tier-Namen)
+- Doku-Overengineering nicht eingrenzbar
+- Status quo, der explizit als Anti-Pattern identifiziert wurde
 
-**Repo-deklariertes `doc-profile.yaml` mit plattform-globalem
-Pflicht-Katalog-Schema und externem Check.**
+### Option B — Cookiecutter-Templates pro Projekttyp
+
+Pro Projekttyp ein `cookiecutter-<typ>`-Repo mit fertigen Doc-Bäumen; Repo-Setup ruft Template einmalig auf.
+
+**Pros:**
+- Schneller Bootstrap (5 Min beim Repo-Onboarding)
+- Klare Initial-Struktur
+- Bekanntes Pattern (cookiecutter-django)
+
+**Cons:**
+- **Drift nach Repo-Lifetime**: einmaliger Template-Aufruf, danach driftet das Repo vom Template weg, ohne Erkennung
+- Keine adversariale Konformitäts-Prüfung (Templates erzeugen, prüfen nicht)
+- Profil-Wechsel praktisch unmöglich (Template-Re-Render würde lokale Änderungen überschreiben)
+- Compliance-Tier-Pflicht ist nicht enforced — User kann Datei einfach löschen
+
+### Option C — Backstage `catalog-info.yaml`-Erweiterung (ADR-077-Hub)
+
+Repo-Selbstbeschreibung über das bestehende `catalog-info.yaml` (Backstage-Konvention), mit eigenen Annotations für Doku-Tiers.
+
+**Pros:**
+- Kein neues Schema-Format (reuse ADR-077)
+- Backstage-Integration nativ
+- TechDocs-Plugin könnte Tiers visualisieren
+
+**Cons:**
+- Backstage-spezifischer Lock-In für eine eigentlich Backstage-unabhängige Frage (Doku-Pflicht)
+- Backstage-Annotations sind schwach-typisiert (`metadata.annotations: { … }`) — Schema-Validierung umständlich
+- Cross-Repo-Check müsste Backstage-Catalog-API querien statt einfach `git`-Tree
+- Profil-Logik (4 distinkte Pflicht-Kataloge) passt nicht zu Backstage's flachem Annotations-Modell
+
+### Option D (gewählt) — Doc-Profile-Schema + externer Check (analog `klickdummy_registry.sh`)
+
+Repo deklariert `docs/doc-profile.yaml` mit einem von 4 Initial-Profilen; Plattform-Schema definiert Pflicht-Tiers; externer Adversarial-Check prüft Konformität.
+
+**Pros:**
+- **Drift-sicher**: nightly + PR-Hook erkennen jede Lücke
+- **Profil-Wechsel als ADR-Trigger** (Cross-Cutting, soll bewusst sein)
+- **Konsistent mit existierendem Pattern** (`klickdummy_registry.sh` ADR-211 Confirmation C1)
+- **Symlink-Sync zu `~/.claude/policies/`** via ADR-209 — Trigger-Words wirken in jeder Claude-Session
+- **Conditional-Tiers** (z.B. „nur bei `vergabe.modus == 'evb-it'`") sind einfach evaluierbar
+- **Kein neuer SaaS-Lock-In** — nur YAML + bash + Python (kein Backstage-Zwang)
+
+**Cons:**
+- Plattform-Wartungsaufwand (Schema-Edits sind zentralisiert)
+- Schema-Versioning (`schema_version: 1`) ist heute deklariert aber nicht erzwungen — Migration bei v2 noch offen
+- Pflicht-Inhalt (`min_inhalt`) ist im Schema definiert, vom Check aber nur als Datei-Existenz geprüft (siehe §Open Questions)
+
+## Decision Outcome
+
+**Gewählt: Option D — Doc-Profile-Schema + externer Check.**
+
+Begründung: Nur Option D liefert *kontinuierliche* Konformitäts-Prüfung
+(Drift-Sicherheit), passt zum etablierten `klickdummy_registry.sh`-Pattern
+(ADR-211) und erzwingt keinen externen SaaS-Lock-In (vs. C). Cookiecutter
+(B) ist ein Initial-Bootstrap-Tool, kein Governance-Mechanismus.
 
 ### Drei Bestandteile
 
@@ -69,7 +148,7 @@ Pflicht-Katalog-Schema und externem Check.**
    - Definition von 4 Initial-Profilen (`lra-pilot`, `konzern-pilot`,
      `forschung`, `saas`)
    - Pro Profil: Pflicht-Tiers (A0, A, A-api, B, C, D, 08-Betrieb) ×
-     Pflicht-Status (`required` / `optional` / `na`)
+     Pflicht-Status (`required` / `optional` / `conditional` / `na`)
    - Pflicht-Frontmatter-Felder je Tier (z.B. `dsfa.kategorie`,
      `bsi.schutzbedarf`)
    - SSoT: Plattform; gepinnter Worktree gleicher Mechanik wie
@@ -78,21 +157,20 @@ Pflicht-Katalog-Schema und externem Check.**
 2. **Repo-lokales `<repo>/docs/doc-profile.yaml`** — Instanz:
    ```yaml
    profile: lra-pilot
-   projektphase: discovery        # discovery | spec | build | rollout | maintain
+   projektphase: discovery       # discovery | spec | build | rollout | maintain
    auftraggeber: lra
    stakeholder_extern: [guenzburg, traunstein]
    vergabe:
-     modus: offen                  # intern | evb-it | offen | freihaendig
+     modus: offen                 # intern | evb-it | offen | freihaendig
      wibe_pflicht: true
    ```
    Überschreibungen einzelner Tier-Pflichten möglich (`overrides.<tier>`)
-   mit Begründung — `doc-profile-check.sh` warnt bei Override ohne `reason`.
+   mit Begründung — `doc_profile_check.sh` warnt bei Override ohne `reason`.
 
 3. **`platform/scripts/checks/doc_profile_check.sh`** — externer
    Adversarial-Check (analog `klickdummy_registry.sh`):
    - Liest `registry/repos.yaml` + `<repo>/docs/doc-profile.yaml`
    - Verifiziert je deklariertem Profil die Pflicht-Tiers existieren
-     (Datei + Mindestinhalt)
    - Exit 0 = konform, 1 = Verstoß, 2 = Setup-Fehler
    - Nightly-Job + PR-Hook im jeweiligen Repo
 
@@ -116,9 +194,23 @@ Pflicht-Katalog-Schema und externem Check.**
 
 ### Profile sind erweiterbar
 
-Neue Profile (z.B. `polit-stiftung`, `kommune-klein`) per Plattform-PR auf
-das Schema. Repo-spezifische *Abweichung* ohne neues Profil:
-`overrides.<tier>` mit `reason:`.
+Neue Profile (z.B. `polit-stiftung`, `kommune-klein`, `internal-tool`,
+`health-pharma`) per Plattform-PR auf das Schema. Repo-spezifische
+*Abweichung* ohne neues Profil: `overrides.<tier>` mit `reason:`.
+
+## Pros and Cons der gewählten Option D
+
+**Pros (siehe §Considered Options Option D)** — Drift-Sicherheit,
+Pattern-Konsistenz, kein SaaS-Lock-In, Conditional-Tiers, Policy-Sync.
+
+**Cons mit Mitigation:**
+
+| Cons | Mitigation |
+|---|---|
+| Plattform-Wartungsaufwand | Profile sind orthogonal zu Repos — Schema-Edits selten |
+| Schema-Schein-Pflicht (Inhalt nicht geprüft) | Folge-Issue mit Akzeptanz-Kriterium (siehe §Open Questions) |
+| Auto-Generator-Tooling existiert nicht | Folge-Issue (siehe §Open Questions) |
+| Schema-Versioning ohne Migration-Strategie | Adressiert in ADR-218 Rev 2 (Phase-aware Check) |
 
 ## Advocatus-Diabolus-Review (pre-integriert)
 
@@ -126,10 +218,10 @@ das Schema. Repo-spezifische *Abweichung* ohne neues Profil:
 |---|---|
 | „Variantenexplosion: 4 Profile sind zu wenig / zu viel" | 4 ist die heute beobachtete Stakeholder-Streuung. Schema ist erweiterbar; Plattform-PR-Threshold = `klickdummy.md`-Pattern (Changelog-bump). |
 | „Was, wenn ein Repo zwischen Profilen pendelt?" | `projektphase` ist orthogonal zum Profil — Phasenwechsel löst kein Profil-Wechsel aus. Profil-Wechsel nur per ADR (cross-cutting). |
-| „Doppelt geschriebene Doku — Spec im Klickdummy + Use-Cases in Tier A" | Tier A0/A sind **auto-generiert** aus Klickdummy-Spec (`gen-doc-from-spec.py`). Pflicht-Check prüft nur Existenz + Mindestinhalt, nicht manuelle Pflege. |
+| „Doppelt geschriebene Doku — Spec im Klickdummy + Use-Cases in Tier A" | Tier A0/A sind **auto-generierbar** aus Klickdummy-Spec (`gen-doc-from-spec.py`, siehe §Open Questions). Pflicht-Check prüft Existenz + Mindestinhalt. |
 | „Compliance-Tiers können nicht aus Spec abgeleitet werden" | Korrekt — D ist *handgeschrieben*. Schema markiert D-Tiers als `auto_generatable: false`. |
 | „Wer pflegt das Schema?" | Plattform-Ebene, gleiches Modell wie `klickdummy.md`-Policy: Symlink in gepinnten Worktree, PR-getrieben, Changelog-bump. |
-| „Drift Profil-Schema vs. Repo-Instanz" | Schema-Version in `doc-profile.yaml` (`schema_version: 1`); Check prüft Kompatibilität. |
+| „Drift Profil-Schema vs. Repo-Instanz" | Schema-Version in `doc-profile.yaml` (`schema_version: 1`); Check prüft Kompatibilität (heute nur weicher Lese-Pfad; Rev 2: harter Cross-Check). |
 | „Wann gilt es?" | Sobald `<repo>/docs/doc-profile.yaml` existiert. Repos ohne Profil sind aus dem Check ausgenommen (kein Vacuous Pass — sondern keine Pflicht). |
 | „Was passiert in monorepo-artigen Repos (mehrere Projekte)?" | `doc-profile.yaml` ist mehrfach erlaubt unter `<repo>/projects/<projektname>/doc-profile.yaml`. Schema unterstützt das (`monorepo: true`). |
 | „Konflikt mit klickdummy.md-Policy?" | Nein — `klickdummy.md` regelt Klickdummy-Spec-Cores, `doc-profile.yaml` regelt die *darüber-/daneben* liegenden Doku-Schichten. Beide referenzieren A0/A. |
@@ -149,23 +241,68 @@ das Schema. Repo-spezifische *Abweichung* ohne neues Profil:
   (kein Big-Bang-Enforcement). Migration repo-by-repo.
 - ⚠ **Profil-Wahl ist Entscheidung**: ein Repo, das fälschlich `forschung`
   deklariert, bekommt keine OZG-Pflicht aufgedrückt. Mitigation: Profil-Wahl
-  ist im ADR-Threshold-Bereich (vgl. Adv.D.: „Profil-Wechsel nur per ADR").
+  ist im ADR-Threshold-Bereich (Profil-Wechsel = ADR-Trigger).
+
+### Confirmation
+
+Konformität wird wie folgt verifiziert:
+
+1. **Nightly**: `scripts/checks/doc_profile_check.sh` läuft gegen `registry/repos.yaml`,
+   meldet je Repo `OK`/`FAIL`/`skip`. Ergebnis als Plattform-Issue bei FAIL > 0.
+2. **PR-Hook im Repo**: bei Änderung an `docs/doc-profile.yaml` oder
+   `docs/05-spezifikation/**` wird der Check gegen das eigene Repo getriggert.
+3. **Schema-Edits**: Pflichtiger Plattform-PR + Changelog-Bump im
+   `docs/conventions/doc-profile-schema.yaml`. Symlink-Sync in
+   `~/.claude/policies/doc-profile.md` zieht via ADR-209-Mechanismus nach.
+4. **Profil-Wechsel** im Repo (`profile:`-Feld ändert sich): zukünftig
+   per `--detect-profile-change`-Modus erzwingen, dass PR mit ADR-NNN-Link
+   verlinkt ist (siehe §Open Questions OQ-4).
+
+## Open Questions
+
+| OQ | Frage | Ziel-Artefakt | Gefunden via |
+|---|---|---|---|
+| **OQ-1** | Wie wird `min_inhalt`-Schwelle (Heading-Count, Tabellenzeilen, Frontmatter-Flag) im Check durchgesetzt? | Plattform-Issue „doc_profile_check.sh Inhalt-Verifikation" | `/adr-challenger` Steel-Man #1 |
+| **OQ-2** | Wie wird `gen-doc-from-spec.py` (Tier-A-Auto-Generator) gebaut? | Plattform-Issue „gen-doc-from-spec.py" | `/adr-challenger` Steel-Man #2 |
+| **OQ-3** | Wie wird Bootstrap erzwungen (Trigger, der ein neues Repo zur Profil-Deklaration zwingt)? | ADR-218 Rev 2 §Trigger-Bedingung analog `klickdummy.md` | `/adr-challenger` Finding #3 |
+| **OQ-4** | Wie wird Profil-Wechsel als ADR-Trigger enforced? | Plattform-Issue „doc_profile_check.sh --detect-profile-change" | `/adr-challenger` Finding #7 |
+| **OQ-5** | Wie laufen Schema-Migrations bei Bump auf v2? | ADR-218 Rev 2 §Schema-Versioning + Kompatibilitäts-Matrix | `/adr-challenger` Finding #6 |
+| **OQ-6** | Wie integriert sich Inheritance/Mixins ins Schema (~80% Pflicht-Kernel redundant)? | ADR-218 Rev 2 §_base_required-Sektion | `/adr-challenger` informativ |
+| **OQ-7** | Welche Profil-Erweiterungen brauchen wir (`internal-tool`, `health-pharma`, `behoerden-zentral`, `finanz`)? | Plattform-PR mit Profil-Definitionen wenn Bedarf entsteht | `/adr-challenger` Finding #7 |
+
+OQ-1, OQ-2, OQ-4 werden vor `proposed → accepted` als Plattform-Issues
+angelegt; OQ-3, OQ-5, OQ-6, OQ-7 sind ADR-218-Rev-2-Material.
 
 ## Implementierungsplan
 
+### Migrations-Tracking
+
+| Phase | Repo | Profil | Status | PR | Datum |
+|---|---|---|---|---|---|
+| 1 — Plattform | platform | (kein Profil — definiert Schema) | 🔄 in Review | #290 | 2026-05-21 |
+| 2 — Pilot | meiki-hub | `lra-pilot` | 🔄 in Review | #41 | 2026-05-21 |
+| 3 — Konzern | sqf-hub | `konzern-pilot` | ⬜ offen | – | – |
+| 3 — Konzern | pg-hub | `konzern-pilot` | ⬜ offen | – | – |
+| 4 — Forschung | ttz-hub | `forschung` | ⬜ offen | – | – |
+| 5 — SaaS | risk-hub | `saas` | ⬜ offen | – | – |
+
+Status-Lemmas: ⬜ offen · 🔄 in Review · ✅ gemerged · 🟢 nightly-konform 30d.
+
+### Rollout-Reihenfolge
+
 1. **Plattform-PR (diese ADR)**:
-   - `docs/adr/ADR-218-doc-profile-konvention.md`
+   - `docs/adr/ADR-218-doc-profile-konvention.md` (dieser File)
    - `docs/conventions/doc-profile-schema.yaml`
    - `scripts/checks/doc_profile_check.sh`
-   - `policies/doc-profile.md` (für `~/.claude/policies/`-Sync via
-     ADR-209)
-2. **meiki-hub-PR (Pilot-Instanziierung)**:
+   - `policies/doc-profile.md` (für `~/.claude/policies/`-Sync via ADR-209)
+2. **meiki-hub-PR (Pilot-Instanziierung)** parallel zu #1:
    - `docs/doc-profile.yaml` (profile: `lra-pilot`, vergabe.modus: `offen`)
-   - `docs/05-spezifikation/A0/`-Skeleton (Tier A0 vorbereitet,
-     Mindestdateien angelegt — Inhalt iterativ)
-3. **Rollout nach Pilot-Stabilität**: bahn-sqf/sqf-hub + bahn-sqf/pg-hub
-   (konzern-pilot), ttz-hub (forschung), risk-hub (saas) — pro Repo
-   eigener PR mit Profil-Instanz + Skeleton.
+   - `docs/05-spezifikation/A0/`-Skeleton (7 Dateien aus Klickdummy abgeleitet)
+3. **Pilot-Reifezeit**: 30 Tage Beobachtung; bei Bedarf Schema-Patches per Folge-PR; sonst Übergang `proposed → accepted`.
+4. **Rollout** nach Pilot-Stabilität: bahn-sqf/sqf-hub + pg-hub (`konzern-pilot`), ttz-hub (`forschung`), risk-hub (`saas`) — pro Repo eigener PR mit Profil-Instanz + Skeleton.
+5. **INDEX.md-Sync**: separater Plattform-PR ergänzt ADR-210…218 in
+   `docs/adr/INDEX.md` (heute Stand 2026-05-14, alle 21x noch nicht
+   gelistet — Plattform-Backlog, nicht ADR-218-spezifisch).
 
 ## Refs
 
@@ -173,4 +310,42 @@ das Schema. Repo-spezifische *Abweichung* ohne neues Profil:
 - ADR-213 Cross-Repo-ADR-Ref-Format (für Profil-Referenzen)
 - ADR-207 Cross-Repo-Doku-Konvention (orthogonal)
 - ADR-209 Policy-Auto-Sync (Mechanismus für `policies/doc-profile.md`)
+- ADR-077 Backstage catalog-info.yaml (als Option C verworfen — siehe §Considered Options)
+- ADR-138 Implementation Tracking (lifecycle der Frontmatter-Felder)
 - `policies/klickdummy.md` (Schwester-Policy)
+
+## Glossar
+
+| Begriff | Erläuterung |
+|---|---|
+| **advocatus diabolus** | Vorausschauende Gegenrede zur eigenen Entscheidung — pre-integrierter Skeptiker-Standpunkt im ADR-Body. |
+| **BayDSG** | Bayerisches Datenschutzgesetz — ergänzt die DSGVO um bayerische Landesregelungen. |
+| **BITV 2.0** | Barrierefreie-Informationstechnik-Verordnung — Pflicht-Standard für barrierefreie IT in der öffentlichen Verwaltung Deutschlands (WCAG-Level-AA-äquivalent). |
+| **BSI-Grundschutz** | Methodik des Bundesamts für Sicherheit in der Informationstechnik zur strukturierten IT-Sicherheits-Modellierung (Schutzbedarf je Datenkategorie, Maßnahmenkatalog). |
+| **DSFA** | Datenschutz-Folgenabschätzung (DSGVO Art. 35) — Pflicht-Bewertung bei Verarbeitung mit hohem Risiko für personenbezogene Daten. |
+| **EVB-IT** | Ergänzende Vertragsbedingungen für IT — Vergaberechts-Mustertexte (Bund/Länder) für IT-Aufträge der öffentlichen Hand. |
+| **FIM** | Föderales Informationsmanagement — XÖV-Datenfeld-Standardisierung im OZG-Kontext. |
+| **ISO 27001** | Internationale Norm für Informationssicherheits-Managementsysteme (ISMS) — Alternative/Ergänzung zu BSI-Grundschutz, im SaaS-Kontext üblich. |
+| **KRITIS** | Kritische Infrastrukturen nach BSI-KritisV — sektorspezifische erhöhte Schutzbedarfe (Energie, Wasser, IT, Verkehr, …). |
+| **MADR** | Markdown Architecture Decision Records — Format-Konvention für ADRs (siehe adr.github.io/madr). |
+| **OZG** | Online-Zugangsgesetz — Bundesrecht zur Digitalisierung von Verwaltungsleistungen. |
+| **smallest-viable-ADR** | ~120-Zeilen-Heuristik (🌀 Lehre aus ADR-201): ein ADR soll genau eine Entscheidung tragen, nicht mehrere. |
+| **supersedes** | Frontmatter-Feld: dieses ADR ersetzt das genannte vorherige (Status des ersetzten wird `superseded`). |
+| **WiBe** | Wirtschaftlichkeitsbetrachtung — Pflicht-Methodik bei IT-Vorhaben des Bundes/Länder >Schwellwert. |
+| **WCAG** | Web Content Accessibility Guidelines — W3C-Standard für Barrierefreiheit, BITV-2.0-Referenz. |
+| **XÖV** | XML in der öffentlichen Verwaltung — Datenaustausch-Standards zwischen Behörden. |
+
+## Changelog
+
+- 2026-05-21 Rev 1: Initial. Pre-integrierter advocatus-diabolus.
+- 2026-05-21 Rev 2 (`amended`): Nach `/adr-challenger`- und `/adr-review`-Pässen:
+  - Title als Decision-Statement
+  - §Considered Options mit 4 Optionen + Pros/Cons
+  - §Decision Drivers explizit
+  - `### Confirmation`-Subsektion
+  - §Open Questions mit 7 OQ-Items (Findings aus Challenger)
+  - §Migrations-Tracking-Tabelle im Implementierungsplan
+  - Glossar mit 15 Begriffen
+  - `implementation_status: partial` + `implementation_evidence`
+  - `scope:`-Block ergänzt
+  - `related:` um ADR-077 + ADR-138 erweitert

--- a/docs/conventions/doc-profile-schema.yaml
+++ b/docs/conventions/doc-profile-schema.yaml
@@ -1,0 +1,340 @@
+# Doc-Profile-Schema (platform:ADR-218)
+# SSoT — gepinnter Worktree, Symlink in ~/.claude/policies/doc-profile.md
+# Änderung nur per platform-PR + Changelog-Bump (vgl. klickdummy.md-Policy).
+#
+# Repos deklarieren ihr Profil in <repo>/docs/doc-profile.yaml.
+# Externer Check: platform/scripts/checks/doc_profile_check.sh
+# Konformitäts-Verifikation: nightly + PR-Hook im Repo.
+
+schema_version: 1
+changelog:
+  - date: 2026-05-21
+    rev: 1
+    note: "Initial. 4 Profile (lra-pilot, konzern-pilot, forschung, saas)."
+
+# ---------------------------------------------------------------------------
+# Tier-Inventar (was es überhaupt gibt; Profil weist Pflicht zu)
+# ---------------------------------------------------------------------------
+tiers:
+  # Tier A0 — Spec-Basis (vor Use-Cases)
+  A0/domain-glossar:
+    pflicht_pfad: "docs/05-spezifikation/A0/domain-glossar.md"
+    auto_generatable: false
+    min_inhalt: "mind. 10 Begriffe mit Definition"
+  A0/personas:
+    pflicht_pfad: "docs/05-spezifikation/A0/personas-rollen-permissions.md"
+    auto_generatable: false
+    min_inhalt: "mind. 2 Personas mit Rollen + Permissions"
+  A0/datenmodell:
+    pflicht_pfad: "docs/05-spezifikation/A0/datenmodell.md"
+    auto_generatable: partial
+    min_inhalt: "mind. 1 ERD + Aggregate-Beschreibung"
+  A0/status-maschinen:
+    pflicht_pfad: "docs/05-spezifikation/A0/status-maschinen.md"
+    auto_generatable: partial
+    min_inhalt: "FSM je Aggregate mit Transitionen"
+  A0/validierungsregeln:
+    pflicht_pfad: "docs/05-spezifikation/A0/validierungsregeln.md"
+    auto_generatable: false
+  A0/fehler-taxonomie:
+    pflicht_pfad: "docs/05-spezifikation/A0/fehler-taxonomie.md"
+    auto_generatable: false
+  A0/konfigurations-modell:
+    pflicht_pfad: "docs/05-spezifikation/A0/konfigurations-modell.md"
+    auto_generatable: false
+
+  # Tier A — Fachliche Schicht (auto-generiert aus Klickdummy)
+  A/use-cases:
+    pflicht_pfad: "docs/05-spezifikation/A/use-cases.md"
+    auto_generatable: true
+    quelle: "klickdummy/cases.json + module-manifest.json + screens/*.html"
+  A/anforderungs-katalog:
+    pflicht_pfad: "docs/05-spezifikation/A/anforderungs-katalog.md"
+    auto_generatable: partial
+  A/coverage-matrix:
+    pflicht_pfad: "docs/05-spezifikation/A/coverage-matrix.md"
+    auto_generatable: true
+    invariant: "klickdummy-i1 (ADR-211) — bidirektional Spec ↔ Screen"
+
+  # Tier A-api — Kontrakt-Schicht
+  A-api/openapi:
+    pflicht_pfad: "docs/05-spezifikation/A-api/openapi/"
+    auto_generatable: false
+    min_inhalt: "mind. 1 OpenAPI-3.0-Datei pro Adapter (DMS/FV/Identität)"
+  A-api/asyncapi:
+    pflicht_pfad: "docs/05-spezifikation/A-api/asyncapi/"
+    auto_generatable: false
+    optional_wenn: "kein Event-Bus im Architektur-Stack"
+  A-api/uebersicht:
+    pflicht_pfad: "docs/05-spezifikation/A-api/schnittstellen-uebersicht.md"
+    auto_generatable: false
+
+  # Tier B — Vergabe-Hülle
+  B/lastenheft:
+    pflicht_pfad: "docs/06-lastenheft/lastenheft.md"
+    auto_generatable: partial
+    quelle: "Tier A0 + A + A-api + 01-architektur"
+  B/pflichtenheft:
+    pflicht_pfad: "docs/06-lastenheft/pflichtenheft-template.md"
+    auto_generatable: false
+
+  # Tier 01 — Architektur (existiert bereits historisch in den Repos)
+  "01/c4-systemkontext":
+    pflicht_pfad: "docs/01-architektur/c4-systemkontext.md"
+    auto_generatable: false
+  "01/c4-container":
+    pflicht_pfad: "docs/01-architektur/c4-container.md"
+    auto_generatable: false
+  "01/slos":
+    pflicht_pfad: "docs/01-architektur/slos.md"
+    auto_generatable: false
+    min_inhalt: "RPO + RTO + p95-Antwortzeit + Skalierungs-Annahmen"
+  "01/bitv":
+    pflicht_pfad: "docs/01-architektur/bitv-konzept.md"
+    auto_generatable: false
+    min_inhalt: "BITV-2.0-WCAG-Level-AA-Coverage je Screen"
+
+  # Tier 07 — Compliance
+  "07/dsfa":
+    pflicht_pfad: "docs/07-compliance/dsfa/"
+    auto_generatable: false
+    min_inhalt: "1 DSFA pro Fachverfahren mit personenbezogenen Daten"
+  "07/ozg":
+    pflicht_pfad: "docs/07-compliance/ozg-konformitaet.md"
+    auto_generatable: false
+    min_inhalt: "OZG-Mapping + FIM-Datenfeld-Abgleich"
+  "07/bsi":
+    pflicht_pfad: "docs/07-compliance/bsi-schutzbedarf.md"
+    auto_generatable: false
+    min_inhalt: "Schutzbedarf je Datenkategorie + Maßnahmen-Katalog"
+  "07/iso27001":
+    pflicht_pfad: "docs/07-compliance/iso27001-statement.md"
+    auto_generatable: false
+    optional_wenn: "kein BSI-Grundschutz angewandt"
+  "07/wibe":
+    pflicht_pfad: "docs/07-compliance/wibe.md"
+    auto_generatable: false
+  "07/roi":
+    pflicht_pfad: "docs/07-compliance/roi-case.md"
+    auto_generatable: false
+    optional_wenn: "kein kommerzielles Modell"
+
+  # Tier 08 — Operativ
+  "08/testkonzept":
+    pflicht_pfad: "docs/08-betrieb/testkonzept.md"
+    auto_generatable: partial
+  "08/migration":
+    pflicht_pfad: "docs/08-betrieb/migration.md"
+    auto_generatable: false
+    optional_wenn: "kein Bestandsdaten-Übergang nötig"
+  "08/schulungskonzept":
+    pflicht_pfad: "docs/08-betrieb/schulungskonzept.md"
+    auto_generatable: false
+  "08/rollout-plan":
+    pflicht_pfad: "docs/08-betrieb/rollout-plan.md"
+    auto_generatable: false
+  "08/betriebshandbuch":
+    pflicht_pfad: "docs/08-betrieb/betriebshandbuch.md"
+    auto_generatable: false
+  "08/feedback-triage":
+    pflicht_pfad: "docs/08-betrieb/feedback-triage.md"
+    auto_generatable: false
+
+  # Tier 09 — Change-Management
+  "09/roundtrip":
+    pflicht_pfad: "docs/09-change/roundtrip.md"
+    auto_generatable: false
+  "09/drift-detection":
+    pflicht_pfad: "docs/09-change/drift-detection.md"
+    auto_generatable: partial
+  "09/release-notes":
+    pflicht_pfad: "docs/09-change/release-notes/"
+    auto_generatable: true
+
+# ---------------------------------------------------------------------------
+# Profile (Pflicht-Status je Tier × Projekttyp)
+# Status-Werte: required | optional | conditional | na
+# 'conditional' hat 'condition'-Feld (yaml-Pfad in doc-profile.yaml)
+# ---------------------------------------------------------------------------
+profiles:
+
+  # --------------------------------------------------------------------- LRA
+  lra-pilot:
+    description: |
+      LRA-IT-Vorhaben (Landratsamt) mit Bürger- und Sachbearbeiter-UI.
+      DSGVO + BayDSG + OZG + BITV + BSI-Grundschutz Pflicht.
+      Vergabe-Modus offen (intern | EVB-IT | freihändig).
+    pflicht:
+      A0/domain-glossar: required
+      A0/personas: required
+      A0/datenmodell: required
+      A0/status-maschinen: required
+      A0/validierungsregeln: required
+      A0/fehler-taxonomie: required
+      A0/konfigurations-modell: required
+      A/use-cases: required
+      A/anforderungs-katalog: required
+      A/coverage-matrix: required
+      A-api/openapi: required
+      A-api/asyncapi: optional
+      A-api/uebersicht: required
+      B/lastenheft: required
+      B/pflichtenheft:
+        status: conditional
+        condition: "vergabe.modus == 'evb-it'"
+      "01/c4-systemkontext": required
+      "01/c4-container": required
+      "01/slos": required
+      "01/bitv": required
+      "07/dsfa": required
+      "07/ozg": required
+      "07/bsi": required
+      "07/iso27001": na
+      "07/wibe":
+        status: conditional
+        condition: "vergabe.wibe_pflicht == true"
+      "07/roi": na
+      "08/testkonzept": required
+      "08/migration": required
+      "08/schulungskonzept": required
+      "08/rollout-plan": required
+      "08/betriebshandbuch": required
+      "08/feedback-triage": required
+      "09/roundtrip": required
+      "09/drift-detection": required
+      "09/release-notes": required
+
+  # ----------------------------------------------------------------- Konzern
+  konzern-pilot:
+    description: |
+      Konzern-Pilot (z.B. DB-Bahn-SQF) — KRITIS-Schutzbedarf,
+      Investitionsrechnung Pflicht. Vergabe meist intern oder konzern-extern.
+    pflicht:
+      A0/domain-glossar: required
+      A0/personas: required
+      A0/datenmodell: required
+      A0/status-maschinen: required
+      A0/validierungsregeln: required
+      A0/fehler-taxonomie: required
+      A0/konfigurations-modell: required
+      A/use-cases: required
+      A/anforderungs-katalog: required
+      A/coverage-matrix: required
+      A-api/openapi: required
+      A-api/asyncapi: optional
+      A-api/uebersicht: required
+      B/lastenheft: required
+      B/pflichtenheft:
+        status: conditional
+        condition: "vergabe.modus == 'extern'"
+      "01/c4-systemkontext": required
+      "01/c4-container": required
+      "01/slos": required
+      "01/bitv":
+        status: conditional
+        condition: "ui_endkunden == true"
+      "07/dsfa": required
+      "07/ozg": na
+      "07/bsi": required
+      "07/iso27001":
+        status: conditional
+        condition: "compliance_regime contains 'iso27001'"
+      "07/wibe": required
+      "07/roi": na
+      "08/testkonzept": required
+      "08/migration":
+        status: conditional
+        condition: "bestandsdaten_uebergang == true"
+      "08/schulungskonzept": required
+      "08/rollout-plan": required
+      "08/betriebshandbuch": required
+      "08/feedback-triage": required
+      "09/roundtrip": required
+      "09/drift-detection": required
+      "09/release-notes": required
+
+  # --------------------------------------------------------------- Forschung
+  forschung:
+    description: |
+      Forschungs-/Public-Sector-Projekt (z.B. TTZ) mit Förderauflagen.
+      Daten-Anonymisierung statt Personenbezug-DSFA; keine Vergabe-Pflicht.
+    pflicht:
+      A0/domain-glossar: required
+      A0/personas: required
+      A0/datenmodell: required
+      A0/status-maschinen: optional
+      A0/validierungsregeln: optional
+      A0/fehler-taxonomie: optional
+      A0/konfigurations-modell: optional
+      A/use-cases: required
+      A/anforderungs-katalog: required
+      A/coverage-matrix: required
+      A-api/openapi: optional
+      A-api/asyncapi: optional
+      A-api/uebersicht: optional
+      B/lastenheft: na  # statt: Projekt-Antrag/Förder-Antrag (extern)
+      B/pflichtenheft: na
+      "01/c4-systemkontext": required
+      "01/c4-container": required
+      "01/slos": optional
+      "01/bitv": optional
+      "07/dsfa":
+        status: conditional
+        condition: "datenklasse contains 'personenbezogen'"
+      "07/ozg": na
+      "07/bsi": optional
+      "07/iso27001": optional
+      "07/wibe": na
+      "07/roi": na
+      "08/testkonzept": required
+      "08/migration": na
+      "08/schulungskonzept": optional
+      "08/rollout-plan": optional
+      "08/betriebshandbuch": optional
+      "08/feedback-triage": optional
+      "09/roundtrip": required
+      "09/drift-detection": optional
+      "09/release-notes": required
+
+  # -------------------------------------------------------------------- SaaS
+  saas:
+    description: |
+      Kommerzielles SaaS (z.B. risk-hub). ROI-Case statt WiBe;
+      ISO 27001 statt BSI-Grundschutz; BITV wenn EU-Kunden.
+    pflicht:
+      A0/domain-glossar: required
+      A0/personas: required
+      A0/datenmodell: required
+      A0/status-maschinen: required
+      A0/validierungsregeln: required
+      A0/fehler-taxonomie: required
+      A0/konfigurations-modell: required
+      A/use-cases: required
+      A/anforderungs-katalog: required
+      A/coverage-matrix: required
+      A-api/openapi: required
+      A-api/asyncapi: optional
+      A-api/uebersicht: required
+      B/lastenheft: na  # statt: Product-Spec (extern in PM-Tool)
+      B/pflichtenheft: na
+      "01/c4-systemkontext": required
+      "01/c4-container": required
+      "01/slos": required
+      "01/bitv":
+        status: conditional
+        condition: "stakeholder_extern.region contains 'eu'"
+      "07/dsfa": required
+      "07/ozg": na
+      "07/bsi": na
+      "07/iso27001": required
+      "07/wibe": na
+      "07/roi": required
+      "08/testkonzept": required
+      "08/migration": optional
+      "08/schulungskonzept": required
+      "08/rollout-plan": required
+      "08/betriebshandbuch": required
+      "08/feedback-triage": required
+      "09/roundtrip": required
+      "09/drift-detection": required
+      "09/release-notes": required

--- a/policies/doc-profile.md
+++ b/policies/doc-profile.md
@@ -1,0 +1,79 @@
+# Policy: Doc-Profile
+
+**Trigger words:** doc-profile, dokumentationsprofil, lastenheft, pflichtenheft,
+projekttyp, doku-pflicht, dsfa-pflicht, ozg-pflicht, bsi-pflicht, wibe-pflicht,
+bitv-pflicht, iso27001, doku-katalog
+
+## Rule
+
+Jedes Klickdummy- oder Plattform-Repo, das eine **strukturierte Doku-Suite**
+(Lastenheft, Pflichtenheft, Compliance-Tiers, …) führt, **deklariert ein
+Projekttyp-Profil** in `docs/doc-profile.yaml`. Daraus folgt ein **fixer
+Pflicht-Tier-Katalog** (Plattform-Schema). Volle Begründung:
+`platform/docs/adr/ADR-218`.
+
+## Wann gilt das
+
+- **Vor** der Erstellung einer Dokumenten-Suite (Lastenheft, DSFA, BSI, WiBe,
+  …) — das Profil entscheidet, welche Tiers überhaupt Pflicht sind.
+- **Sobald** ein Repo `docs/doc-profile.yaml` enthält, wird es vom
+  Plattform-Check `doc_profile_check.sh` adversarial verifiziert.
+
+## Wann NICHT
+
+- Reine Code-Repos ohne Doku-Suite (z.B. Library, Tooling, MCP-Server) — kein
+  Profil nötig.
+- Wegwerf-Repos, Forks, Spike-Branches.
+- Repos, die ihre Doku komplett extern führen (z.B. Outline-only) — Profil
+  optional, nur sinnvoll als Inhaltsverzeichnis.
+
+## Vier Initial-Profile
+
+| Profil | Wann | Pflicht-Cores (Auszug) |
+|---|---|---|
+| `lra-pilot` | LRA / öffentliche Verwaltung mit Bürger-UI | DSFA + OZG + BSI + BITV |
+| `konzern-pilot` | DB / KRITIS-Konzern | BSI-KRITIS + WiBe + DSFA-Mitarbeiter |
+| `forschung` | TTZ / Förder-Projekte | Anonymisierung + Projekt-Antrag |
+| `saas` | kommerzielles SaaS | ROI + ISO 27001 + DSFA |
+
+Schema: `platform/docs/conventions/doc-profile-schema.yaml`.
+
+## Repo-Instanz (Beispiel meiki-hub)
+
+```yaml
+profile: lra-pilot
+projektphase: discovery       # discovery | spec | build | rollout | maintain
+auftraggeber: lra
+stakeholder_extern: [guenzburg, traunstein]
+vergabe:
+  modus: offen                # intern | evb-it | offen | freihaendig
+  wibe_pflicht: true
+```
+
+Override eines Pflicht-Tiers nur mit `reason`:
+
+```yaml
+overrides:
+  "07/wibe":
+    status: na
+    reason: "Investitionsvolumen unter Schwelle (Genehmigung 2026-05-Q2)"
+```
+
+## Profil-Wechsel = ADR
+
+Ein Repo wechselt **nicht ohne ADR** das Profil (Cross-Repo-Auswirkung auf
+Pflicht-Tiers, Compliance-Implikation). Phasen-Wechsel innerhalb eines
+Profils (`projektphase: discovery → spec → build`) ist **kein** ADR-Trigger.
+
+## Mechanik (SSoT)
+
+Diese Datei ist die versionierte SSoT. `~/.claude/policies/doc-profile.md` ist
+ein **Symlink** in den gepinnten platform-Worktree (kein Kopier-Sync) —
+`inject_policies.py`/`claude-policy` lesen den Symlink unverändert. Änderung
+nur per **platform-PR + Changelog-Bump**; der gepinnte Worktree zieht beim
+nächsten Refresh nach (ADR-209-Pattern).
+
+## Changelog
+
+- 2026-05-21: Initial. Aus ADR-218 abgeleitet (Trigger: User-Frage zur
+  projekt-typ-abhängigen Doku-Variation).

--- a/scripts/checks/doc_profile_check.sh
+++ b/scripts/checks/doc_profile_check.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# ADR-218 — Doc-Profile-Konformitätscheck.
+#
+# Invariante: Jedes Repo mit <repo>/docs/doc-profile.yaml deklariert ein
+# Plattform-bekanntes Profil. Aus Profil + Repo-Vars folgt ein Pflicht-Tier-
+# Katalog. Dieser Check verifiziert, dass alle required-Tiers existieren
+# und mind. den im Schema definierten Inhalt haben.
+#
+# Exit 0 = alle deklarierten Repos konform (oder kein Profil deklariert).
+# Exit 1 = mindestens ein Verstoß. Exit 2 = Setup-/Parsefehler.
+#
+# Repos ohne doc-profile.yaml werden ÜBERSPRUNGEN (kein Vacuous Pass —
+# sondern keine Pflicht). Migration ist repo-by-repo, kein Big-Bang.
+#
+# Reine bash + python3/pyyaml (kein yq).
+set -euo pipefail
+
+GITHUB_DIR="${GITHUB_DIR:-$HOME/github}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REGISTRY="$REPO_ROOT/registry/repos.yaml"
+SCHEMA="$REPO_ROOT/docs/conventions/doc-profile-schema.yaml"
+
+STRICT=0
+USE_REMOTE_MAIN=0
+SINGLE_REPO=""
+for arg in "$@"; do
+  case "$arg" in
+    --strict) STRICT=1 ;;
+    --main)   USE_REMOTE_MAIN=1 ;;
+    --repo=*) SINGLE_REPO="${arg#--repo=}" ;;
+    -h|--help)
+      cat <<EOF
+Usage: $0 [--strict] [--main] [--repo=<name>]
+  --strict   Repos ohne doc-profile.yaml als FAIL (Default: WARN).
+  --main     Quelle origin/main statt Working-Tree (CI-Sicht).
+  --repo=X   Nur Repo X prüfen statt alle aus registry/repos.yaml.
+EOF
+      exit 0 ;;
+  esac
+done
+
+[[ -f "$REGISTRY" ]] || { echo "FATAL: $REGISTRY fehlt"; exit 2; }
+[[ -f "$SCHEMA" ]]   || { echo "FATAL: $SCHEMA fehlt"; exit 2; }
+command -v python3 >/dev/null || { echo "FATAL: python3 nötig"; exit 2; }
+
+# --- Repo-Liste ermitteln ---------------------------------------------------
+if [[ -n "$SINGLE_REPO" ]]; then
+  REPOS=("$SINGLE_REPO")
+else
+  mapfile -t REPOS < <(python3 - "$REGISTRY" <<'PY'
+import sys, yaml
+doc = yaml.safe_load(open(sys.argv[1], encoding="utf-8")) or {}
+seen = set()
+for d in doc.get("domains", []) or []:
+    for s in d.get("systems", []) or []:
+        r = s.get("repo")
+        if r and r not in seen:
+            seen.add(r); print(r)
+PY
+  ) || { echo "FATAL: registry/repos.yaml nicht parsebar"; exit 2; }
+fi
+
+# --- Header -----------------------------------------------------------------
+printf '%-22s %-14s %-20s %s\n' "REPO" "PROFIL" "MISSING_TIERS" "STATUS"
+printf '%s\n' "--------------------------------------------------------------------------------------------"
+
+fail=0 warn=0 checked=0 skipped=0 conform=0
+
+# --- Pro Repo ---------------------------------------------------------------
+for repo in "${REPOS[@]}"; do
+  repo_dir="$GITHUB_DIR/$repo"
+  profile_file="$repo_dir/docs/doc-profile.yaml"
+
+  if [[ ! -d "$repo_dir" ]]; then
+    printf '%-22s %-14s %-20s %s\n' "$repo" "—" "—" "skipped: not-checked-out"
+    ((skipped++)) || true
+    continue
+  fi
+
+  if [[ ! -f "$profile_file" ]]; then
+    if [[ $STRICT -eq 1 ]]; then
+      printf '%-22s %-14s %-20s %s\n' "$repo" "—" "—" "FAIL: no doc-profile.yaml (--strict)"
+      ((fail++)) || true
+    else
+      printf '%-22s %-14s %-20s %s\n' "$repo" "—" "—" "skip: no doc-profile.yaml"
+      ((skipped++)) || true
+    fi
+    continue
+  fi
+
+  # --- Konformitäts-Check via Python ---------------------------------------
+  result=$(python3 - "$SCHEMA" "$profile_file" "$repo_dir" <<'PY'
+import sys, yaml, os, pathlib
+
+schema_p, profile_p, repo_dir = sys.argv[1:4]
+schema = yaml.safe_load(open(schema_p, encoding="utf-8"))
+prof   = yaml.safe_load(open(profile_p, encoding="utf-8"))
+
+profile_name = prof.get("profile")
+if not profile_name:
+    print(f"FAIL:no-profile-field:")
+    sys.exit(0)
+
+profiles = schema.get("profiles", {})
+if profile_name not in profiles:
+    print(f"FAIL:unknown-profile:{profile_name}")
+    sys.exit(0)
+
+tier_defs = schema.get("tiers", {})
+pflicht   = profiles[profile_name].get("pflicht", {})
+overrides = prof.get("overrides", {}) or {}
+
+# Conditional-Evaluator (sehr einfache Subset-Sprache).
+def eval_cond(cond: str, ctx: dict) -> bool:
+    # Unterstützt: 'a.b == "x"', 'a.b == true', 'a.b contains "x"'
+    if " == " in cond:
+        left, right = cond.split(" == ", 1)
+        val = ctx
+        for p in left.strip().split("."):
+            val = (val or {}).get(p) if isinstance(val, dict) else None
+        right = right.strip().strip("'\"")
+        if right == "true":  right_v = True
+        elif right == "false": right_v = False
+        else: right_v = right
+        return val == right_v
+    if " contains " in cond:
+        left, right = cond.split(" contains ", 1)
+        val = ctx
+        for p in left.strip().split("."):
+            val = (val or {}).get(p) if isinstance(val, dict) else None
+        right = right.strip().strip("'\"")
+        if isinstance(val, list): return right in val
+        if isinstance(val, str):  return right in val
+        return False
+    return False
+
+missing = []
+for tier, req in pflicht.items():
+    if isinstance(req, dict):
+        status = req.get("status", "required")
+        cond   = req.get("condition")
+        if status == "conditional" and cond and not eval_cond(cond, prof):
+            continue  # condition false → tier nicht pflicht
+        status_eff = "required" if status in ("required", "conditional") else status
+    else:
+        status_eff = req
+
+    if status_eff != "required":
+        continue
+
+    # Override aus Repo-Profil zulässt Wegfall mit Begründung
+    ov = overrides.get(tier)
+    if ov and isinstance(ov, dict) and ov.get("status") == "na" and ov.get("reason"):
+        continue
+
+    tdef = tier_defs.get(tier, {})
+    path = tdef.get("pflicht_pfad")
+    if not path:
+        continue
+    full = pathlib.Path(repo_dir) / path
+    if path.endswith("/"):
+        if not full.is_dir() or not any(full.iterdir()):
+            missing.append(tier)
+    else:
+        if not full.is_file():
+            missing.append(tier)
+
+if missing:
+    print(f"FAIL:missing-tiers:{profile_name}:{','.join(missing)}")
+else:
+    print(f"OK::{profile_name}:")
+PY
+  )
+
+  outcome="${result%%:*}"
+  rest="${result#*:}"
+  detail="${rest#*:}"
+  profile="${detail%%:*}"
+  miss="${detail#*:}"
+
+  case "$outcome" in
+    OK)
+      printf '%-22s %-14s %-20s %s\n' "$repo" "$profile" "—" "✓ konform"
+      ((conform++)) || true
+      ((checked++)) || true
+      ;;
+    FAIL)
+      reason="${rest%%:*}"
+      case "$reason" in
+        no-profile-field)
+          printf '%-22s %-14s %-20s %s\n' "$repo" "—" "—" "FAIL: doc-profile.yaml ohne 'profile:'-Feld"
+          ;;
+        unknown-profile)
+          printf '%-22s %-14s %-20s %s\n' "$repo" "$profile" "—" "FAIL: Profil unbekannt"
+          ;;
+        missing-tiers)
+          # Sanity-Cut: max 3 tiers in der Spalte zeigen
+          mshow="$miss"
+          if [[ ${#mshow} -gt 18 ]]; then mshow="${mshow:0:15}…"; fi
+          printf '%-22s %-14s %-20s %s\n' "$repo" "$profile" "$mshow" "FAIL: $miss"
+          ;;
+        *)
+          printf '%-22s %-14s %-20s %s\n' "$repo" "—" "—" "FAIL: $reason"
+          ;;
+      esac
+      ((fail++)) || true
+      ((checked++)) || true
+      ;;
+    *)
+      printf '%-22s %-14s %-20s %s\n' "$repo" "—" "—" "ERROR: unparsable result '$result'"
+      ((fail++)) || true
+      ;;
+  esac
+done
+
+# --- Summary ----------------------------------------------------------------
+printf '%s\n' "--------------------------------------------------------------------------------------------"
+printf 'Summary: %d checked · %d conform · %d failed · %d skipped (no doc-profile.yaml)\n' \
+  "$checked" "$conform" "$fail" "$skipped"
+
+if [[ $fail -gt 0 ]]; then
+  echo ""
+  echo "Hinweis: doc-profile.yaml-Schema siehe docs/conventions/doc-profile-schema.yaml"
+  echo "         ADR-218 für Konvention; --strict um Repos ohne Profil zu rügen."
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Was

Plattform-Konvention für **projekttyp-abhängige Doku-Suite**: Jedes Repo deklariert ein Profil; daraus folgt ein fixer Pflicht-Tier-Katalog.

Antwort auf User-Frage 2026-05-21 (Iter. 34):

> „dokumentation variiert je nach projekttyp/kunde — vorab festlegen oder parallel mit?"

→ **Beides**: Profil vorab, Inhalte parallel zum Klickdummy.

## Vier Initial-Profile

| Profil | Wann | Pflicht-Cores |
|---|---|---|
| `lra-pilot` | LRA / öffentliche Verwaltung mit Bürger-UI | DSFA + OZG + BSI + BITV |
| `konzern-pilot` | DB / KRITIS-Konzern | BSI-KRITIS + WiBe |
| `forschung` | TTZ / Förder-Projekte | Anonymisierung + Projekt-Antrag |
| `saas` | kommerzielles SaaS | ROI + ISO 27001 |

## Vier Artefakte (in diesem PR)

1. **`docs/adr/ADR-218-doc-profile-konvention.md`** — mit pre-integriertem advocatus-diabolus-Review
2. **`docs/conventions/doc-profile-schema.yaml`** — Tier-Inventar × Profil-Pflicht-Matrix mit conditional-Logik
3. **`scripts/checks/doc_profile_check.sh`** — externer Adversarial-Check (Pattern aus `klickdummy_registry.sh`)
4. **`policies/doc-profile.md`** — Symlink-Target für `~/.claude/policies/` (ADR-209-Pattern)

## Mechanik

- Repos **mit** `<repo>/docs/doc-profile.yaml` werden geprüft (Pflicht-Tiers vorhanden? Mindest-Inhalt?)
- Repos **ohne** Profil werden übersprungen (kein Vacuous Pass — sondern keine Pflicht; Migration repo-by-repo)
- `--strict` macht CI rot bei Repos ohne Profil
- Conditional-Tiers (`vergabe.modus == 'evb-it'`) werden je Repo evaluiert
- Profil-Wechsel = ADR-Trigger (Cross-Repo-Auswirkung)

## Smoke-Test

```bash
$ scripts/checks/doc_profile_check.sh --repo=meiki-hub
meiki-hub              —            —                  skip: no doc-profile.yaml
Summary: 0 checked · 0 conform · 0 failed · 1 skipped (no doc-profile.yaml)
```

## Follow-Up (separate PRs)

1. **meiki-hub** — `docs/doc-profile.yaml` (profile: `lra-pilot`, vergabe.modus: `offen`) + Tier-A0-Skeleton
2. **bahn-sqf/sqf-hub** + **pg-hub** — `konzern-pilot`
3. **ttz-hub** — `forschung`
4. **risk-hub** — `saas`

## Refs

- platform:ADR-211 Klickdummy-Rahmen (Spec-Basis Tier A0/A)
- platform:ADR-213 Cross-Repo-ADR-Ref-Format
- platform:ADR-207 Cross-Repo-Doku-Konvention (orthogonal)
- platform:ADR-209 Policy-Auto-Sync-on-Merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)