### PR TITLE
feat(claude-policy): 'remember' — Memory-Upsert über den stateless /run-REST-Shim

### DIFF
--- a/.github/workflows/cc-skill-dist-doctor.yml
+++ b/.github/workflows/cc-skill-dist-doctor.yml
@@ -1,0 +1,36 @@
+name: CC-Skill-Dist Round-Trip (ADR-230)
+
+# Determinismus-Gate für die Skill-Distribution: erzeugt das Distributions-Ziel
+# aus dem PR-Baum (generate.py) und prüft, dass doctor.py es als Drift 0 liest.
+# Fängt Tooling-Regresse (z.B. generate-Footer ≠ doctor-Vergleich) VOR dem
+# gegateten Live-Rollout. Braucht KEIN ~/.claude/commands — rein selbst-konsistent.
+
+on:
+  push:
+    paths:
+      - "tools/cc-skill-dist/**"
+      - ".windsurf/workflows/**"
+  pull_request:
+    paths:
+      - "tools/cc-skill-dist/**"
+      - ".windsurf/workflows/**"
+
+jobs:
+  round-trip:
+    name: generate → doctor == Drift 0 (HEAD)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # ls-tree/cat-file gegen den vollen Baum
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      # Tools sind stdlib-only — keine pip-Deps.
+      - name: Generate Distributions-Ziel aus PR-Baum
+        run: python3 tools/cc-skill-dist/generate.py --ref HEAD --target /tmp/cc-roundtrip
+
+      - name: Doctor gegen Erzeugnis — erwartet Drift 0
+        run: python3 tools/cc-skill-dist/doctor.py --ref HEAD --commands /tmp/cc-roundtrip

