### PR TITLE
fix(ci): install-iil-packages installiert iil-platform-context, nicht platform-context

### DIFF
--- a/.github/actions/install-iil-packages/action.yml
+++ b/.github/actions/install-iil-packages/action.yml
@@ -58,13 +58,19 @@ runs:
         fi
 
     - name: Install platform-context[testing] (ADR-058)
+      # PyPI-Naming: das echte Paket heißt `iil-platform-context`.
+      # `platform-context` (ohne iil-Präfix) ist auf PyPI ein fremder Squatter
+      # in 0.5.0 und führt zu "Could not find version" + ImportError in CI.
+      # Fallback-Chain matches Architecture-Guardian Step in _ci-python.yml.
       if: ${{ inputs.platform_context_version != '' }}
       shell: bash
       run: |
         if [ -d "vendor/platform_context" ]; then
           pip install -e "vendor/platform_context[testing]"
         else
-          pip install "platform-context[testing]${{ inputs.platform_context_version }}" || true
+          pip install "iil-platform-context[testing]${{ inputs.platform_context_version }}" \
+            || pip install "platform-context[testing]${{ inputs.platform_context_version }}" \
+            || true
         fi
 
     - name: Install additional vendor packages


### PR DESCRIPTION
## Summary

- Composite action `install-iil-packages` zog bisher das falsche PyPI-Paket
  (`platform-context`, fremder Squatter in 0.5.0) statt unseres
  `iil-platform-context` (Versionen 0.5.1, 0.7.0 verfügbar).
- Fallback-Chain eingezogen (`iil-platform-context` → `platform-context` → `|| true`),
  identisch zur bereits korrekten Logik im Architecture-Guardian-Step
  (`_ci-python.yml:510`).
- Damit wird primär das korrekte Paket gezogen; Legacy-Pfad bleibt als
  Schritt-2-Fallback erhalten.

## Wer profitiert

Alle Konsumenten-Repos, die diesen Reusable-Workflow nutzen — z.B.
ausschreibungs-hub PR #57, deren Unit+Integration-CI seit der Pilot-Phase
mit folgendem Symptom rot war:

```
ERROR: Could not find a version that satisfies the requirement
       platform-context>=0.7.0 (from versions: 0.5.0)
ImportError: No module named 'decouple'
```

Reference: drift memory `platform-context-healthbypass-drift` —
"fix the upstream package, not per-repo workarounds".

## Test plan

- [x] Lokale Verifikation: \`pip index versions iil-platform-context\`
      zeigt 0.5.1 + 0.7.0 auf PyPI verfügbar (default `>=0.7.0` greift).
- [ ] CI auf diesem Branch: gleicher Workflow läuft via self-call → sollte
      grün durchgehen (oder zumindest nicht mehr am Package-Name scheitern).
- [ ] Re-Trigger CI an ausschreibungs-hub PR #57 nach Merge → Unit +
      Integration sollten primären Symptom-Fehler nicht mehr werfen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)