### PR TITLE
fix(ci): align stale ADR-210 refs to ADR-226 in library-CI feature files

### DIFF
--- a/.github/actions/gitleaks-scan/action.yml
+++ b/.github/actions/gitleaks-scan/action.yml
@@ -1,5 +1,5 @@
 # Composite Action: gitleaks-scan
-# ADR-210 DRY extraction of the #198-hardened secret-scan block. Single source
+# ADR-226 DRY extraction of the #198-hardened secret-scan block. Single source
 # of truth — consumed by _ci-python.yml (history), _ci-pypi.yml (history) and
 # _ci-pypi.yml build job (built-sdist, --no-git). Steps-only, no permissions,
 # no GitHub API → immune to the #191/#198 reusable-permission-narrowing trap.

--- a/.github/actions/resolve-install-extra/action.yml
+++ b/.github/actions/resolve-install-extra/action.yml
@@ -1,5 +1,5 @@
 # Composite Action: resolve-install-extra
-# ADR-210: a shared library-CI contract assumes a homogeneous extra name
+# ADR-226: a shared library-CI contract assumes a homogeneous extra name
 # (`dev`) across ~14 heterogeneous packages. pip only *warns* on a missing
 # extra and installs the base — so a wrong/typo'd `install_extra` silently
 # under-installs test deps and the failure surfaces far downstream as

--- a/.github/workflows/_ci-pypi.yml
+++ b/.github/workflows/_ci-pypi.yml
@@ -1,7 +1,7 @@
 # ╔═══════════════════════════════════════════════════════════════════════════╗
 # ║  REUSABLE WORKFLOW: PyPI Library CI (Lint, Secret-Scan, Test, Audit)       ║
 # ║  Usage: uses: achimdehnert/platform/.github/workflows/_ci-pypi.yml@main    ║
-# ║  ADR-210: binding CI for every PyPI-published platform package.            ║
+# ║  ADR-226: binding CI for every PyPI-published platform package.            ║
 # ║  Library-shaped — NO Django settings, NO Postgres. Apps use _ci-python.yml ║
 # ║  Caller needs only `permissions: { contents: read }` (secret-scan is       ║
 # ║  GitHub-API-free, so the #191/#198 permission-narrowing trap cannot recur).║
@@ -21,7 +21,7 @@ on:
         description: >-
           JSON list of Python versions the *test* job runs as a matrix.
           Libraries publish to PyPI and must support a range — apps pin one
-          Python, libraries do not (ADR-210). Default = single 3.12 so existing
+          Python, libraries do not (ADR-226). Default = single 3.12 so existing
           single-version behaviour is preserved until a package opts into a
           wider range, e.g. '["3.10","3.11","3.12","3.13"]'.
         required: false
@@ -70,7 +70,7 @@ on:
       enable_build:
         description: >-
           Build the distribution (python -m build), validate metadata
-          (twine check) and scan the *built sdist* for secrets. ADR-210
+          (twine check) and scan the *built sdist* for secrets. ADR-226
           decision driver #1 is "secret leakage in a published wheel/sdist
           is irreversible" — the history scan does NOT cover secrets that
           enter the artifact via MANIFEST.in / package_data without a clean
@@ -86,7 +86,7 @@ on:
       block_pip_audit:
         description: >-
           Make pip-audit (CVE scan) blocking. Default true for libraries:
-          ADR-210 premise is that published artifacts have the widest,
+          ADR-226 premise is that published artifacts have the widest,
           irreversible blast radius — shipping a known-CVE dependency in a
           public wheel is worse than in an internal app, so the app-CI
           "non-blocking for parity" stance is deliberately NOT inherited here.
@@ -117,7 +117,7 @@ jobs:
 
   # ── Secret Detection ──────────────────────────────────────────────────────
   # Single source of the #198-hardened logic: the shared `gitleaks-scan`
-  # composite action (ADR-210 DRY resolution — preferred over a
+  # composite action (ADR-226 DRY resolution — preferred over a
   # _secrets-scan.yml reusable: steps-only, no nested-reusable limits, repo
   # already uses composite actions). _ci-python.yml + this job + the build
   # job below all consume the SAME action — no divergence possible.
