### PR TITLE
chore: gitignore auto-generated NEXT.md (untrack)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ env_loader.py
 # PDF-Dateien (generiert via print_agent)
 *.pdf
 !docs/pdf/*.pdf
+
+# Auto-generierter Editor-Cache (claude-next-sync) — analog dev-hub
+NEXT.md

--- a/NEXT.md
+++ b/NEXT.md
@@ -1,9 +1,0 @@
-# NEXT · platform
-
-> Auto-Cache aus `git log + status (Fallback)`. Pflege: `AGENT_HANDOVER.md` (führend) per `/session-ende`.
-> Letzter Sync: 2026-05-30 04:47 · stale nach 14 Tagen.
-
-1. [Sonnet] Working Tree hat 5 ungesicherte Änderungen — sichern oder verwerfen
-2. [Opus] Letzter Commit: 5d60713 fix(adr): renumber Klickdummy-Feedback-Bridge 226->227 (in-flight collision w/ #199) — prüfen, ob die Arbeit fortgesetzt werden soll
-3. [Opus] Davor: c340f81 merge main into ADR-feedback-bridge (pre-renumber)
-


### PR DESCRIPTION
`NEXT.md` (claude-next-sync Editor-Cache, pro Session regeneriert) wurde in #335 versehentlich per `git add -A` mitcommittet. Hier: untracken + `.gitignore`-Eintrag — analog zur dev-hub-Konvention (`2fae125`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)