### PR TITLE
docs(claude): CLAUDE.md als Auto-Load-Pointer auf CORE_CONTEXT.md-SSoT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# Platform — Repo Context
+
+> Meta-Repo des IIL-Ökosystems: ADRs, Workflows, Governance, `shared_contracts`.
+> **Kein App-Code, kein Django** — der lebt in den Hub-Repos (dev-hub, risk-hub, …).
+
+## SSoT: zuerst `CORE_CONTEXT.md` lesen
+
+Die maßgebliche Repo-Doku ist **[`CORE_CONTEXT.md`](CORE_CONTEXT.md)** — Rolle,
+Verzeichnis-Karte, Tech-Stack, **Konventionen**, Pflicht-Lesestoff und Infra
+stehen dort und werden **nur dort** gepflegt. Diese Datei dupliziert das nicht,
+sondern wird von Claude Code automatisch geladen und zeigt auf die SSoT.
+
+Vor dem ersten Keystroke zusätzlich: `AGENT_HANDOVER.md` (aktueller Stand) und
+`AGENT_MEMORY.md` (Drift-Episoden & Lessons).
+
+## Precedence (höchste gewinnt)
+
+1. **dieses `CLAUDE.md` + `CORE_CONTEXT.md`** (repo-spezifisch)
+2. **Orchestrator MCP** (`orchestrator.iil.pet`) — Live-Shared-Memory, wo geladen
+3. **`~/.claude/policies/<topic>.md`** — file-basierte Defaults (immer geladen)
+
+## Auto-Load-Guardrails (Details → `CORE_CONTEXT.md`)
+
+- **Brauche ich ein ADR?** → `~/.claude/policies/adr-threshold.md` ist maßgeblich.
+  Reine Ergänzung nach bestehendem Muster = **kein** ADR (CHANGELOG/PR genügt);
+  ADR nur bei echter Architektur-Entscheidung. Nicht überschießend gaten.
+- **ADR-Nummern**: zur Merge-Zeit allokiert (ADR-228, amends ADR-065), monoton,
+  nie wiederverwendet. Bestand live: `ls docs/adr/ADR-*.md | wc -l`.
+- **Commits in `docs/adr/`**: scope = `adr`, nicht `docs`.
+- **Secrets** nie ins Repo — immer `~/.secrets/`.


### PR DESCRIPTION
## Was

Fügt `platform/CLAUDE.md` hinzu — bisher fehlte sie, obwohl platform der **SSoT-Meta-Repo** ist. Claude Code lädt `CLAUDE.md` **automatisch** in jede Session; die bereits bestehende Konventions-SSoT `CORE_CONTEXT.md` wird nur auf Aufforderung gelesen.

## Design: Pointer statt Dublette

Der Repo hat **schon** `CORE_CONTEXT.md` mit Rolle, Verzeichnis-Karte, Konventionen, Pflicht-Lesestoff. Eine zweite Konventions-Doku wäre ein DRY-/Drift-Anti-Pattern (beide laufen garantiert auseinander — `CORE_CONTEXT.md` trägt z.B. schon die stale Zahl „168 ADRs/206").

Deshalb ist diese `CLAUDE.md` ein **schlanker Auto-Load-Pointer**:
- Rolle in einem Satz (kein App-Code, kein Django)
- **Precedence-Kette** (repo CLAUDE.md+CORE_CONTEXT > Orchestrator MCP > policies)
- Verweis auf `CORE_CONTEXT.md` als SSoT — Konventionen werden **nur dort** gepflegt
- Wenige auto-load-würdige Guardrails: ADR-Threshold (maßgeblich: `policies/adr-threshold.md`), ADR-Nummerierung (ADR-228 merge-time, amends ADR-065), commit-scope `adr`, secrets

## Adversarial-Review-Korrekturen ggü. erstem Entwurf

Der erste Entwurf (aus liegengebliebenem `feat/workflow-incident` gerettet) hat CORE_CONTEXT.md-Konventionen **dupliziert** und dabei eine übergeneralisiert: *„bootstrap.sh-Änderungen sind ADR-pflichtig"* — CORE_CONTEXT.md sagt korrekt nur **Breaking Changes**. Statt das umzuformulieren → ganz raus, Verweis auf die SSoT. Eingefrorene ADR-Zahl → Live-Befehl.

## Kein ADR nötig

Repo-lokale Doku, folgt bestehendem Muster (dev-hub & weitere Hubs haben CLAUDE.md). CHANGELOG/PR genügt.

## Follow-up (separat)

`CORE_CONTEXT.md` trägt dieselbe stale ADR-Zahl („168/206", real 175/ADR-228) — eigener kleiner Fix-PR sinnvoll, bewusst nicht in diesen PR gemischt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)