### PR TITLE
feat(tools): agent-handover --ref + Inject-Modus (Bestand erhalten)

### DIFF
--- a/tools/agent-handover/README.md
+++ b/tools/agent-handover/README.md
@@ -8,26 +8,34 @@ Orchestrator), nach der `new-github-project`-Vorlage.
 
 - **Anker werden gezogen, nicht getippt** (git/gh/Repo-Introspektion) → driftfrei.
 - **Auto-Block zwischen Markern** (`AGENT_HANDOVER:AUTO START`…`END`): Re-Runs ersetzen
-  nur diesen Block; von Hand gepflegte Abschnitte (Offene Aufgaben, Bekannte Probleme,
-  Wichtige Befehle) bleiben erhalten.
+  nur diesen Block; von Hand gepflegte Abschnitte bleiben erhalten.
 - **Uniform über alle Repos** — keine ttz/meiki-Sonderbehandlung (souveränitäts-neutrale
   Doku-/Metadaten-Arbeit; etwaige Sonderlogik ist Zukunfts-Option). `--no-orchestrator`
   für Repos ohne Orchestrator-Bindung (z. B. meiki-hub).
 
+## `--ref` (wichtig für Fremd-Repos)
+
+Ohne `--ref` liest der Generator den **Working-Tree** — steht der auf einem Feature-Branch
+oder ist dirty, wären die Anker **stale**. Für Repos, in denen man nicht selbst arbeitet,
+daher `--ref origin/main`: liest Anker **read-only aus dem Ref**, ohne den Working-Tree
+anzufassen (Branch-Anker = `main`, Working-Tree-Anker = `n/a (Snapshot)`).
+
+```bash
+git -C ~/github/<repo> fetch origin main -q
+python3 tools/agent-handover/generate.py ~/github/<repo> --ref origin/main
+```
+
 ## Usage
 
 ```bash
-# Dry-Run (Default) — gibt die generierte Datei auf stdout aus
-python3 tools/agent-handover/generate.py ~/github/<repo>
+# Dry-Run (Default) — generierte Datei auf stdout
+python3 tools/agent-handover/generate.py ~/github/<repo> [--ref origin/main]
 
 # Schreiben
-python3 tools/agent-handover/generate.py ~/github/<repo> --write
-
-# Bestandsdatei OHNE Marker überschreiben (Pilot-Migration)
-python3 tools/agent-handover/generate.py ~/github/<repo> --write --force
+python3 tools/agent-handover/generate.py ~/github/<repo> --ref origin/main --write
 
 # Repo ohne Orchestrator-Bindung
-python3 tools/agent-handover/generate.py ~/github/<repo> --write --no-orchestrator
+python3 tools/agent-handover/generate.py ~/github/<repo> --ref origin/main --write --no-orchestrator
 ```
 
 ## Verhalten bei bestehender Datei
@@ -36,10 +44,14 @@ python3 tools/agent-handover/generate.py ~/github/<repo> --write --no-orchestrat
 |---|---|
 | keine Datei | neu erstellt (Auto-Block + Platzhalter-Hand-Abschnitte) |
 | Datei **mit** Markern | nur Auto-Block ersetzt, Hand-Abschnitte erhalten |
-| Datei **ohne** Marker | WARN + Dry-Run-Vorschau; Überschreiben nur mit `--force` |
+| Datei **ohne** Marker | **Inject:** Auto-Block nach dem H1 eingefügt, restliches Dokument vollständig erhalten |
+| `--force` | bestehende Datei mit frischer Vorlage **überschrieben** (Bestand verworfen — bewusst nutzen) |
+
+Der Inject-Modus erhält handkuratierte Legacy-Handover-Docs (Repo-Zweck, Stack, Regeln …)
+vollständig und fügt nur den Anker-/SSoT-Block oben hinzu.
 
 ## Rollout
 
-Gedacht für den plattformweiten AGENT_HANDOVER-Anker-Rollout (Batch-weise, z. B. erst
-aktive Django-Hubs). Pro Repo ein additiver PR mit gezogenen Ankern; Arbeits-Abschnitte
+Plattformweiter AGENT_HANDOVER-Anker-Rollout, Batch-weise (z. B. erst aktive Django-Hubs).
+Pro Repo ein additiver PR; Anker via `--ref origin/main` gezogen; Arbeits-Abschnitte
 bleiben „vom Bearbeiter zu füllen".