--- a/tools/cc-skill-dist/doctor.py
+++ b/tools/cc-skill-dist/doctor.py
@@ -9,6 +9,15 @@ Usage: doctor.py [--platform ~/github/platform] [--commands ~/.claude/commands] 
 """
 import argparse, os, subprocess, sys
 
+# Footer, den generate.py an jede verteilte Kopie anhängt (MANAGED-BY-Marke).
+# doctor muss ihn vor dem Inhaltsvergleich abstreifen, sonst liest sich jede
+# korrekt generierte Kopie fälschlich als copy-stale (Footer ≠ nackter Blob).
+MARK = "MANAGED-BY: platform/tools/cc-skill-dist"
+
+def strip_managed_footer(text):
+    idx = text.rfind("<!-- " + MARK)
+    return text if idx == -1 else text[:idx]
+
 def git(args, cwd):
     r = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
     return r.stdout if r.returncode == 0 else None
@@ -50,7 +59,8 @@ def main():
             disk = open(path, encoding="utf-8", errors="ignore").read()
         except Exception as e:
             issues.append(("unlesbar", name, str(e)[:40])); continue
-        same = (disk == (canon_content(canon[name]) or "\0"))
+        src = canon_content(canon[name]) or "\0"
+        same = (strip_managed_footer(disk).rstrip("\n") == src.rstrip("\n"))
         if is_link:
             sym_ok += 1 if same else 0
             if not same: sym_stale += 1; issues.append(("symlink-stale", name, "Symlink-Inhalt ≠ Quelle"))

--- a/tools/claude-policy/README.md
+++ b/tools/claude-policy/README.md
@@ -82,13 +82,13 @@ JSON in/out, kein base64.** Die robuste Basis für `session-ende` Phase 2.
 | Var | Default |
 |---|---|
 | `ORCHESTRATOR_RUN_URL` | `https://orchestrator.iil.pet/run` |
-| `ORCHESTRATOR_MCP_API_KEY` | *(erforderlich; ≠ MCP-SSE-Bearer)* — aus `~/.secrets` sourcen |
+| `ORCHESTRATOR_MCP_API_KEY` | *(erforderlich; ≠ MCP-SSE-Bearer)* — `export ORCHESTRATOR_MCP_API_KEY="$(cat ~/.secrets/orchestrator_run_api_key)"` |
 | `ORCHESTRATOR_RUN_TIMEOUT` | `30` |
 
 Sauber sourcen (Tool ← env ← Secrets-Layer):
 
 ```bash
-set -a; . ~/.secrets/orchestrator.env; set +a
+export ORCHESTRATOR_MCP_API_KEY="$(cat ~/.secrets/orchestrator_run_api_key)"
 echo "<content>" | claude-policy remember --key … --type context --title "…"
 ```
 

--- a/tools/claude-policy/README.md
+++ b/tools/claude-policy/README.md
@@ -52,7 +52,49 @@ claude-policy diff                  # Drift anzeigen, keine Writes
 claude-policy push                  # Dateien → orchestrator (sichere Richtung)
 claude-policy push --only llm-routing
 claude-policy pull [--only X] [-y]  # orchestrator → Dateien (advisory)
+
+# Beliebigen Memory-Entry schreiben (jeder entry_type) — MCP-unabhängig:
+echo "<content>" | claude-policy remember \
+  --key session:2026-05-30:platform --type context \
+  --title "Session …" --tags "session,platform"
+claude-policy remember --key … --type lesson_learned --title … --content "…"
 ```
+
+### `remember` — Transport: der `/run`-REST-Shim
+
+Die orchestrator-MCP-Tools sind über die **SSE-Bindung unbrauchbar**:
+`list_tools` klappt, aber **jeder `tools/call` → `-32602`** (verifiziert
+2026-05-30, auch das argumentlose `workflow_list`). Root Cause ist **nicht**
+Signatur/Schema (deployed == source, flat, per Prod-Check bestätigt) und
+**nicht** nginx (`/run` liefert sauber 401 → POST wird korrekt proxied),
+sondern der **SSE-Per-Prozess-Session-State** (server.py-Lifespan-Kommentar):
+bricht der `/sse`-Stream ab, ist die `session_id` verwaist → jeder folgende
+`tools/call` scheitert.
+
+`remember` ruft daher `agent_memory_upsert` über den **stateless
+`/run`-REST-Endpunkt** des Servers (`handle_run` → `_call_tool_inner`, dieselbe
+Dispatch-Tabelle wie die MCP-Tools — Single Source of Truth). Vorteile ggü. dem
+ssh+docker-Pfad: **kein Shell-Hop, kein Per-Prozess-Session-State, strukturiertes
+JSON in/out, kein base64.** Die robuste Basis für `session-ende` Phase 2.
+
+**Auth/Config (env, nie eingebettet):**
+
+| Var | Default |
+|---|---|
+| `ORCHESTRATOR_RUN_URL` | `https://orchestrator.iil.pet/run` |
+| `ORCHESTRATOR_MCP_API_KEY` | *(erforderlich; ≠ MCP-SSE-Bearer)* — aus `~/.secrets` sourcen |
+| `ORCHESTRATOR_RUN_TIMEOUT` | `30` |
+
+Sauber sourcen (Tool ← env ← Secrets-Layer):
+
+```bash
+set -a; . ~/.secrets/orchestrator.env; set +a
+echo "<content>" | claude-policy remember --key … --type context --title "…"
+```
+
+`push`/`pull`/`list`/`diff` nutzen weiterhin den ssh+docker-Pfad; sie können
+in einem Folge-PR ebenfalls auf `_orch_run` migrieren, um den docker-Hack ganz
+abzulösen.
 
 ## Caveat
 
@@ -64,6 +106,13 @@ Voraussetzungen: Python 3.10+ und SSH-Zugang zum Prod-Host.
 
 ## Stand
 
+- 2026-05-30: `remember`-Subcommand ergänzt — generischer Memory-Upsert (jeder
+  `entry_type`, Enum-validiert) über den **stateless `/run`-REST-Shim**
+  (`_orch_run`), nicht das kaputte MCP-SSE. Grund: orchestrator-MCP `tools/call`
+  global `-32602` (Root Cause = SSE-Per-Prozess-Session, nicht Signatur/nginx —
+  beides per Prod-Check ausgeschlossen). Macht `session-ende` Phase 2
+  MCP-unabhängig. Env-getrieben (`ORCHESTRATOR_MCP_API_KEY`). STUB-getestet
+  (Syntax, Arg-Parsing, Enum, Unicode, fehlender-Key-Pfad).
 - 2026-05-17: Script von Stub → funktionsfähig (SSH/docker-exec, base64-inline,
   idempotent). Argv-Reparse-Bug beim Live-Test gefunden + behoben. README an
   Realität angepasst (vorheriges „autonomes CLI nicht möglich" war falsch).

--- a/tools/claude-policy/claude-policy
+++ b/tools/claude-policy/claude-policy
@@ -49,6 +49,8 @@ import os
 import re
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 # Policy source dir. Default = local Claude config; CI overrides it to the
@@ -68,6 +70,15 @@ LOCAL_MODE = os.environ.get("ORCH_LOCAL") == "1"
 
 SSH_CONNECT_TIMEOUT = 20
 SSH_RUN_TIMEOUT = 90
+
+# Canonical transport: the server's stateless REST shim `/run` (server.py
+# handle_run → _call_tool_inner, the same dispatch table as the MCP tools).
+# Preferred over the ssh+docker path: no shell hop, no per-process SSE session
+# state, structured JSON in/out. Key is read from the env (Tool ← env ←
+# secrets layer); never embedded.
+RUN_URL = os.environ.get("ORCHESTRATOR_RUN_URL", "https://orchestrator.iil.pet/run")
+RUN_API_KEY = os.environ.get("ORCHESTRATOR_MCP_API_KEY", "")
+RUN_TIMEOUT = int(os.environ.get("ORCHESTRATOR_RUN_TIMEOUT", "30"))
 
 
 def slug(name: str) -> str:
@@ -168,6 +179,87 @@ def _orch_upsert(key: str, md: str) -> bool:
     )
     out = _docker_py(code).strip().splitlines()
     return bool(out) and out[-1] == "WROTE"
+
+
+# Server-side enum (orchestrator_mcp/server.py agent_memory_upsert inputSchema).
+_VALID_ENTRY_TYPES = (
+    "open_task", "decision", "context", "lesson_learned",
+    "error_pattern", "repo_context", "agent_handoff",
+)
+
+
+def _orch_run(tool: str, arguments: dict) -> dict:
+    """Call an orchestrator tool through the stateless `/run` REST shim.
+
+    POST {tool, arguments} with Bearer auth → the server dispatches via
+    `handle_run` → `_call_tool_inner` (the *same* table the MCP tools use)
+    and returns the tool's JSON. Canonical transport: it sidesteps the SSE
+    per-process-session bug (every MCP tools/call → -32602) with no ssh/docker
+    hop and structured JSON in/out. Returns the parsed result dict; raises
+    TransportError on any failure.
+    """
+    if not RUN_API_KEY:
+        raise TransportError(
+            "ORCHESTRATOR_MCP_API_KEY not set — required for the /run transport. "
+            "Export it (e.g. sourced from ~/.secrets) before calling."
+        )
+    body = json.dumps({"tool": tool, "arguments": arguments}).encode("utf-8")
+    req = urllib.request.Request(
+        RUN_URL, data=body, method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {RUN_API_KEY}",
+            # Cloudflare (fronting orchestrator.iil.pet) bans the default
+            # "Python-urllib/x" UA with error 1010 — set an explicit one.
+            "User-Agent": "claude-policy/1.0",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=RUN_TIMEOUT) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:300]
+        raise TransportError(f"/run {tool}: HTTP {exc.code} — {detail}") from exc
+    except (urllib.error.URLError, json.JSONDecodeError) as exc:
+        raise TransportError(f"/run {tool}: {exc}") from exc
+    if isinstance(payload, dict) and payload.get("ok") is False:
+        raise TransportError(f"/run {tool}: {payload.get('error', 'unknown error')}")
+    return payload
+
+
+def _orch_upsert_entry(entry_key, entry_type, title, content, tags):
+    """Upsert any memory entry (any entry_type) via the `/run` transport.
+
+    Calls agent_memory_upsert through the stateless REST shim — structured
+    JSON, no base64/ssh/docker. Returns True if a write happened, False if
+    unchanged (content_hash dedup) or stub mode.
+    """
+    if entry_type not in _VALID_ENTRY_TYPES:
+        raise SystemExit(
+            f"invalid entry_type {entry_type!r}; one of {', '.join(_VALID_ENTRY_TYPES)}"
+        )
+    if ":" not in entry_key:
+        raise SystemExit(
+            f"invalid entry_key {entry_key!r}: MemoryEntrySchema requires "
+            "'namespace:identifier' (e.g. 'session:2026-05-30:platform')"
+        )
+    if STUB_MODE:
+        sys.stderr.write(
+            f"[stub] would /run agent_memory_upsert(entry_key={entry_key!r}, "
+            f"entry_type={entry_type!r}, title={title!r}, "
+            f"content=<{len(content)} chars>, tags={list(tags)!r})\n"
+        )
+        return False
+    result = _orch_run("agent_memory_upsert", {
+        "entry_key": entry_key,
+        "entry_type": entry_type,
+        "title": title,
+        "content": content,
+        "agent": "cascade",
+        "tags": list(tags),
+    })
+    # handle_run returns the tool JSON: {"ok": true, "written": <bool>, ...}
+    return bool(result.get("written", True)) if isinstance(result, dict) else True
 
 
 def _orch_fetch(key: str) -> str | None:
@@ -312,6 +404,21 @@ def cmd_diff(_a: argparse.Namespace) -> int:
     return drift and 1 or 0
 
 
+def cmd_remember(args: argparse.Namespace) -> int:
+    """Upsert an arbitrary memory entry (any entry_type) — the MCP-independent
+    path for session-ende Phase 2 et al. Content via --content or stdin."""
+    content = args.content
+    if content is None or content == "-":
+        content = sys.stdin.read()
+    if not content.strip():
+        sys.stderr.write("claude-policy remember: empty content\n")
+        return 2
+    tags = [t.strip() for t in (args.tags or "").split(",") if t.strip()]
+    wrote = _orch_upsert_entry(args.key, args.type, args.title, content, tags)
+    print("WROTE" if wrote else "UNCHANGED")
+    return 0
+
+
 # --- Main ---------------------------------------------------------------
 
 
@@ -328,6 +435,17 @@ def build_parser() -> argparse.ArgumentParser:
     sp_pull.add_argument("--yes", "-y", action="store_true", help="overwrite without prompt")
     sp_pull.set_defaults(fn=cmd_pull)
     sub.add_parser("diff", help="show drift, no writes").set_defaults(fn=cmd_diff)
+    sp_rem = sub.add_parser(
+        "remember",
+        help="upsert any memory entry (any entry_type) via the docker-exec store path",
+    )
+    sp_rem.add_argument("--key", required=True, help="entry_key, e.g. SESSION-20260530-PLATFORM")
+    sp_rem.add_argument("--type", default="context",
+                        help="entry_type (default: context); one of the ADR-113 enum")
+    sp_rem.add_argument("--title", required=True, help="short title")
+    sp_rem.add_argument("--content", help="content text; '-' or omit reads from stdin")
+    sp_rem.add_argument("--tags", help="comma-separated tags")
+    sp_rem.set_defaults(fn=cmd_remember)
     return p
 
 


### PR DESCRIPTION
## Problem

orchestrator-MCP-Memory über die **SSE-Bindung unbrauchbar**: `list_tools` klappt, aber **jeder `tools/call` → `-32602`** — verifiziert 2026-05-30 mit `agent_memory_upsert`, `agent_memory_search` UND dem **argumentlosen `workflow_list`**. → `session-ende` Phase 2 (pgvector) scheitert in jeder Session stumm.

## Root Cause (eingegrenzt, nicht geraten)

Per Prod-Check ausgeschlossen:
- **nicht Signatur/Schema:** deployed == source (flaches inputSchema, `context` im enum).
- **nicht nginx:** `POST /run` liefert sauber `401` → POST wird korrekt proxied.

Tatsächlich: **SSE-Per-Prozess-Session-State** (server.py `_lifespan`-Kommentar: *„session state is per-process today"*). Der `/sse`-Stream trägt die `session_id`; bricht er ab (Proxy-Idle-Timeout / Container-Restart), ist die Session verwaist → jeder folgende `tools/call` → `-32602`.

## Lösung — der sanktionierte `/run`-Pfad

Der Server hat bereits einen **stateless REST-Shim** `POST /run` (`handle_run` → `_call_tool_inner`, **dieselbe Dispatch-Tabelle wie die MCP-Tools** — Single Source of Truth), gebaut als Nicht-SSE-Escape-Hatch (dev-hub nutzt ihn schon).

Neuer Subcommand **`claude-policy remember`** ruft `agent_memory_upsert` über `/run`:

```bash
set -a; . ~/.secrets/orchestrator.env; set +a   # ORCHESTRATOR_MCP_API_KEY
echo "<content>" | claude-policy remember --key SESSION-… --type context --title "…" --tags "session,platform"
```

**Architektur:** sauberes `_orch_run(tool, arguments)`-HTTP-Primitiv (stdlib `urllib`, kein dep), env-getriebene Config (`ORCHESTRATOR_RUN_URL` / `ORCHESTRATOR_MCP_API_KEY` / `ORCHESTRATOR_RUN_TIMEOUT`), Key **nie eingebettet** (Tool ← env ← Secrets-Layer). Kein ssh/docker, kein Per-Prozess-Session, strukturiertes JSON, kein base64. `entry_type` gegen ADR-113-Enum validiert.

## Verifikation

`py_compile` ✓ · STUB-Test (Arg-Parsing, Enum-Reject, Unicode/Quotes) ✓ · fehlender-Key → klare `TransportError` (kein Crash) ✓ · `--help` listet `remember` ✓ · **Live-`/run`-Test** gegen Prod folgt im PR-Thread.

## Folge

- `push`/`pull`/`list`/`diff` können ebenfalls auf `_orch_run` migrieren → docker-Hack ganz ablösen.
- `/session-ende` Phase 2 von der (stale, nested) MCP-Annahme auf `claude-policy remember` umstellen.
- Eigentlicher Server-Fix: SSE-Session-Persistenz (mcp-hub#XX) — separat.

## Kein ADR nötig

Additive Erweiterung eines bestehenden Tools, nutzt einen bestehenden Server-Endpunkt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)