### PR TITLE
feat(workflows): /issues-offen — gated single-repo open-issue worker

### DIFF
--- a/.windsurf/workflows/issues-offen.md
+++ b/.windsurf/workflows/issues-offen.md
@@ -1,0 +1,98 @@
+---
+description: Offene GitHub-Issues EINES Repos triagieren und gate-freie selbst abarbeiten (1 PR/Issue, Stopp bei Judgment/Infra)
+mode: write
+---
+
+# /issues-offen — Open-Issue Worker (single repo, gated)
+
+> **Zweck:** Live die offenen Issues eines Repos von GitHub holen, triagieren
+> und die *gate-freien* selbst erledigen — ein PR pro Issue, harter Stopp bei
+> Judgment/Infra. Frischer, idempotenter Lauf → schedule-tauglich
+> (`/schedule /issues-offen <repo>`), KEINE Endlos-Session.
+>
+> **Wann:** "Erledige, was in `<repo>` offen ist", ohne vorab geplanten Handoff.
+> **Wann NICHT:** Es gibt einen dokumentierten Handoff/NÄCHSTE-AKTIONEN →
+> `/issues-abarbeiten`. Multi-Repo `auto`-Queue über Nacht → `/process-agent-queue`.
+> **Abgrenzung:** `/issues-abarbeiten` setzt einen *geplanten* Stand fort (Quelle =
+> Memory-Handoff). `/issues-offen` startet *frisch aus `gh issue list`* (Quelle =
+> GitHub) und triagiert selbst.
+
+## Verwendung
+
+```
+/issues-offen <repo>          # z.B. /issues-offen risk-hub
+/issues-offen                 # ohne Arg: aktuelles Repo aus cwd
+```
+
+`$ARGUMENTS` = Repo-Kurzname. Default: aktuelles Repo.
+
+## Step 0: Repo-Kontext (NICHT hardcoden)
+
+1. Repo bestimmen: `$ARGUMENTS` → `<repo>`; sonst Basename von `git rev-parse --show-toplevel`.
+2. Owner/Org NICHT raten — aus dem Repo lesen:
+   `gh repo view --json nameWithOwner -q .nameWithOwner` im Zielrepo
+   (`~/github/<repo>`), bzw. `project-facts.md`. Niemals `achimdehnert` o.ä. hardcoden.
+3. pgvector-Tunnel optional; dieser Workflow braucht ihn nicht.
+
+## Phase 1: Holen + Triage (read-only)
+
+1. `gh issue list --repo <owner>/<repo> --state open --limit 50 --json number,title,labels,milestone`
+2. Jedes Issue in genau einen Eimer einsortieren:
+
+   **DO-NOW (gate-frei, selbst erledigen)** — wenn ALLE zutreffen:
+   - Label `ai-assignable` ODER `automated` ODER (`type:bug` + `complexity:simple`)
+     ODER `documentation`/`docu-update`
+   - KEIN `P1`/`P0`/`blocked`/`needs-discussion`/`security`
+   - Titel/Body enthält KEINE Judgment-/Infra-Marker (siehe STOP)
+
+   **STOP (nur listen, NICHT anfassen)** — sobald EINES zutrifft:
+   - ADR-Bezug, Migration, Deploy/Infra, Secrets/Security, DSGVO-Wertung
+   - "architektur", "cross-repo", Schema-/Datenmodell-Entscheidung
+   - `P1`/`P0`, oder Label `needs-discussion`/`blocked`
+   - Issue ohne klaren, umrissenen Scope (Diskussion/Konzept)
+
+   **SKIP** — kein actionable Code (Frage, Duplikat, `wontfix`, fremd-assigned).
+3. DO-NOW nach Priorität ordnen (P2 > P3 > unlabelled), Cap: **max 5 Issues/Lauf**.
+4. Plan als Tasks materialisieren (`TaskCreate`), ein Task pro DO-NOW-Issue.
+
+## Phase 2: Guardrails (vor JEDER Aktion)
+
+1. **Kein Duplikat:** `gh pr list --repo <owner>/<repo> --search "<#issue>"` —
+   existiert schon ein PR/Branch zum Issue → nur fortführen, NIE neu anlegen.
+2. **Branch:** `fix/<issue>-<slug>` bzw. `feat/<issue>-<slug>` aus aktuellem `main`.
+3. **ScopeLock:** nur Dateien anfassen, die das Issue benennt/impliziert. Bei
+   Ausweitung auf fremde Bereiche → STOP, Issue als STOP umklassifizieren.
+
+## Phase 3: Pro DO-NOW-Issue
+
+1. Minimal umsetzen (kein Refactor drumherum), Konventionen aus `project-facts.md`.
+2. Tests für neue Funktion mitliefern; vorhandene Tests/Lint laufen lassen.
+3. **Genau ein PR pro Issue**, Body endet mit `Closes #<n>`. Kein Merge, kein
+   Force-Push.
+4. Erste fehlschlagende Aktion (Test/Lint/Build rot, das du nicht trivial fixt)
+   → STOP für dieses Issue, als Kommentar am Issue vermerken, nächstes Issue.
+
+## Phase 4: Report (immer, am Ende)
+
+```
+/issues-offen <owner>/<repo> — <datum>
+DONE:    #<n> <titel> → PR #<p>   (xN)
+STOP:    #<n> <titel> — <grund: ADR/Infra/P1/Scope>   (xM)
+SKIP:    #<n> <titel> — <grund>   (xK)
+Cap erreicht: <ja/nein>  | Nächster Lauf nimmt den Rest.
+```
+
+## Anti-Patterns
+
+- ❌ Mehr als 1 PR pro Issue, oder PR ohne `Closes #n`.
+- ❌ Ein STOP-Issue trotzdem anfassen (ADR/Migration/Infra/Security/P1).
+- ❌ ScopeLock verletzen (fremde Dateien "gleich mit" ändern).
+- ❌ Mergen, Force-Push, Branch löschen, oder rote CI ignorieren.
+- ❌ Owner/Org/Pfade hardcoden statt aus dem Repo lesen.
+- ❌ Endlos-Loop in einer Session — Lauf endet nach Cap; Wiederholung via `/schedule`.
+
+## Changelog
+
+- 2026-05-28: Initial. Geschwister von `/issues-abarbeiten` ohne Handoff-Pflicht;
+  Quelle = `gh issue list`. Gate-Signale an risk-hub-Labels orientiert
+  (`ai-assignable`, `complexity:simple`). Schedule-tauglich (frische Läufe).