--- a/tools/agent-handover/generate.py
+++ b/tools/agent-handover/generate.py
@@ -4,18 +4,26 @@ verifizierbaren Ankern + SSoT-Zeigern (platform:new-github-project-Vorlage).
 
 Prinzip: Anker werden GEZOGEN (git/gh/Repo-Introspektion), nicht getippt —
 daher driftfrei. Der Auto-Block liegt zwischen Markern; Re-Runs ersetzen NUR
-diesen Block, von Hand gepflegte Abschnitte (Offene Aufgaben, Bekannte
-Probleme, Wichtige Befehle) bleiben erhalten.
+diesen Block, von Hand gepflegte Abschnitte bleiben erhalten.
 
 Uniform über alle Repos (keine ttz/meiki-Sonderbehandlung — souveränitäts-
 neutrale Doku-/Metadaten-Arbeit).
 
+`--ref` liest die Anker read-only aus einem Git-Ref (z. B. `origin/main`),
+OHNE den (evtl. dirty / Feature-Branch-) Working-Tree anzufassen. Pflicht für
+Repos, in denen man nicht selbst arbeitet, sonst sind die Anker stale.
+
+Verhalten bei bestehender docs/AGENT_HANDOVER.md:
+  - mit AUTO-Markern   → nur Auto-Block ersetzt (Hand-Abschnitte bleiben)
+  - ohne Marker        → Auto-Block wird nach dem H1 EINGEFÜGT, restliches
+                         Dokument bleibt vollständig erhalten (Inject-Modus)
+  - keine Datei        → aus Vorlage neu erstellt
+  - --force            → bestehende Datei mit frischer Vorlage ÜBERSCHREIBEN
+                         (Bestand verworfen; nur bewusst nutzen)
+
 Usage:
