### PR TITLE
feat(ci): add lint_soft_fail input to _ci-python.yml

### DIFF
--- a/.github/workflows/_ci-python.yml
+++ b/.github/workflows/_ci-python.yml
@@ -90,6 +90,11 @@ on:
         required: false
         default: 'postgres:16-alpine'
         type: string
+      lint_soft_fail:
+        description: 'Make Lint & Format non-blocking (job runs + annotates but does not fail the workflow). For consumers that gate deploy on secrets/tests, not lint (mcp-hub #78). Default false = lint hard-fails.'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   qm-gate:
@@ -115,6 +120,10 @@ jobs:
   lint:
     name: "Lint & Format"
     runs-on: ${{ inputs.runs_on }}
+    # When lint_soft_fail=true the job still runs + annotates, but a failure
+    # does not fail the workflow (so consumers can gate deploy on secrets/tests
+    # without lint debt blocking them — mcp-hub #78). gitleaks stays hard.
+    continue-on-error: ${{ inputs.lint_soft_fail }}
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python


### PR DESCRIPTION
Enables **mcp-hub #78** Option 3 (gate deploy on secrets/tests, not lint).

## What
- New `workflow_call` input `lint_soft_fail` (boolean, **default false**).
- `lint` job gets `continue-on-error: ${{ inputs.lint_soft_fail }}` — when true, Lint & Format still runs and annotates but does **not** fail the workflow.

## Why
mcp-hub's `deploy.yml` (push→main) has never deployed: `_ci-python.yml`'s aggregate result is `failure` whenever Lint **or** gitleaks fails, and `deploy: if ci==success||skipped` then skips. The repo wants deploy gated on **secrets/tests** (gitleaks stays hard) but **not** on lint debt. Since gitleaks is centralized here (no per-repo duplication, #191/#198), the knob belongs in the shared workflow.

## Blast radius
**None for existing consumers** — default `false` preserves current hard-lint behavior. Only repos that opt in (`lint_soft_fail: true`) change. `architecture-guardian` (`needs: [lint]`) still runs (continue-on-error doesn't block dependents).

## Consumer
mcp-hub `deploy.yml` will pass `lint_soft_fail: true` (separate PR — merge this first, else that workflow errors on the unknown input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)