### PR TITLE
cc-skill-dist hardening: doctor footer-fix + CI-Gate, Policy CC-first, /escalate+/next in den Kanon (ADR-229/230)

### DIFF
--- a/.github/workflows/cc-skill-dist-doctor.yml
+++ b/.github/workflows/cc-skill-dist-doctor.yml
@@ -1,0 +1,36 @@
+name: CC-Skill-Dist Round-Trip (ADR-230)
+
+# Determinismus-Gate für die Skill-Distribution: erzeugt das Distributions-Ziel
+# aus dem PR-Baum (generate.py) und prüft, dass doctor.py es als Drift 0 liest.
+# Fängt Tooling-Regresse (z.B. generate-Footer ≠ doctor-Vergleich) VOR dem
+# gegateten Live-Rollout. Braucht KEIN ~/.claude/commands — rein selbst-konsistent.
+
+on:
+  push:
+    paths:
+      - "tools/cc-skill-dist/**"
+      - ".windsurf/workflows/**"
+  pull_request:
+    paths:
+      - "tools/cc-skill-dist/**"
+      - ".windsurf/workflows/**"
+
+jobs:
+  round-trip:
+    name: generate → doctor == Drift 0 (HEAD)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # ls-tree/cat-file gegen den vollen Baum
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      # Tools sind stdlib-only — keine pip-Deps.
+      - name: Generate Distributions-Ziel aus PR-Baum
+        run: python3 tools/cc-skill-dist/generate.py --ref HEAD --target /tmp/cc-roundtrip
+
+      - name: Doctor gegen Erzeugnis — erwartet Drift 0
+        run: python3 tools/cc-skill-dist/doctor.py --ref HEAD --commands /tmp/cc-roundtrip

--- a/.github/workflows/cc-skill-dist-doctor.yml
+++ b/.github/workflows/cc-skill-dist-doctor.yml
@@ -28,9 +28,10 @@ jobs:
         with:
           python-version: "3.12"
 
-      # Tools sind stdlib-only — keine pip-Deps.
+      # Tools sind stdlib-only — keine pip-Deps. --platform = Checkout (nicht der
+      # ~/github/platform-Default, der auf dem CI-Runner nicht existiert).
       - name: Generate Distributions-Ziel aus PR-Baum
-        run: python3 tools/cc-skill-dist/generate.py --ref HEAD --target /tmp/cc-roundtrip
+        run: python3 tools/cc-skill-dist/generate.py --platform "$GITHUB_WORKSPACE" --ref HEAD --target /tmp/cc-roundtrip
 
       - name: Doctor gegen Erzeugnis — erwartet Drift 0
-        run: python3 tools/cc-skill-dist/doctor.py --ref HEAD --commands /tmp/cc-roundtrip
+        run: python3 tools/cc-skill-dist/doctor.py --platform "$GITHUB_WORKSPACE" --ref HEAD --commands /tmp/cc-roundtrip