@@ -186,7 +186,7 @@ jobs:
           fi
 
   # ── Build + Publish-Vector Secret Scan ────────────────────────────────────
-  # The `secrets-scan` job scans git HISTORY. ADR-210's stated threat is
+  # The `secrets-scan` job scans git HISTORY. ADR-226's stated threat is
   # "secret leakage in a published wheel/sdist" — a secret can enter the
   # *artifact* via MANIFEST.in / package_data / setuptools data-files without
   # ever being a clean history finding. This job builds the real distribution
@@ -214,7 +214,7 @@ jobs:
       - name: Scan built artifact for secrets (the bytes that reach PyPI)
         # Shared composite action, mode=sdist: it locates+extracts the sdist
         # AND the wheel from dist/ and scans them — the SAME control wired
-        # into every publish-*.yml (ADR-210 binding gate). Blocking: a secret
+        # into every publish-*.yml (ADR-226 binding gate). Blocking: a secret
         # in the published artifact is irreversible (rotate + yank).
         uses: achimdehnert/platform/.github/actions/gitleaks-scan@main
         with:

--- a/.github/workflows/_ci-python.yml
+++ b/.github/workflows/_ci-python.yml
@@ -150,7 +150,7 @@ jobs:
     # local history — zero GitHub API, zero token/permission coupling,
     # immune to caller config.
     #
-    # ADR-210: this logic now lives ONCE in the composite action and is
+    # ADR-226: this logic now lives ONCE in the composite action and is
     # consumed identically by _ci-python.yml + _ci-pypi.yml (history + built
     # sdist). ESCAPE HATCH for false positives / pre-existing history leaks:
     # repo-root `.gitleaksignore` (fingerprint, preferred) or `.gitleaks.toml`