-  generate.py [REPO_PATH] [--write] [--force] [--no-orchestrator]
-  Default: Dry-Run (Ausgabe auf stdout). REPO_PATH default = cwd.
-  --write           Datei schreiben.
-  --force           bestehende Datei OHNE Marker überschreiben (sonst nur Warnung).
-  --no-orchestrator SSoT-Zeiger auf Orchestrator weglassen (z. B. meiki-hub, nicht gebunden).
+  generate.py [REPO_PATH] [--ref origin/main] [--write] [--force] [--no-orchestrator]
+  Default: Dry-Run (stdout). REPO_PATH default = cwd.
 """
 import argparse
 import datetime
@@ -27,6 +35,9 @@ import sys
 
 AUTO_START = "<!-- AGENT_HANDOVER:AUTO START — generiert via platform/tools/agent-handover, nicht von Hand editieren -->"
 AUTO_END = "<!-- AGENT_HANDOVER:AUTO END -->"
+INJECT_NOTE = "> _Anker-Block unten ist generiert (`platform/tools/agent-handover`); Re-Runs ersetzen nur den Block zwischen den Markern. Restliches Dokument von Hand gepflegt._"
+
+PF_CANDIDATES = ("project-facts.md", ".windsurf/rules/project-facts.md", "docs/project-facts.md")
 
 
 def run(cmd, cwd):
@@ -37,12 +48,17 @@ def run(cmd, cwd):
         return None
 
 
-def find_project_facts(root):
-    for p in ("project-facts.md", ".windsurf/rules/project-facts.md", "docs/project-facts.md"):
-        fp = os.path.join(root, p)
-        if os.path.isfile(fp):
-            return fp
-    return None
+def read_project_facts(root, ref):
+    for p in PF_CANDIDATES:
+        if ref:
+            c = run(["git", "show", "{0}:{1}".format(ref, p)], root)
+            if c is not None:
+                return p, c
+        else:
+            fp = os.path.join(root, p)
+            if os.path.isfile(fp):
+                return p, open(fp, encoding="utf-8").read()
+    return PF_CANDIDATES[0], ""
 
 
 def pf_value(text, key):
@@ -50,53 +66,59 @@ def pf_value(text, key):
     return m.group(1).strip() if m else None
 
 
-def build_auto(root, today, no_orch):
-    pf_path = find_project_facts(root)
-    pf = open(pf_path, encoding="utf-8").read() if pf_path else ""
+def build_auto(root, today, no_orch, ref):
+    pf_rel, pf = read_project_facts(root, ref)
     repo_name = pf_value(pf, "REPO_NAME") or os.path.basename(root)
     owner = pf_value(pf, "REPO_OWNER") or "achimdehnert"
     adr_path = pf_value(pf, "ADR_PATH") or "docs/adr"
-    pf_rel = os.path.relpath(pf_path, root) if pf_path else "project-facts.md"
 
-    branch = run(["git", "branch", "--show-current"], root) or "main"
-    last = run(["git", "log", "-1", "--format=%h %s"], root) or "?"
+    if ref:
+        branch = ref.split("/")[-1]
+        last = run(["git", "log", "-1", "--format=%h %s", ref], root) or "?"
+        clean = "n/a (Snapshot von {0})".format(ref)
+        manage = run(["bash", "-c", "git ls-tree -r --name-only {0} | grep -E '(^|/)manage\\.py$' | head -1".format(ref)], root)
+        log5 = run(["git", "log", "-5", "--format=%ad %s", "--date=short", ref], root) or ""
+        adr_listing = run(["bash", "-c", "git ls-tree --name-only {0}:{1} 2>/dev/null".format(ref, adr_path)], root) or ""
+        adr_files = [l for l in adr_listing.splitlines() if re.match(r"ADR-\d+", l)]
+    else:
+        branch = run(["git", "branch", "--show-current"], root) or "main"
+        last = run(["git", "log", "-1", "--format=%h %s"], root) or "?"
+        dirty = run(["git", "status", "--porcelain"], root)
+        clean = "ja" if dirty == "" else "nein (uncommittete Änderungen)"
+        manage = run(["bash", "-c", "find . -name manage.py -not -path '*/node_modules/*' -not -path '*/.venv*' | head -1"], root)
+        log5 = run(["git", "log", "-5", "--format=%ad %s", "--date=short"], root) or ""
+        adr_dir = os.path.join(root, adr_path)
+        adr_files = sorted(f for f in os.listdir(adr_dir) if re.match(r"ADR-\d+", f)) if os.path.isdir(adr_dir) else []
+
     last_sha = last.split(" ", 1)[0]
-    dirty = run(["git", "status", "--porcelain"], root)
-    clean = "ja" if dirty == "" else "nein (uncommittete Änderungen)"
 
     ci = "n/a"
     ci_raw = run(["gh", "run", "list", "-L1", "--branch", branch, "--repo",
-                  f"{owner}/{repo_name}", "--json", "conclusion,databaseId"], root)
+                  "{0}/{1}".format(owner, repo_name), "--json", "conclusion,databaseId"], root)
     if ci_raw:
         try:
             arr = json.loads(ci_raw)
             if arr:
-                ci = f"{arr[0].get('conclusion')}@{arr[0].get('databaseId')}"
+                ci = "{0}@{1}".format(arr[0].get("conclusion"), arr[0].get("databaseId"))
         except Exception:
             pass
 
-    manage = run(["bash", "-c",
-                  "find . -name manage.py -not -path '*/node_modules/*' -not -path '*/.venv*' | head -1"], root)
     if manage:
         mig_val, mig_cmd = "siehe Prüfbefehl (DB nötig)", "python manage.py showmigrations | grep '\\[ \\]'"
     else:
         mig_val, mig_cmd = "n/a (kein Django/manage.py)", "—"
 
-    log5 = run(["git", "log", "-5", "--format=%ad %s", "--date=short"], root) or ""
     recent = "\n".join("- " + l for l in log5.splitlines()) or "- (keine Commits gelesen)"
 
-    adr_dir = os.path.join(root, adr_path)
-    adrs = []
-    if os.path.isdir(adr_dir):
-        adrs = sorted(f for f in os.listdir(adr_dir) if re.match(r"ADR-\d+", f))[:6]
-    if adrs:
-        adr_line = ", ".join("`{0}:{1}`".format(repo_name, re.match(r"(ADR-\d+)", a).group(1)) for a in adrs)
+    adr_files = adr_files[:6]
+    if adr_files:
+        adr_line = ", ".join("`{0}:{1}`".format(repo_name, re.match(r"(ADR-\d+)", a).group(1)) for a in adr_files)
     else:
         adr_line = "`{0}/` (Index)".format(adr_path)
 
     orch_line = "" if no_orch else "\n- Orchestrator-Memory: `agent_memory_search \"{0}\"`".format(repo_name)
 
-    return repo_name, """{START}
+    auto = """{START}
 ## Aktueller Stand
 | Attribut | Wert |
 |---|---|
@@ -110,7 +132,7 @@ def build_auto(root, today, no_orch):
 | Anker | Wert | Prüfbefehl |
 |---|---|---|
 | Letzter stabiler SHA | `{last}` | `git log --oneline -1 {last_sha}` |
-| CI-Status | {ci} | `gh run list -L1` |
+| CI-Status | {ci} | `gh run list -L1 --branch {branch}` |
 | Migrationen | {mig_val} | `{mig_cmd}` |
 | Working-Tree sauber | {clean} | `git status --porcelain` |
 
@@ -123,6 +145,7 @@ def build_auto(root, today, no_orch):
 {END}""".format(START=AUTO_START, END=AUTO_END, today=today, branch=branch, pf_rel=pf_rel,
                 last=last, last_sha=last_sha, ci=ci, mig_val=mig_val, mig_cmd=mig_cmd,
                 clean=clean, adr_line=adr_line, orch_line=orch_line, recent=recent)