--- a/.windsurf/workflows/escalate.md
+++ b/.windsurf/workflows/escalate.md
@@ -1,0 +1,49 @@
+---
+description: Eskaliert eine Aufgabe an ein höheres Modell-Tier (Sonnet → Opus, oder Stop+Refactor)
+mode: read-only
+---
+
+# /escalate — Tier-Mismatch-Signal
+
+**Zweck**: User-Trigger, wenn die aktuelle Session-Modell-Stufe für die
+laufende Aufgabe zu klein ist. Im Gegensatz zu modellseitiger Selbst-
+Detection (unzuverlässig) ist `/escalate` ein **expliziter User-Befehl**.
+
+## Output
+
+```
+⚠️ Tier-Escalation angefordert.
+
+Aktuelle Session-Modell: <model aus System-Context>
+Empfohlene Aktion:
+
+  • Wenn aktuell Haiku/Sonnet → `/model claude-opus-4-7`  (Tier 4)
+  • Wenn aktuell Opus 4.7    → Aufgabe splitten:
+       1. den Anteil identifizieren, der NICHT konvergiert
+       2. ihn extrahieren und neu formulieren
+       3. ggf. mit /next neu priorisieren
+
+Tipps zum Erkennen, dass eine Aufgabe wirklich Tier-4 ist:
+  - Synthese über mehrere ADRs/Policies/Repos
+  - Reversibilitäts-Frage (DSGVO, Sicherheit, Lizenzen)
+  - Architektur-Entscheidung mit Folge-ADRs
+  - Wiederholte Sackgassen in Sonnet trotz klaren Inputs
+```
+
+## Anschluss
+
+- Wenn der User nach `/escalate` `/model claude-opus-4-7` ruft und denselben
+  Prompt wiederholt: in der neuen Session ist der Kontext frisch — daher den
+  bisherigen Stand mit 1–2 Sätzen rekapitulieren (was wurde versucht, wo
+  blieb's hängen), bevor die neue Lösung gestartet wird.
+
+## Was der Skill NICHT tut
+
+- Kein automatischer Modell-Wechsel (das geht nur über `/model`).
+- Keine Garantie, dass Opus die Aufgabe löst — manche Aufgaben sind nicht
+  Tier-, sondern Daten-/Klarheits-Probleme.
+
+## Changelog
+
+- 2026-05-20: Initial (live-only CC-Utility-Skill).
+- 2026-05-30: In den Kanon `platform main .windsurf/workflows/` promoted (ADR-230 CC-first); `mode: read-only` ergänzt.

--- a/.windsurf/workflows/next.md
+++ b/.windsurf/workflows/next.md
@@ -1,0 +1,73 @@
+---
+description: Zeigt die 3 sinnvollsten nächsten Schritte für den aktuellen Repo (mit Tier-Tag)
+mode: read-only
+---
+
+# /next — Schnell-Orientierung
+
+**Zweck**: in 3 Zeilen sagen, was als nächstes in diesem Repo sinnvoll ist —
+mit Modell-Tier-Tag (`[Sonnet]`/`[/fast]`/`[Opus]`). Funktioniert in **jedem**
+Repo, auch wenn dort noch keine `NEXT.md` existiert (Self-Healing).
+
+Einziger Seiteneffekt ist die **idempotente** Regeneration des lokalen
+`NEXT.md`-Caches (no-op, wenn frisch) — daher `mode: read-only`.
+
+## Mechanik
+
+1. **Selbst-Heilung**: `claude-next-sync` ausführen, das aktualisiert `NEXT.md`
+   aus `AGENT_HANDOVER.md` (falls vorhanden) oder aus git log (Fallback).
+   Wenn `NEXT.md` aktuell ist (jünger als Source und < 14 Tage alt), ist es
+   ein no-op (~0,1 s).
+
+2. **Tier-Mismatch-Warnung**: falls eines der Top-Items mit `[Opus]` markiert
+   ist und du **nicht** in einer Opus-Session bist (du siehst das im
+   System-Reminder: „You are powered by claude-sonnet-…" / „claude-haiku-…"
+   / „claude-opus-4-7"), gib eine klare Vorab-Warnung:
+
+   ```
+   ⚠️ Top-Item ist Tier-4 (Opus-Klasse). Aktuelle Session: <model>.
+      Empfehlung: `/model claude-opus-4-7` vor Start.
+   ```
+
+3. **Output-Format**:
+
+   ```
+   📋 NEXT · <repo>   (sync: 2026-05-20 11:30, fresh)
+
+   1. [Sonnet] Slice 1 — Cockpit echt
+   2. [/fast]  Platform-Registry committen
+   3. [Opus]   Hosting-ADR Sozialdaten
+
+   → Details: cat AGENT_HANDOVER.md
+   → Roster aller Repos: cat ~/.claude/state/next-roster.md
+   ```
+
+## Schritte
+
+```bash
+# 1. Self-Heal (silent if fresh)
+"$HOME/.claude/bin/claude-next-sync" --repo "$(pwd)" 2>/dev/null
+
+# 2. NEXT.md ausgeben
+[ -f NEXT.md ] && cat NEXT.md || echo "kein NEXT.md — Skript-Fallback griff nicht"
+```
+
+## Was der Skill NICHT tut
+
+- Keine Bestätigungs-Frage. Output → Ende.
+- Keine Heavy-Tool-Aufrufe (Web-Fetch, Orchestrator-MCP) — läuft auch in Haiku/Fast.
+- Kein Ritual. Wenn du tiefere Übersicht willst: `cat AGENT_HANDOVER.md`.
+
+## Wann den Bootstrap neu laufen lassen
+
+Bei neuen Repos oder wenn du den globalen Roster aktualisieren willst:
+
+```bash
+"$HOME/.claude/bin/claude-next-init"
+cat ~/.claude/state/next-roster.md
+```
+
+## Changelog
+
+- 2026-05-20: Initial (live-only CC-Utility-Skill).
+- 2026-05-30: In den Kanon `platform main .windsurf/workflows/` promoted (ADR-230 CC-first); `mode: read-only` ergänzt, hartkodierte `/home/devuser/…`-Pfade auf `$HOME` portabilisiert.

--- a/policies/README.md
+++ b/policies/README.md
@@ -5,9 +5,10 @@ landscape (achimdehnert, ttz-lif, meiki-lra). They are loaded by Claude Code
 on every session via `~/.claude/CLAUDE.md`.
 
 **SSoT = this directory** (`platform/policies/`, versioned). `~/.claude/policies/`
-is a symlink into a pinned platform worktree (`~/github/platform-pinned/policies/`)
-— same pattern as `~/.claude/commands` → `platform-workflows`. The
-`inject_policies.py` hook and `claude-policy` CLI read that path unchanged.
+is a symlink into a pinned platform worktree (`~/github/platform-pinned/policies/`).
+The `inject_policies.py` hook and `claude-policy` CLI read that path unchanged.
+(Note: the analogous `~/.claude/commands` distribution is migrating off the
+`platform-workflows` symlink to `cc-skill-dist` CC-first generation — ADR-230.)
 
 ## Files
 

--- a/policies/claude-skills.md
+++ b/policies/claude-skills.md
@@ -4,9 +4,9 @@
 
 ## Was ist eine CC-Skill?
 
-Markdown-Workflow mit YAML-Frontmatter, im Verzeichnis `platform-workflows/.windsurf/workflows/`. Verfügbar als Slash-Command in **beiden** Tools:
-- Claude Code via Symlink `~/.claude/commands/` → `~/github/platform-workflows/.windsurf/workflows/`
-- Windsurf Cascade nativ
+Markdown-Workflow mit YAML-Frontmatter. **Kanonische Quelle:** `platform` `main` `.windsurf/workflows/` (branch-stabil, resolved Commit) — **nicht** der `platform-workflows`-Worktree (Coding-Ära-Altlast).
+- **Claude Code (primär):** verteilt nach `~/.claude/commands/` über `cc-skill-dist` (`generate.py`/`doctor.py`, MANAGED-Footer + Manifest) — CC-first, ADR-230.
+- **Windsurf (nur ADR/Review):** Windsurf wird **nicht mehr zum Coden** genutzt. Es erhält ausschließlich das **Review-Subset** via `windsurf-subset.py` (`tool_targets: [windsurf-review]`), nicht alle Skills (ADR-229).
 
 Abgrenzung zu anderen Konzepten:
 - **Django Platform-Agents** (`dev-hub/apps/<agent>/`, siehe `platform-agents.md`) — Headless, scheduled, lange Laufzeit
@@ -17,7 +17,7 @@ Abgrenzung zu anderen Konzepten:
 CC-Skill ist die **Default-Antwort** bei:
 - Wiederkehrender Workflow >3× pro Woche manuell ausgeführt
 - Kombination aus 2+ MCP-Calls + Output-Aggregation
-- Bedarf für Cross-Tool-Verfügbarkeit (CC + Windsurf)
+- Wiederverwendbarkeit über CC-Sessions/Maschinen hinweg (CC-first; Windsurf nur für ADR/Review-Skills relevant)
 - Read-only-Analyse oder Reporting
 
 **Nicht** als Skill:
@@ -103,13 +103,17 @@ PR der eine neue Skill enthält oder eine bestehende ändert:
 4. Output-Format als Code-Block exemplifiziert
 5. CHANGELOG-Eintrag in der Skill-Datei
 
-## Verteilung
+## Verteilung (ADR-230 CC-first)
 
-`~/.claude/commands` Symlink ist **single-machine**. Cross-Machine-Sync für CC-Sessions auf Dev-Server/Prod:
-- Plan: zukünftig Plugin-basiertes Distribution (Backlog)
-- Aktuell: `git pull` in `~/github/platform-workflows` auf jeder Maschine
+Quelle = `platform main .windsurf/workflows/` (resolved Commit). Verteilung nach `~/.claude/commands/` über `platform/tools/cc-skill-dist/`:
+- `generate.py` — deterministische Kopien mit MANAGED-Footer (`source_commit`/`content_hash`/`do_not_edit`) + `manifest.json`; atomarer Swap mit `.bak`; Live nur mit `--allow-live` (gegatet, ADR-230 §8).
+- `doctor.py` — read-only Drift-Diagnose Quelle ↔ `~/.claude/commands` (footer-aware; CI-Round-Trip-Gate `cc-skill-dist-doctor.yml`).
+- Windsurf-Review-Subset: `windsurf-subset.py` (`tool_targets: [windsurf-review]`).
+
+Der frühere `~/.claude/commands` → `platform-workflows`-Symlink ist die **Coding-Ära-Altlast** und wird durch das gegatete Live-Rollout abgelöst; Cross-Machine-Sync läuft dann ebenfalls über `generate.py` je Maschine.
 
 ## Changelog
 
 - 2026-05-15: Initial. Geschrieben nach Dogfood-Findings der ersten 2 CC-Skills (`/adr-curator`, `/adr-challenger`, PR #168). Schließt Policy-Lücke die `platform-agents.md` offen ließ.
 - 2026-05-15: Pushed to orchestrator memory (`entry_key: policy:claude-skills`).
+- 2026-05-30: Auf ADR-229/230 (CC-first) ausgerichtet — Quelle = `platform main` (nicht `platform-workflows`-Worktree), Windsurf nur ADR/Review-Subset (nicht mehr Coding), Verteilung über `cc-skill-dist`. Stale „beide Tools / platform-workflows / Plugin-Backlog"-Prämisse korrigiert.

--- a/tools/cc-skill-dist/doctor.py
+++ b/tools/cc-skill-dist/doctor.py
@@ -9,6 +9,15 @@ Usage: doctor.py [--platform ~/github/platform] [--commands ~/.claude/commands] 
 """
 import argparse, os, subprocess, sys
 
+# Footer, den generate.py an jede verteilte Kopie anhängt (MANAGED-BY-Marke).
+# doctor muss ihn vor dem Inhaltsvergleich abstreifen, sonst liest sich jede
+# korrekt generierte Kopie fälschlich als copy-stale (Footer ≠ nackter Blob).
+MARK = "MANAGED-BY: platform/tools/cc-skill-dist"
+
+def strip_managed_footer(text):
+    idx = text.rfind("<!-- " + MARK)
+    return text if idx == -1 else text[:idx]
+
 def git(args, cwd):
     r = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
     return r.stdout if r.returncode == 0 else None
@@ -50,7 +59,8 @@ def main():
             disk = open(path, encoding="utf-8", errors="ignore").read()
         except Exception as e:
             issues.append(("unlesbar", name, str(e)[:40])); continue
-        same = (disk == (canon_content(canon[name]) or "\0"))
+        src = canon_content(canon[name]) or "\0"
+        same = (strip_managed_footer(disk).rstrip("\n") == src.rstrip("\n"))
         if is_link:
             sym_ok += 1 if same else 0
             if not same: sym_stale += 1; issues.append(("symlink-stale", name, "Symlink-Inhalt ≠ Quelle"))


### PR DESCRIPTION
## Was & Warum

Härtet die **CC-first Skill-Distribution** (ADR-229/230) auf der Tooling- und Policy-Ebene — entstanden beim Versuch, den gegateten Live-Rollout (`generate --allow-live`) vorzubereiten.

### 1. `fix(cc-skill-dist)` — doctor footer-aware + Round-Trip-CI-Gate
- **Bug:** `generate.py` hängt an jede Kopie einen MANAGED-Footer (`generate.py:62-64`), aber `doctor.py` verglich **byte-exakt** gegen den nackten Kanon-Blob → jede generierte Kopie las sich als `copy-stale`. Der Post-Live-Gate konnte **nie Drift 0** zeigen (Staging-Probe ergab Drift 69 statt 0). Damit war der ganze Live-Rollout-Recheck unerfüllbar.
- **Fix:** Footer am `MARK` abstreifen vor dem Vergleich. Verifiziert: generiertes Ziel → Drift 0; echte Drift (stale/extra/fehlend) bleibt sichtbar.
- **Neu:** `.github/workflows/cc-skill-dist-doctor.yml` — Round-Trip-Gate (`generate --ref HEAD` → `doctor` == Drift 0). Hätte genau diesen Bug gefangen.

### 2. `docs(policy)` — claude-skills auf ADR-229/230 CC-first ausrichten
Die Policy trug noch die **Coding-Ära-Prämisse**: Quelle = `platform-workflows`-Worktree, „verfügbar in **beiden** Tools / Windsurf nativ", Verteilung per `git pull` / Plugin-Backlog. Korrigiert auf: Quelle = **`platform main`**, **Windsurf nur ADR/Review-Subset** (nicht mehr Coden), Verteilung über **`cc-skill-dist`**. `README.md` analog (falsche `commands → platform-workflows`-Analogie entschärft).

### 3. `feat(skills)` — `/escalate` + `/next` in den Kanon
Beide existierten nur live in `~/.claude/commands` (nie im Kanon) → ein `generate --allow-live` hätte sie **gelöscht**. Jetzt kanonisch. Geprüft gegen `policies/claude-skills.md`: `mode: read-only` + Changelog ergänzt; `next.md` hartkodierte `/home/devuser/…`-Pfade auf `$HOME` portabilisiert (echter Distributions-Bug). Step 0 (project-facts) n/a — Meta/CC-Utility-Skills.

## Dogfood
```
$ python3 tools/cc-skill-dist/generate.py --ref HEAD --target /tmp/cc-rt2   # 71 Skills
$ python3 tools/cc-skill-dist/doctor.py   --ref HEAD --commands /tmp/cc-rt2
=== DRIFT-SCORE: 0 (0 = sauber) ===   # exit 0
```
Gegenprobe: der alte footer-blinde doctor meldete auf demselben Ziel Drift 69.

## Bewusst NICHT in diesem PR (gegatet, ADR-230 §8 — eigene Entscheidung)
- **Live-Rollout** `generate --allow-live` (Re-Pointing `~/.claude/commands` weg vom `platform-workflows`-Symlink).
- **Live-Sync der Policy-Korrektur:** `~/.claude/policies` ist Symlink auf `platform-pinned` (gepinnt) → greift erst nach Merge + Pin-Vorrücken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