### PR DESCRIPTION
## Why

We want "erledige die offenen Issues" for a single repo, runnable on a schedule, without hand-crafting a per-issue prompt. The existing `/issues-abarbeiten` deliberately refuses generic open-issue work (it's a *handoff resumer*), and `/process-agent-queue` is the multi-repo `labels:auto` over-night processor. This fills the gap with a **gated, single-repo** worker.

## What

`/issues-offen <repo>` (default: current repo):
1. **Triage** — pulls open issues via `gh issue list` and buckets each into **DO-NOW** (gate-free: `ai-assignable` / `complexity:simple` / `documentation`+`automated`), **STOP** (ADR / migration / infra / security / `P1` / unclear scope), or **SKIP**.
2. **Work** the gate-free ones — one PR per issue (`Closes #n`), ScopeLock to the issue's files, dup-check via `gh pr list`, **cap 5/run**, stop on first red CI it can't trivially fix.
3. **Report** done / stopped / skipped.

**Fresh + idempotent** → meant for `/schedule /issues-offen <repo>` (fresh context each run), explicitly **not** a permanently-open session — that recreates the giant-context cost pattern surfaced in the recent spend audit (one session = 2509 calls / \$2294).

Conforms to `claude-skills` policy: `mode: write`, Step 0 repo-context (no hardcoded owner/org), Anti-Patterns, Changelog, When/When-NOT.

## Dogfood — triage on `risk-hub` (read-only Phase 1)

`gh issue list --repo achimdehnert/risk-hub --state open` → applying the triage rules:

| Issue | Labels | Bucket | Reason |
|---|---|---|---|
| #41 DSFA-Warnung styling | P3, ai-assignable, bug, simple | **DO-NOW** | ai-assignable + simple bug |
| #40 Empty-State HTMX | P2, ai-assignable, bug, simple | **DO-NOW** | ai-assignable + simple bug |
| #39 Formularlabels DE | P2, ai-assignable, bug, simple | **DO-NOW** | ai-assignable + simple bug |
| #19/#20 docs/ anlegen | documentation, docu-update, automated | **DO-NOW** | docu + automated |
| #124 Klausel-1-Migration (ADR-212) | — | **STOP** | migration + ADR |
| #29 Jahresbericht-Generator | enhancement | **STOP** | large feat, unclear scope |
| #18 evaluate uv vs requirements | dependencies, chore | **STOP** | "evaluate" = judgment |

→ Cap 5: first run would do #41, #40, #39, #19, #20; #124/#29/#18 correctly held. Demonstrates the gate logic separates mechanical work from judgment/infra.

## Test plan

- [ ] `/issues-offen risk-hub` → triage matches the table above; only DO-NOW get PRs
- [ ] STOP issues (#124 migration) are listed, never touched
- [ ] Re-run → dup-check skips issues that already have a PR (idempotent)
- [ ] `/schedule /issues-offen risk-hub` runs fresh, posts the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)