### PR TITLE
fix(adr): kanonisches 'id:' statt Legacy 'adr_id:' (ADR-061, ADR-215)

### DIFF
--- a/docs/adr/ADR-061-hardcoding-elimination-strategy.md
+++ b/docs/adr/ADR-061-hardcoding-elimination-strategy.md
@@ -1,5 +1,5 @@
 ---
-adr_id: ADR-061
+id: ADR-061
 title: "Adopt hardcode_scanner.py as Platform-wide Hardcoding Prevention Tool"
 status: accepted
 date: 2026-02-21

--- a/docs/adr/ADR-215-klickdummy-pgvector-discovery.md
+++ b/docs/adr/ADR-215-klickdummy-pgvector-discovery.md
@@ -1,5 +1,5 @@
 ---
-adr_id: ADR-215
+id: ADR-215
 title: "Klickdummy Discovery via Orchestrator pgvector (Stage 1.5)"
 status: proposed
 date: 2026-05-21


### PR DESCRIPTION
## Was

Migriert die **einzigen 2 ADRs** mit Legacy-Frontmatter `adr_id:` auf das kanonische `id:`:
- `ADR-061-hardcoding-elimination-strategy.md`
- `ADR-215-klickdummy-pgvector-discovery.md`

## Warum

`iil-adrfw` SCHEMA-V3 hat das Feld **`adr_id` → `id`** umbenannt. Eine Base-Rate-Prüfung über alle 176 ADRs ergab: 31× `id:`, **2× `adr_id:`**, 143× keins. `adr_id:` ist also isolierter Drift.

## Bewusst NICHT enthalten

**`id:` wird nicht erzwungen.** Das offizielle Template (`docs/templates/adr-template.md`) hat gar kein `id:`-Feld, und `iil-adrfw._resolve_id()` leitet die ADR-Id aus dem Dateinamen ab — `id:` ist optional. Eine „erzwinge id:"-Regel würde 143 ADRs brechen (verworfen).

## Folge-Arbeit (separater PR, anderes Repo)

Guard gegen künftigen `adr_id:`-Drift kommt als Validator-Regel in **iil-adrfw** (Schema-SSoT, läuft via `adr-validate.yml` über alle Repos) — nicht als platform-lokales Bash-Script. Aktivierung dort = iil-adrfw-Release + Pin-Bump in `adr-validate.yml`.

## Kein ADR nötig

Reine Frontmatter-Korrektur, repo-lokal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)