+    return repo_name, auto
 
 
 HEADER = """# AGENT_HANDOVER — {repo_name}
@@ -149,33 +172,41 @@ HUMAN_DEFAULT = """
 """
 
 
+def inject(existing, auto):
+    """Auto-Block nach dem H1 (vor der ersten ##-Überschrift) einfügen, Rest erhalten."""
+    m = re.search(r"^## ", existing, re.M)
+    cut = m.start() if m else len(existing)
+    pre, rest = existing[:cut].rstrip(), existing[cut:]
+    body = pre + "\n\n" + INJECT_NOTE + "\n\n" + auto
+    return body + ("\n\n" + rest if rest.strip() else "\n")
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("repo_path", nargs="?", default=".")
+    ap.add_argument("--ref", default=None, help="Git-Ref für Anker (z. B. origin/main); read-only, kein Working-Tree")
     ap.add_argument("--write", action="store_true")
-    ap.add_argument("--force", action="store_true")
+    ap.add_argument("--force", action="store_true", help="Bestandsdatei mit frischer Vorlage ÜBERSCHREIBEN (Bestand verworfen)")
     ap.add_argument("--no-orchestrator", action="store_true")
     ap.add_argument("--date", default=None)
     args = ap.parse_args()
 
     root = os.path.abspath(args.repo_path)
     today = args.date or datetime.date.today().isoformat()
-    repo_name, auto = build_auto(root, today, args.no_orchestrator)
+    repo_name, auto = build_auto(root, today, args.no_orchestrator, args.ref)
 
     target = os.path.join(root, "docs", "AGENT_HANDOVER.md")
     existing = open(target, encoding="utf-8").read() if os.path.isfile(target) else None
 
-    if existing and AUTO_START in existing and AUTO_END in existing:
+    if args.force or not existing:
+        new = HEADER.format(repo_name=repo_name) + auto + HUMAN_DEFAULT
+        mode = "überschrieben (--force, Bestand verworfen)" if existing else "neu erstellt"
+    elif AUTO_START in existing and AUTO_END in existing:
         new = re.sub(re.escape(AUTO_START) + r".*?" + re.escape(AUTO_END), lambda m: auto, existing, flags=re.S)
         mode = "aktualisiert (Auto-Block ersetzt, Hand-Abschnitte erhalten)"
-    elif existing and not args.force:
-        sys.stderr.write("WARN: {0} existiert OHNE AUTO-Marker — manueller Merge nötig oder --force.\n".format(target))
-        sys.stderr.write("      (Dry-Run-Ausgabe unten zeigt, wie die generierte Datei aussähe.)\n")
-        print(HEADER.format(repo_name=repo_name) + auto + HUMAN_DEFAULT)
-        return
     else:
-        new = HEADER.format(repo_name=repo_name) + auto + HUMAN_DEFAULT
-        mode = "neu erstellt" if not existing else "überschrieben (--force)"
+        new = inject(existing, auto)
+        mode = "Anker-Block injiziert (Bestandsdokument erhalten)"
 
     if args.write:
         os.makedirs(os.path.dirname(target), exist_ok=True)


### PR DESCRIPTION
Zieht den Generator auf den Stand, der im Batch-1-Rollout tatsächlich nötig war:

- **`--ref <git-ref>`** — Anker read-only aus z. B. `origin/main`, ohne den (dirty/Feature-Branch-) Working-Tree. Ohne das wären Anker bei Fremd-Repos **stale** (Batch-1: alle drei lokal auf Feature-Branches, 7–13 hinter main).
- **Inject-Modus** für marker-lose Bestandsdocs: Auto-Block nach dem H1 **einfügen**, restliches Dokument **vollständig erhalten** (statt bisherigem destruktiven Überschreiben). risk-hubs 196 Zeilen kuratiertes Wissen wären sonst geplättet worden.
- `--force` bleibt als bewusster Überschreib-Escape.

Dogfood: Inject gegen risk-hub-Legacy (196→230 Zeilen, alle Sektionen erhalten); `--ref` zieht main-Anker (inkl. ehrlichem `CI=cancelled`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)