### PR TITLE
docs: stale ADR-Zahl in CORE_CONTEXT.md fixen (drift-resistent)

### DIFF
--- a/CORE_CONTEXT.md
+++ b/CORE_CONTEXT.md
@@ -1,7 +1,7 @@
 # CORE_CONTEXT — platform
 
 > Pflicht-Lektüre für jeden Coding-Agent vor dem ersten Keystroke.
-> Aktualisiert: 2026-05-15
+> Aktualisiert: 2026-05-30
 
 ## Was ist platform?
 
@@ -10,7 +10,7 @@ ist die Single-Source-of-Truth für plattformweite Entscheidungen, Conventions
 und geteilte Werkzeuge der 45+ Hub-Repos.
 
 **GitHub:** https://github.com/achimdehnert/platform
-**ADR-Verzeichnis:** `docs/adr/` (168 ADRs, höchste Nummer 206)
+**ADR-Verzeichnis:** `docs/adr/` (Bestand live: `ls docs/adr/ADR-*.md | wc -l`; höchste Nr.: `ls docs/adr/ADR-*.md | grep -oE 'ADR-[0-9]+' | sort -V | tail -1`)
 
 ## Rolle gegenüber anderen Repos
 
@@ -24,7 +24,7 @@ und geteilte Werkzeuge der 45+ Hub-Repos.
 
 | Pfad | Zweck |
 |---|---|
-| `docs/adr/` | Architecture Decision Records (SSoT, 168 Dateien) |
+| `docs/adr/` | Architecture Decision Records (SSoT; live: `ls docs/adr/ADR-*.md | wc -l`) |
 | `docs/concepts/` | Konzeptpapiere vor ADRs |
 | `docs/templates/` | ADR-, Use-Case-, Settings-Templates für neue Repos |
 | `docs/reference/` | Reference-Docs (audit/health-Checker, …) |


### PR DESCRIPTION
## Was

`CORE_CONTEXT.md` trug an zwei Stellen die stale Zahl **„168 ADRs / höchste 206"** — real sind es **175 ADRs / `ADR-228`** (Stand 2026-05-30).

## Wie (drift-resistent)

Statt die Zahl nur fortzuschreiben (veraltet beim nächsten ADR wieder) → **datierter Stand + Live-Befehl** `ls docs/adr/ADR-*.md | wc -l`. Aktualisiert-Datum auf 2026-05-30 gehoben.

## Kontext

Follow-up aus dem Review von #337 (CLAUDE.md als Auto-Load-Pointer). Bewusst getrennt, da #337 nur CLAUDE.md anfasst und CORE_CONTEXT.md die eigentliche Konventions-SSoT ist.

## Kein ADR nötig

Reine Doku-Korrektur, repo-lokal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)