### PR TITLE
feat(skills): tool_targets:[windsurf-review] in 9 ADR/Review-Workflows (ADR-230)

### DIFF
--- a/.windsurf/workflows/adr-challenger.md
+++ b/.windsurf/workflows/adr-challenger.md
@@ -1,4 +1,5 @@
 ---
+tool_targets: [windsurf-review]
 description: Adversarial review of a proposed ADR — find conflicts, right-size, surface 1-2 strong counter-arguments. Read-only. Does NOT write or modify ADRs.
 mode: read-only
 ---

--- a/.windsurf/workflows/adr-curator.md
+++ b/.windsurf/workflows/adr-curator.md
@@ -1,4 +1,5 @@
 ---
+tool_targets: [windsurf-review]
 description: Disambiguate which ADR is canonical for a topic — supersession chains, naming collisions, conflict warnings. Read-only.
 mode: read-only
 ---

--- a/.windsurf/workflows/adr-handoff-extern.md
+++ b/.windsurf/workflows/adr-handoff-extern.md
@@ -1,4 +1,5 @@
 ---
+tool_targets: [windsurf-review]
 description: Schreibt ADR-Review-Briefing als .md nach ~/shared/ für externe LLM-Zweitmeinung (Advocatus Diabolus + Out-of-the-Box).
 mode: write
 ---

--- a/.windsurf/workflows/adr-health.md
+++ b/.windsurf/workflows/adr-health.md
@@ -1,4 +1,5 @@
 ---
+tool_targets: [windsurf-review]
 description: Full ADR Health Audit — Schema, Staleness, Freshness, Redundancy, Compliance in einem Durchlauf
 ---
 

--- a/.windsurf/workflows/adr-review.md
+++ b/.windsurf/workflows/adr-review.md
@@ -1,4 +1,5 @@
 ---
+tool_targets: [windsurf-review]
 description: Review an ADR against the platform-specific checklist (MADR 4.0 + infrastructure conventions + Modern Platform Patterns)
 mode: read-only
 ---

--- a/.windsurf/workflows/adr.md
+++ b/.windsurf/workflows/adr.md
@@ -1,4 +1,5 @@
 ---
+tool_targets: [windsurf-review]
 description: Create new ADR with automatic scope detection, proper structure, and pgvector memory storage
 mode: write
 ---

--- a/.windsurf/workflows/agent-review.md
+++ b/.windsurf/workflows/agent-review.md
@@ -1,4 +1,5 @@
 ---
+tool_targets: [windsurf-review]
 description: Review Agent — automatisierter PR-Review gegen ADRs, Ruff, Bandit, Platform-Patterns (ADR-100)
 ---
 

--- a/.windsurf/workflows/pr-review.md
+++ b/.windsurf/workflows/pr-review.md
@@ -1,4 +1,5 @@
 ---
+tool_targets: [windsurf-review]
 description: Review and address PR comments using GitHub MCP
 mode: write
 args:

--- a/.windsurf/workflows/workflow-review.md
+++ b/.windsurf/workflows/workflow-review.md
@@ -1,4 +1,5 @@
 ---
+tool_targets: [windsurf-review]
 description: Systematischer Review aller .windsurf/workflows/ — Qualität, Stabilität, Fehlerquellen, Optimierungspotenzial für fehlerfreies Coding-Agent-Szenario
 ---
 


### PR DESCRIPTION
Setzt den Frontmatter-Tag `tool_targets: [windsurf-review]` in die 9 ADR/Review-Workflows (adr, adr-review, adr-challenger, adr-curator, adr-health, adr-handoff-extern, agent-review, pr-review, workflow-review).

Damit wählt `cc-skill-dist/windsurf-subset.py` das Windsurf-Subset **deklarativ über Tags** statt über die kuratierte Fallback-Liste (ADR-230 REC-10). Additive Frontmatter-Ergänzung, kein Verhaltensänderung der Skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)