### PR TITLE
fix(deploy): health-gate retries 12→30 + configurable (ADR-231 Welle 0a)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -141,17 +141,23 @@ if [[ "$ENVIRONMENT" == "staging" ]]; then
   fi
 fi
 
+# Retry-Budget konfigurierbar (Default 30 × 5s ≈ 150s Sleep + curl). Vorher fix 12 (60s) —
+# zu kurz für langsame Cold-Starts (z.B. dev-hub: 16 Django-Apps gunicorn-Boot >60s) →
+# falsch-roter Deploy trotz gesundem Prod (ADR-231 Welle 0). Loop bricht beim ersten 200 →
+# schnelle Apps verlieren nichts; nur echt-langsame/kaputte Deploys nutzen das Budget aus.
+# Per-Deploy übersteuerbar via env HEALTH_CHECK_RETRIES.
+HEALTH_CHECK_RETRIES="${HEALTH_CHECK_RETRIES:-30}"
 if [[ -n "$HEALTH_CHECK_URL" ]]; then
-  echo "Health-Check: $HEALTH_CHECK_URL"
-  for i in $(seq 1 12); do
+  echo "Health-Check: $HEALTH_CHECK_URL (max $HEALTH_CHECK_RETRIES Versuche)"
+  for i in $(seq 1 "$HEALTH_CHECK_RETRIES"); do
     HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" --max-time 10 "$HEALTH_CHECK_URL" 2>/dev/null || echo "000")
     if [[ "$HTTP_CODE" == "200" ]]; then
-      echo "✅ Health-Check OK (Versuch $i)"
+      echo "✅ Health-Check OK (Versuch $i/$HEALTH_CHECK_RETRIES)"
       break
     fi
-    echo "⏳ Versuch $i/12 — HTTP $HTTP_CODE"
+    echo "⏳ Versuch $i/$HEALTH_CHECK_RETRIES — HTTP $HTTP_CODE"
     sleep 5
-    [[ $i -eq 12 ]] && { echo "❌ Health-Check fehlgeschlagen nach 60s"; exit 4; }
+    [[ $i -eq "$HEALTH_CHECK_RETRIES" ]] && { echo "❌ Health-Check fehlgeschlagen nach $((HEALTH_CHECK_RETRIES * 5))s"; exit 4; }
   done
 else
   sleep 5


### PR DESCRIPTION
**ADR-231 Welle 0a** — den falsch-roten Deploy-Health-Gate fixen.

`scripts/deploy.sh` (→ `/opt/scripts/deploy.sh`) brach nach **fix 12 Versuchen (60s)** ab. dev-hubs Cold-Start (16 Django-Apps, gunicorn-Boot >60s) übersteigt das → **jeder Deploy mit Container-Recreate meldet falsch ROT**, obwohl Prod danach gesund ist (real beobachtet 2026-05-30, dreimal).

## Fix
- Default-Retry-Budget **12 → 30** (×5s ≈ 150s) + per `env HEALTH_CHECK_RETRIES` übersteuerbar.
- Dynamische Meldungen (`$i/$HEALTH_CHECK_RETRIES`, korrekte Sekundenzahl).
- Loop bricht beim **ersten HTTP 200** → schnelle Apps verlieren nichts; nur langsame/kaputte Deploys nutzen das Budget. Trade-off: Rollback bei *echtem* Fehler verzögert sich 60s→~150s (akzeptabel).

## Cross-Repo
Reusable für alle Repos (`_deploy-unified.yml` ruft dieses Script). Strikt toleranter, kein Nachteil für gesunde Deploys.

## Nach Merge
Script muss auf den Prod-Server (`/opt/scripts/deploy.sh`) — erfolgt separat (SSH-Sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)