### PR TITLE
feat(tools): cc-skill-dist doctor — read-only Drift-Diagnose (ADR-230 REC-9)

### DIFF
--- a/tools/cc-skill-dist/README.md
+++ b/tools/cc-skill-dist/README.md
@@ -1,0 +1,31 @@
+# cc-skill-dist — CC-Skill-Distribution-Tooling (platform:ADR-230)
+
+Werkzeuge zur deterministischen Verteilung der Skills aus der **einen kanonischen Quelle**
+(platform `main` `.windsurf/workflows/`) nach `~/.claude/commands/` — gemäß ADR-230 (CC-first).
+
+## `doctor.py` — read-only Drift-Diagnose (ADR-230 REC-9)
+
+Vergleicht die branch-stabile Quelle (`origin/main`) mit dem live `~/.claude/commands/`,
+**ohne etwas zu ändern**. Meldet stale Kopien, dangling Symlinks, extra/fehlende Skills,
+Hybrid-Status und einen Drift-Score.
+
+```bash
+python3 tools/cc-skill-dist/doctor.py            # Default: ~/github/platform, ~/.claude/commands, origin/main
+python3 tools/cc-skill-dist/doctor.py --ref origin/main
+```
+
+Exit-Code: `0` = sauber, `1` = Drift gefunden (CI-tauglich), `2` = Quelle nicht lesbar.
+
+**Dogfood 2026-05-30:** 69 kanonisch / 68 Ziel; 28 Symlinks ok; 35 Kopien fresh, **3 stale**
+(`adr-handoff-extern`, `onboard-repo`, `run-local`); 2 extra, 3 fehlend — **Drift-Score 8**.
+Belegt empirisch die ADR-230-R1-Realrisiken (statische, stale-prone Kopien).
+
+## Roadmap (nach ADR-230-Acceptance)
+
+- `generate.py` — erzeugt `~/.claude/commands/` deterministisch aus dem **resolved Commit**:
+  einheitliche generierte Kopien mit Header (`generated/source_commit/content_hash/do_not_edit`),
+  atomar + gelockt (Staging → validieren → Swap), `MANAGED_BY`-Datei, Manifest.
+- `windsurf-subset.py` — generiert das ADR-Review-Subset über Frontmatter-Tags (`tool_targets`).
+- Policy-Kollaps (≥ 4 `claude-skills.md`-Kopien → eine + Pointer-Stubs).
+
+> Schreibende Schritte folgen **nach** ADR-230-Acceptance. `doctor.py` ist read-only und schon jetzt nützlich.

