### PR TITLE
feat(ci): postgres_image input — opt-in pgvector ohne Default-Wechsel

### DIFF
--- a/.github/workflows/_ci-python.yml
+++ b/.github/workflows/_ci-python.yml
@@ -80,6 +80,11 @@ on:
         required: false
         default: '.'
         type: string
+      postgres_image:
+        description: 'Postgres service image. Override to "pgvector/pgvector:pg16" for repos that need the vector extension (aifw, ausschreibungs-hub, bfagent, iil-enrichment).'
+        required: false
+        default: 'postgres:16-alpine'
+        type: string
 
 jobs:
   qm-gate:
@@ -266,7 +271,7 @@ jobs:
     if: ${{ !inputs.skip_tests }}
     services:
       postgres:
-        image: postgres:16-alpine
+        image: ${{ inputs.postgres_image }}
         env:
           POSTGRES_USER: test_user
           POSTGRES_PASSWORD: test_pass
@@ -326,7 +331,7 @@ jobs:
     continue-on-error: true
     services:
       postgres:
-        image: postgres:16-alpine
+        image: ${{ inputs.postgres_image }}
         env:
           POSTGRES_USER: test_user
           POSTGRES_PASSWORD: test_pass
@@ -445,7 +450,7 @@ jobs:
     if: ${{ inputs.run_contract_tests && !inputs.skip_tests }}
     services:
       postgres:
-        image: postgres:16-alpine
+        image: ${{ inputs.postgres_image }}
         env:
           POSTGRES_USER: test_user
           POSTGRES_PASSWORD: test_pass


### PR DESCRIPTION
## Summary

- Neuer Workflow-Input \`postgres_image\` (default \`postgres:16-alpine\`)
- 3 hartcodierte Image-Strings in test-unit / test-integration / test-contract durch \`\${{ inputs.postgres_image }}\` ersetzt
- Konsumenten die pgvector brauchen (aifw, ausschreibungs-hub, bfagent, iil-enrichment) opten in via \`with: postgres_image: \"pgvector/pgvector:pg16\"\`

## Trigger

ausschreibungs-hub PR #57 (Pilot 1 submission_workflow) deckte das Problem auf: Integration-Tests scheitern bei \`CREATE EXTENSION vector\`, weil das CI-Postgres-Image keine pgvector-Extension enthält.

## Warum nicht Default-Wechsel

21+ Konsumenten-Repos nutzen \`_ci-python.yml@main\`. Nur 4 davon nutzen pgvector tatsächlich. Hartes Umstellen würde 15+ Repos ein ~65 MB größeres Image pullen lassen für nichts.

## Backwards-Kompatibilität

Default unverändert → kein bestehender CI-Lauf bricht.

## Test plan

- [x] Workflow-Datei syntaktisch valide (YAML-Parser)
- [ ] Self-CI auf diesem Branch grün (Platform-eigene context-review + guardian)
- [ ] Nach Merge: ausschreibungs-hub als Erst-Konsument testen (separates PR \`with: postgres_image: pgvector/pgvector:pg16\`)

## Follow-up

- aifw, bfagent, iil-enrichment: Owner sollten in ihren ci.yml den Input ergänzen, sobald pgvector-Integration-Tests aktiv werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)