### PR TITLE
ci: run_migrations-Input für django-tenants (Unit-Tests mit Migrationen)

### DIFF
--- a/.github/workflows/_ci-python.yml
+++ b/.github/workflows/_ci-python.yml
@@ -60,6 +60,11 @@ on:
         required: false
         default: 'auto'
         type: string
+      run_migrations:
+        description: 'Run unit tests WITH migrations (drop --no-migrations). Required for django-tenants repos — Tenant-Schema-Tabellen entstehen nur per migrate_schemas.'
+        required: false
+        default: false
+        type: boolean
       ruff_version:
         description: 'Pinned ruff version to install (e.g. ==0.15.4). Empty = latest. Pin to match pyproject.toml required-version.'
         required: false
@@ -304,15 +309,19 @@ jobs:
           POSTGRES_HOST: localhost
         run: |
           WORKERS=${{ inputs.pytest_workers }}
+          # django-tenants-Repos brauchen echte Migrationen (Tenant-Schema-Tabellen
+          # entstehen nur per migrate_schemas) → --no-migrations nur, wenn run_migrations=false.
+          MIGRATIONS_FLAG="--no-migrations"
+          if [ "${{ inputs.run_migrations }}" = "true" ]; then MIGRATIONS_FLAG=""; fi
           if [ "$WORKERS" = "1" ] || [ "$WORKERS" = "0" ]; then
             pytest -m "not integration and not contract and not slow" \
-              --no-migrations \
+              $MIGRATIONS_FLAG \
               --cov \
               --cov-report=xml:coverage-unit.xml \
               --cov-report=term-missing
           else
             pytest -m "not integration and not contract and not slow" \
-              --no-migrations \
+              $MIGRATIONS_FLAG \
               --cov \
               --cov-report=xml:coverage-unit.xml \
               --cov-report=term-missing \


### PR DESCRIPTION
## Problem

`_ci-python.yml` fährt Unit-Tests mit `--no-migrations`. Das ist **inkompatibel mit django-tenants**: TENANT_APP-Tabellen werden nur per `migrate_schemas` in Tenant-Schemas angelegt — unter `--no-migrations` bleibt das Tenant-Schema leer → `relation "..._portal" does not exist`. Deshalb nutzt travel-beat das Workflow gar nicht erst.

## Fix

Neuer opt-in-Input **`run_migrations`** (boolean, default `false` → kein Verhaltenswechsel für Bestandsrepos). Bei `true` entfällt `--no-migrations` im Unit-Test-Step (beide Worker-Pfade).

## Erstanwender

ausschreibungs-hub (Pilot 2, django-tenants Schema-Isolation) — setzt `run_migrations: true` + `pytest_workers: "1"`; entblockt dort die CI / PR #60.

## Test plan

- [ ] ausschreibungs-hub CI mit `run_migrations: true` → Unit Tests grün (Tenant-Tabellen vorhanden)
- [x] Default `false` unverändert → `--no-migrations` wie bisher

🤖 Generated with [Claude Code](https://claude.com/claude-code)