### PR TITLE
registry: 3 fehlende Klickdummy-Repos für ADR-211 C1-Coverage

### DIFF
--- a/registry/repos.yaml
+++ b/registry/repos.yaml
@@ -108,6 +108,17 @@ domains:
         tenancy_mode: none  # MCP servers, per-user auth via MCP protocol
         coverage_threshold: 80
 
+      - name: nl2iot-hub
+        repo: nl2iot-hub
+        description: Natural-language-to-IoT — Developer Cockpit
+        github: achimdehnert/nl2iot-hub
+        deployed: false
+        type: python
+        lifecycle: experimental
+        tenancy_mode: none
+        coverage_threshold: 60
+        notes: "Klickdummy-konform (platform:ADR-211): docs/adr/ADR-002 (Rev-11 class: spec-demo). klickdummy.class-Registry-Wert offen (Rev-9/11-Migration)."
+
   - name: Content & Publishing
     systems:
       - name: bfagent
@@ -143,6 +154,19 @@ domains:
         dockerfile: docker/app/Dockerfile
         compose: docker-compose.prod.yml
         coverage_threshold: 60
+
+      - name: writing-hub
+        repo: writing-hub
+        description: Eigenständige Autorenplattform (Django 5.2, PostgreSQL 15)
+        github: achimdehnert/writing-hub
+        deployed: false
+        type: django
+        lifecycle: experimental
+        tenancy_mode: none
+        dockerfile: Dockerfile
+        compose: docker-compose.prod.yml
+        coverage_threshold: 60
+        notes: "Klickdummy-konform (platform:ADR-211): docs/adr/ADR-180 (Rev-11 class: spec-demo). klickdummy.class-Registry-Wert offen (Rev-9/11-Migration)."
 
   - name: Story & Travel
     systems:
@@ -286,6 +310,19 @@ domains:
         lifecycle: active
         tenancy_mode: none  # library, no runtime tenancy
         coverage_threshold: 80
+
+      - name: ausschreibungs-hub
+        repo: ausschreibungs-hub
+        description: KI-gestützte Ausschreibungs- und Angebotsplattform für KMU, Bau, Ingenieurbüros
+        github: achimdehnert/ausschreibungs-hub
+        deployed: false
+        type: django
+        lifecycle: experimental
+        tenancy_mode: none  # django-tenants-Pivot WIP (siehe Repo)
+        dockerfile: Dockerfile
+        compose: docker-compose.prod.yml
+        coverage_threshold: 60
+        notes: "Klickdummy-konform (platform:ADR-211): ADR-001 (mock) + ADR-002 (spec-demo). klickdummy.class-Registry-Wert offen (Rev-9/11-Migration)."
 
   - name: Analytics & Data
     systems:


### PR DESCRIPTION
## Summary
- `ausschreibungs-hub`, `writing-hub`, `nl2iot-hub` haben einen `klickdummy/`-Pfad **und** ein konformes Klickdummy-ADR (`conforms_to: platform:ADR-211`), standen aber nicht in `registry/repos.yaml`.
- Dadurch waren sie für `scripts/checks/klickdummy_registry.sh` (ADR-211 **C1 / SF1**) **unsichtbar** — die rote/grüne Ampel deckte sie nicht ab.
- Nach Aufnahme ist C1 mit den dreien grün (4/4 konform: + risk-hub).

## ADR-Belege je Repo
| Repo | Klickdummy-ADR | Rev-11 class |
|---|---|---|
| ausschreibungs-hub | ADR-001 + ADR-002 | mock + spec-demo |
| writing-hub | ADR-180 | spec-demo |
| nl2iot-hub | ADR-002 | spec-demo |

## Bewusste Nicht-Änderungen
- **`klickdummy.class`-Registry-Wert offen gelassen** — kein Repo auf `main` hat ihn aktuell befüllt; das Rev-9-Enum (`mock-prototype`/`demo-render`) vs. die Rev-11-4-Pattern der ADRs ist noch im Soft-Migrate (ADR-211 §F12). Befüllung als Folge-PR, wenn die Taxonomie fixiert ist.
- **Skript unangetastet** — `klickdummy_registry.sh` hat auf `main` bereits den `--main`-Modus; keine Logik-Änderung nötig.
- **Andere Orgs draußen** — `bahn-sqf` (sqf-hub, pg-hub) und `meiki-lra` bleiben per S1-Geltungsbereich Repo-CI-Verantwortung, nicht Teil der achimdehnert-Registry.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — repos.yaml parst (18 systems)
- [x] `bash scripts/checks/klickdummy_registry.sh` → ✓ C1 GRÜN, 4/4 konform, exit 0
- [ ] CI-Coverage-Gate / repo_checker für die 3 neuen Repos beobachten (lifecycle=experimental, coverage_threshold=60 gesetzt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)