--- a/.github/workflows/publish-iil-codeguard.yml
+++ b/.github/workflows/publish-iil-codeguard.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Check
         run: twine check dist/*
 
-      # ADR-210 binding gate: scan the EXACT bytes about to be uploaded.
+      # ADR-226 binding gate: scan the EXACT bytes about to be uploaded.
       # CI on the package repo is advisory; this is the only place the
       # irreversible event (twine upload) is actually blocked.
       - name: Pre-publish secret gate (built artifact)

--- a/.github/workflows/publish-iil-ingest.yml
+++ b/.github/workflows/publish-iil-ingest.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Check
         run: twine check dist/*
 
-      # ADR-210 binding gate: scan the EXACT bytes about to be uploaded.
+      # ADR-226 binding gate: scan the EXACT bytes about to be uploaded.
       # CI on the package repo is advisory; this is the only place the
       # irreversible event (twine upload) is actually blocked.
       - name: Pre-publish secret gate (built artifact)

--- a/.github/workflows/publish-iil-testkit.yml
+++ b/.github/workflows/publish-iil-testkit.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Check
         run: twine check dist/*
 
-      # ADR-210 binding gate: scan the EXACT bytes about to be uploaded.
+      # ADR-226 binding gate: scan the EXACT bytes about to be uploaded.
       # CI on the package repo is advisory; this is the only place the
       # irreversible event (twine upload) is actually blocked.
       - name: Pre-publish secret gate (built artifact)

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -117,7 +117,7 @@ jobs:
           name: dist-django-tenancy-${{ needs.build-django-tenancy.outputs.version }}
           path: dist/
 
-      # ADR-210 binding gate — scan the exact artifact before the
+      # ADR-226 binding gate — scan the exact artifact before the
       # irreversible pypi.org upload (gh-action-pypi-publish).
       - name: Pre-publish secret gate (built artifact)
         uses: achimdehnert/platform/.github/actions/gitleaks-scan@main
@@ -224,7 +224,7 @@ jobs:
           name: dist-concept-templates-${{ needs.build-concept-templates.outputs.version }}
           path: dist/
 
-      # ADR-210 binding gate — scan the exact artifact before the
+      # ADR-226 binding gate — scan the exact artifact before the
       # irreversible pypi.org upload (gh-action-pypi-publish).
       - name: Pre-publish secret gate (built artifact)
         uses: achimdehnert/platform/.github/actions/gitleaks-scan@main
@@ -332,7 +332,7 @@ jobs:
           name: dist-dvelop-client-${{ needs.build-dvelop-client.outputs.version }}
           path: dist/
 
-      # ADR-210 binding gate — scan the exact artifact before the
+      # ADR-226 binding gate — scan the exact artifact before the
       # irreversible pypi.org upload (gh-action-pypi-publish).
       - name: Pre-publish secret gate (built artifact)
         uses: achimdehnert/platform/.github/actions/gitleaks-scan@main
@@ -368,7 +368,7 @@ jobs:
           path: dist/
           merge-multiple: true
 
-      # ADR-210 binding gate — test.pypi.org is also public; a leaked
+      # ADR-226 binding gate — test.pypi.org is also public; a leaked
       # secret there is still irreversibly exposed.
       - name: Pre-publish secret gate (all artifacts)
         if: |

--- a/.github/workflows/publish-platform-context.yml
+++ b/.github/workflows/publish-platform-context.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build wheel + sdist
         run: python -m build
 
-      # ADR-210 binding gate: dist/* is attached to a PUBLIC GitHub Release
+      # ADR-226 binding gate: dist/* is attached to a PUBLIC GitHub Release
       # (and pip-installable via git+https) — same irreversible-exposure
       # class as PyPI. Scan the exact artifact before it is released.
       # NOTE: a `uses:` step ignores defaults.working-directory, so the

--- a/.github/workflows/pypi-ci-adoption-gate.yml
+++ b/.github/workflows/pypi-ci-adoption-gate.yml
@@ -1,7 +1,7 @@
 # ╔═══════════════════════════════════════════════════════════════════════════╗
-# ║  ADR-210 Adoption Gate — PyPI packages NOT yet on _ci-pypi.yml             ║
+# ║  ADR-226 Adoption Gate — PyPI packages NOT yet on _ci-pypi.yml             ║
 # ║                                                                           ║
-# ║  ADR-210 introduces a mandatory hardened secret-scan for published        ║
+# ║  ADR-226 introduces a mandatory hardened secret-scan for published        ║
 # ║  packages, but a reusable workflow protects only the repos that CALL it.  ║
 # ║  Onboarding is intentionally rolling, so the inverted-risk window stays   ║
 # ║  open until each package adopts it. "Rolling onboarding" without a meter  ║
@@ -12,7 +12,7 @@
 # ║  it can't itself become noise that gets disabled.                         ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
-name: ADR-210 Adoption Gate
+name: ADR-226 Adoption Gate
 
 on:
   schedule:
@@ -38,7 +38,7 @@ jobs:
       # see/track private package repos if any appear later.
       GH_TOKEN: ${{ secrets.PROJECT_PAT || secrets.GITHUB_TOKEN }}
       OWNER: achimdehnert
-      MARKER_LABEL: adr-210-adoption
+      MARKER_LABEL: adr-226-adoption
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -113,7 +113,7 @@ jobs:
           total = len(libs)
           pct = round(100 * len(adopted_l) / total) if total else 0
           lines = [
-              "# ADR-210 — `_ci-pypi.yml` adoption",
+              "# ADR-226 — `_ci-pypi.yml` adoption",
               "",
               f"**{len(adopted_l)}/{total} ({pct}%)** library repos consume the "
               "hardened library CI. Until a package adopts it, the public-PyPI "
@@ -135,7 +135,7 @@ jobs:
           print(report)
 
           # Upsert exactly one tracking issue keyed by the marker label.
-          title = "🔭 ADR-210: PyPI packages not yet on `_ci-pypi.yml`"
+          title = "🔭 ADR-226: PyPI packages not yet on `_ci-pypi.yml`"
           st, body = api(
               f"/repos/{owner}/platform/issues?state=open&labels={marker}&per_page=1")
           existing = json.loads(body) if st < 400 else []
@@ -149,7 +149,7 @@ jobs:
                   # Label is best-effort; create issue regardless.
                   api(f"/repos/{owner}/platform/labels", method="POST",
                       data={"name": marker, "color": "FBCA04",
-                            "description": "ADR-210 _ci-pypi.yml adoption tracking"})
+                            "description": "ADR-226 _ci-pypi.yml adoption tracking"})
                   api(f"/repos/{owner}/platform/issues", method="POST",
                       data={"title": title, "body": report, "labels": [marker]})
                   print("Created tracking issue")

--- a/NEXT.md
+++ b/NEXT.md
@@ -1,0 +1,9 @@
+# NEXT · platform
+
+> Auto-Cache aus `git log + status (Fallback)`. Pflege: `AGENT_HANDOVER.md` (führend) per `/session-ende`.
+> Letzter Sync: 2026-05-30 04:47 · stale nach 14 Tagen.
+
+1. [Sonnet] Working Tree hat 5 ungesicherte Änderungen — sichern oder verwerfen
+2. [Opus] Letzter Commit: 5d60713 fix(adr): renumber Klickdummy-Feedback-Bridge 226->227 (in-flight collision w/ #199) — prüfen, ob die Arbeit fortgesetzt werden soll
+3. [Opus] Davor: c340f81 merge main into ADR-feedback-bridge (pre-renumber)
+

--- a/docs/adr/ADR-226-library-ci-reusable-mandatory-secret-scan.md
+++ b/docs/adr/ADR-226-library-ci-reusable-mandatory-secret-scan.md
@@ -215,7 +215,7 @@ Compliance is verified by construction and continuously, not by review alone:
    for adopted packages.
 3. **Adoption meter.** `pypi-ci-adoption-gate.yml` (weekly) lists every
    registry `type: library` repo not yet calling `_ci-pypi.yml` and maintains
-   one tracking issue (label `adr-210-adoption`) — the shrinking backlog is
+   one tracking issue (label `adr-226-adoption`) — the shrinking backlog is
    the measurable rollout signal.
 4. **Live verification.** PR #199: `gitleaks-scan` succeeded end-to-end on
    `iil-testkit` + `iil-promptfw` throwaway branches (real CI, then deleted).
@@ -259,7 +259,7 @@ Compliance is verified by construction and continuously, not by review alone:
   migration + escape-hatch + fingerprint surfacing).
 * ADR-057 (test strategy), ADR-058 (test taxonomy) — coverage-gate lineage.
 * `.github/workflows/pypi-ci-adoption-gate.yml` — the adoption meter; its
-  tracking issue (label `adr-210-adoption`) is the live rollout backlog.
+  tracking issue (label `adr-226-adoption`) is the live rollout backlog.
 * `.github/actions/gitleaks-scan` + `.github/actions/resolve-install-extra` —
   the shared composite actions introduced here (DRY single source).
 * PR #199 — implementing PR (review history incl. advocatus-diabolus passes).


### PR DESCRIPTION
## Was

Folgefix aus dem ADR-226-Review (PR #199 / #329). Das Library-CI/Secret-Scan-ADR wurde als **ADR-210** entworfen, dann wegen Kollision mit dem **echten** `ADR-210 local-staging-prod-architecture` auf **226** umnummeriert. Doc + Dateiname waren umnummeriert — die Kommentare in den Feature-Workflows/Actions und das Adoption-Label hingen noch auf `ADR-210`.

## Änderung

- `ADR-210` → `ADR-226` in den 11 Feature-Dateien (gitleaks-scan/resolve-install-extra Actions, `_ci-pypi.yml`, `_ci-python.yml`, 5× `publish-*.yml`, `pypi-ci-adoption-gate.yml`, ADR-226-Doc)
- Adoption-Label `adr-210-adoption` → `adr-226-adoption` (kein Live-Issue/Label existierte → kein Relabeling nötig)

## Bewusst NICHT angefasst

Echte ADR-210-Staging-Refs: `registry/repos.yaml`, `scripts/checks/staging_*.sh`, `run_all.sh`, `stale.yml` (`adr-210-followup`), `CONTRIBUTING.md`, ADR-212/215/216/218/220/221. Reiner Kommentar-/Label-Change, keine Logik.

🤖 Generated with [Claude Code](https://claude.com/claude-code)