--- a/tools/cc-skill-dist/doctor.py
+++ b/tools/cc-skill-dist/doctor.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""doctor.py — read-only Drift-Diagnose für CC-Skill-Distribution (platform:ADR-230).
+
+Vergleicht die branch-stabile kanonische Quelle (platform `origin/main`
+`.windsurf/workflows/`) mit dem live `~/.claude/commands/` — OHNE etwas zu ändern.
+Meldet: stale Kopien, dangling Symlinks, fehlende/zusätzliche Skills, Hybrid-Status.
+
+Usage: doctor.py [--platform ~/github/platform] [--commands ~/.claude/commands] [--ref origin/main]
+"""
+import argparse, os, subprocess, sys
+
+def git(args, cwd):
+    r = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+    return r.stdout if r.returncode == 0 else None
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--platform", default=os.path.expanduser("~/github/platform"))
+    ap.add_argument("--commands", default=os.path.expanduser("~/.claude/commands"))
+    ap.add_argument("--ref", default="origin/main")
+    a = ap.parse_args()
+
+    git(["fetch", "origin", "main", "-q"], a.platform)
+    # Kanonische Quelle: blob-sha = inhalts-adressiert, branch-stabil
+    listing = git(["ls-tree", "-r", a.ref, ".windsurf/workflows/"], a.platform) or ""
+    canon = {}  # name -> blob_sha
+    for line in listing.splitlines():
+        # <mode> blob <sha>\t<path>
+        parts = line.split()
+        if len(parts) >= 4 and parts[1] == "blob" and parts[-1].endswith(".md"):
+            canon[os.path.basename(parts[-1])] = parts[2]
+    if not canon:
+        print(f"FEHLER: keine kanonischen Workflows unter {a.ref}:.windsurf/workflows/"); sys.exit(2)
+
+    def canon_content(sha):
+        return git(["cat-file", "blob", sha], a.platform)
+
+    cmd_files = {f: os.path.join(a.commands, f) for f in os.listdir(a.commands) if f.endswith(".md")} \
+        if os.path.isdir(a.commands) else {}
+
+    sym_ok = sym_stale = sym_dangling = copy_fresh = copy_stale = extra = 0
+    issues = []
+    for name, path in sorted(cmd_files.items()):
+        is_link = os.path.islink(path)
+        if name not in canon:
+            extra += 1; issues.append(("extra", name, "im Ziel, aber nicht in der Quelle")); continue
+        if is_link and not os.path.exists(path):
+            sym_dangling += 1; issues.append(("dangling", name, "Symlink ins Leere → " + os.readlink(path))); continue
+        try:
+            disk = open(path, encoding="utf-8", errors="ignore").read()
+        except Exception as e:
+            issues.append(("unlesbar", name, str(e)[:40])); continue
+        same = (disk == (canon_content(canon[name]) or "\0"))
+        if is_link:
+            sym_ok += 1 if same else 0
+            if not same: sym_stale += 1; issues.append(("symlink-stale", name, "Symlink-Inhalt ≠ Quelle"))
+        else:
+            if same: copy_fresh += 1
+            else: copy_stale += 1; issues.append(("copy-stale", name, "Kopie ≠ Quelle (veraltet)"))
+
+    missing = sorted(set(canon) - set(cmd_files))
+
+    print(f"=== CC-Skill-Doctor (Quelle: {a.ref}, {len(canon)} kanonische Workflows) ===")
+    print(f"  Ziel {a.commands}: {len(cmd_files)} Dateien")
+    print(f"  Symlinks ok={sym_ok}  symlink-stale={sym_stale}  dangling={sym_dangling}")
+    print(f"  Kopien fresh={copy_fresh}  copy-stale={copy_stale}")
+    print(f"  extra (nicht in Quelle)={extra}  fehlend (in Quelle, nicht im Ziel)={len(missing)}")
+    print(f"  Hybrid? {'JA — Symlinks UND Kopien gemischt' if (sym_ok+sym_stale+sym_dangling)>0 and (copy_fresh+copy_stale)>0 else 'nein'}")
+    if missing:
+        print("  fehlende Skills:", ", ".join(missing[:10]) + (" …" if len(missing) > 10 else ""))
+    if issues:
+        print("  --- Befunde (max 15) ---")
+        for kind, name, why in issues[:15]:
+            print(f"    [{kind}] {name} — {why}")
+    drift = sym_stale + sym_dangling + copy_stale + extra + len(missing)
+    print(f"=== DRIFT-SCORE: {drift} (0 = sauber) ===")
+    sys.exit(1 if drift else 0)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Erster, **read-only** Baustein der ADR-230-Implementierung (REC-9 Drift-Check) — sicher unabhängig von der (deferred) Acceptance.

`tools/cc-skill-dist/doctor.py` vergleicht die branch-stabile Quelle (platform `origin/main` `.windsurf/workflows/`) mit dem live `~/.claude/commands/` — **ohne Änderung** — und meldet stale Kopien, dangling Symlinks, extra/fehlende Skills, Hybrid-Status + Drift-Score (Exit 1 bei Drift → CI-tauglich).

**Dogfood 2026-05-30:** 69 kanonisch / 68 Ziel · 28 Symlinks ok · 35 Kopien fresh, **3 stale** (`adr-handoff-extern`, `onboard-repo`, `run-local`) · 2 extra · 3 fehlend → **Drift-Score 8**. Belegt empirisch die ADR-230-R1-Realrisiken (statische, stale-prone Kopien) — der `adr-handoff-extern`-Skill ist als Live-CC-Kopie veraltet ggü. der heute editierten Quelle.

Schreibende Schritte (`generate.py`, `windsurf-subset.py`, Policy-Kollaps) folgen **nach** ADR-230-Acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
