### PR TITLE
fix(ci): force-reinstall iil-packages — stale self-hosted Tool-Cache besiegen (flaky aifw-Contract)

### DIFF
--- a/.github/actions/install-iil-packages/action.yml
+++ b/.github/actions/install-iil-packages/action.yml
@@ -75,14 +75,18 @@ runs:
         else
           echo "::warning::${{ inputs.requirements_file }} not found — only the action's default iil ranges were used (no consumer pins re-asserted)."
         fi
-        # Guard that --no-deps did not leave a broken dependency tree:
-        python -m pip check || { echo "::error::pip check failed after iil-package reinstall"; exit 1; }
+        # Advisory: surface a broken --no-deps tree without hard-failing. The
+        # shared self-hosted tool-cache can carry PRE-EXISTING unrelated
+        # conflicts; a hard `pip check` would turn those into red CI for every
+        # consumer. Becomes a hard gate once job-local venv isolation lands (#357).
+        python -m pip check || echo "::warning::pip check reported issues after iil reinstall (advisory until venv isolation, #357)"
         # Freshness probe — the exact bug this step fixes is .dist-info metadata
-        # claiming a version while the installed CODE is stale. Assert metadata
-        # == the code's own __version__ for iil-aifw (version-agnostic: works for
-        # any pinned version). A partial/raced reinstall fails LOUD here instead
-        # of surfacing later as a confusing "flaky" contract test.
-        python -c "import importlib.metadata as M, aifw, sys; meta=M.version('iil-aifw'); code=getattr(aifw,'__version__',None); print('iil-aifw metadata=%s code=%s @ %s'%(meta,code,aifw.__file__)); sys.exit('::error::iil-aifw metadata %s != code %s — stale tool-cache not repaired'%(meta,code)) if code and code!=meta else None"
+        # claiming a version while the installed CODE is stale. If iil-aifw is
+        # present, assert metadata == the code's own __version__ (version-agnostic).
+        # Guarded on presence: repos that don't use iil-aifw (or a best-effort
+        # install above failed) must NOT fail here — the critical case (a pinned
+        # consumer dep) already fails fatally in the requirements pass above.
+        python -c "import importlib.util as u,importlib.metadata as M,sys; (sys.exit(0) if u.find_spec('aifw') is None else None); import aifw; meta=M.version('iil-aifw'); code=getattr(aifw,'__version__',None); print('iil-aifw metadata=%s code=%s @ %s'%(meta,code,aifw.__file__)); sys.exit('::error::iil-aifw metadata %s != code %s — stale tool-cache not repaired'%(meta,code)) if code and code!=meta else None"
         # iil-fieldprefill: private repo, not on PyPI (ADR-107)
         if [ -n "$PROJECT_PAT" ]; then
           pip install "git+https://x-access-token:${PROJECT_PAT}@github.com/achimdehnert/iil-fieldprefill.git" 2>/dev/null || true

--- a/.github/actions/install-iil-packages/action.yml
+++ b/.github/actions/install-iil-packages/action.yml
@@ -47,15 +47,16 @@ runs:
       # --no-deps keeps it fast (deps already resolved by requirements.txt above).
       run: |
         # Presence + code-freshness for the iil family (covers repos that do
-        # not pin them in requirements.txt):
-        pip install --force-reinstall --no-deps \
+        # not pin them in requirements.txt). `python -m pip` ensures the install
+        # hits the SAME interpreter the tests use.
+        python -m pip install --force-reinstall --no-deps \
           "iil-aifw>=0.5.0,<1" \
           "iil-promptfw>=0.5.1,<1" \
           "iil-authoringfw>=0.3.0,<1" \
           "iil-weltenfw>=0.1.0,<1" \
           "iil-nl2cad>=0.1.0,<1" \
           2>/dev/null || \
-        pip install --force-reinstall --no-deps \
+        python -m pip install --force-reinstall --no-deps \
           "aifw>=0.5.0,<1" \
           "promptfw>=0.2.0,<1" \
           "authoringfw>=0.3.0,<1" \
@@ -63,14 +64,25 @@ runs:
           2>/dev/null || true
         # Authoritative: re-assert the consumer's requirements.txt pins so the
         # looser ranges above can never override an intended cap (e.g. a repo
-        # pinning iil-aifw<0.11 must not get a future 0.11 from here).
+        # pinning iil-aifw<0.11 must not get a future 0.11 from here). A pinned
+        # spec that fails to install is FATAL here (no `|| true`).
         if [ -f "${{ inputs.requirements_file }}" ]; then
           pins=$(grep -iE '^(iil-aifw|iil-promptfw|iil-authoringfw|iil-weltenfw|iil-nl2cad)([<>=!~ ]|$)' \
                  "${{ inputs.requirements_file }}" || true)
           if [ -n "$pins" ]; then
-            printf '%s\n' "$pins" | pip install --force-reinstall --no-deps -r /dev/stdin
+            printf '%s\n' "$pins" | python -m pip install --force-reinstall --no-deps -r /dev/stdin
           fi
+        else
+          echo "::warning::${{ inputs.requirements_file }} not found — only the action's default iil ranges were used (no consumer pins re-asserted)."
         fi
+        # Guard that --no-deps did not leave a broken dependency tree:
+        python -m pip check || { echo "::error::pip check failed after iil-package reinstall"; exit 1; }
+        # Freshness probe — the exact bug this step fixes is .dist-info metadata
+        # claiming a version while the installed CODE is stale. Assert metadata
+        # == the code's own __version__ for iil-aifw (version-agnostic: works for
+        # any pinned version). A partial/raced reinstall fails LOUD here instead
+        # of surfacing later as a confusing "flaky" contract test.
+        python -c "import importlib.metadata as M, aifw, sys; meta=M.version('iil-aifw'); code=getattr(aifw,'__version__',None); print('iil-aifw metadata=%s code=%s @ %s'%(meta,code,aifw.__file__)); sys.exit('::error::iil-aifw metadata %s != code %s — stale tool-cache not repaired'%(meta,code)) if code and code!=meta else None"
         # iil-fieldprefill: private repo, not on PyPI (ADR-107)
         if [ -n "$PROJECT_PAT" ]; then
           pip install "git+https://x-access-token:${PROJECT_PAT}@github.com/achimdehnert/iil-fieldprefill.git" 2>/dev/null || true

--- a/.github/actions/install-iil-packages/action.yml
+++ b/.github/actions/install-iil-packages/action.yml
@@ -36,20 +36,41 @@ runs:
       shell: bash
       env:
         PROJECT_PAT: ${{ inputs.project_pat }}
+      # --force-reinstall --no-deps: self-hosted runners share a PERSISTENT
+      # setup-python tool-cache. A prior partial/concurrent install can leave an
+      # iil-package with CURRENT metadata (e.g. iil-aifw 0.10.2 in .dist-info)
+      # but STALE code in __init__.py — missing newer public-API symbols. Plain
+      # `pip install` then sees "already satisfied" and never repairs it, so
+      # contract tests fail intermittently (missing get_action_config/QualityLevel/
+      # AIFWError, 'LLMResult' has no 'as_json', …). Forcing a code-level reinstall
+      # makes the installed code always match the pin, regardless of cache state.
+      # --no-deps keeps it fast (deps already resolved by requirements.txt above).
       run: |
-        pip install \
+        # Presence + code-freshness for the iil family (covers repos that do
+        # not pin them in requirements.txt):
+        pip install --force-reinstall --no-deps \
           "iil-aifw>=0.5.0,<1" \
           "iil-promptfw>=0.5.1,<1" \
           "iil-authoringfw>=0.3.0,<1" \
           "iil-weltenfw>=0.1.0,<1" \
           "iil-nl2cad>=0.1.0,<1" \
           2>/dev/null || \
-        pip install \
+        pip install --force-reinstall --no-deps \
           "aifw>=0.5.0,<1" \
           "promptfw>=0.2.0,<1" \
           "authoringfw>=0.3.0,<1" \
           "weltenfw>=0.1.0,<1" \
           2>/dev/null || true
+        # Authoritative: re-assert the consumer's requirements.txt pins so the
+        # looser ranges above can never override an intended cap (e.g. a repo
+        # pinning iil-aifw<0.11 must not get a future 0.11 from here).
+        if [ -f "${{ inputs.requirements_file }}" ]; then
+          pins=$(grep -iE '^(iil-aifw|iil-promptfw|iil-authoringfw|iil-weltenfw|iil-nl2cad)([<>=!~ ]|$)' \
+                 "${{ inputs.requirements_file }}" || true)
+          if [ -n "$pins" ]; then
+            printf '%s\n' "$pins" | pip install --force-reinstall --no-deps -r /dev/stdin
+          fi
+        fi
         # iil-fieldprefill: private repo, not on PyPI (ADR-107)
         if [ -n "$PROJECT_PAT" ]; then
           pip install "git+https://x-access-token:${PROJECT_PAT}@github.com/achimdehnert/iil-fieldprefill.git" 2>/dev/null || true


### PR DESCRIPTION
## Problem (höchster Hebel — bremst ALLE dev-hub PRs/Deploys)

Der iil-aifw-Contract-Test wird **intermittierend rot** auf `Unit Tests` (CI `_ci-python.yml@main`) und blockiert so gelegentlich `Unit→Deploy`. Heute 2× passiert (z. B. CI `fix/welle0b` 11:10 ❌ → 11:14 ✅, gleicher Branch).

## Root Cause (aus dem echten Fehler-Log, nicht geraten)

Run 26682308021, Step „Unit Tests":
```
ImportError: cannot import name 'get_action_config' from 'aifw'
  (…/_work/_tool/Python/3.12.13/x64/.../aifw/__init__.py)
AssertionError: iil-aifw is missing public API symbols: [get_action_config, QualityLevel, AIFWError, …]
AttributeError: 'LLMResult' object has no attribute 'as_json'
```
Gleichzeitig meldet pip: `Requirement already satisfied: iil-aifw<0.11,>=0.10.2 … (0.10.2)`.

→ Der **self-hosted Runner-Tool-Cache** (`_work/_tool/Python/.../site-packages`, persistent & shared) hat ein iil-aifw mit **0.10.2-Metadaten, aber stale Code** (fehlende Symbole) — Resultat eines früheren partiellen/parallelen Installs. Weil pip „already satisfied" sieht, **repariert es den Code nie**. Intermittierend = je nach Cache-Zustand (frischer Cache → grün).

Also: **nicht** PyPI (0.10.2 ist korrekt), **nicht** der Pin — sondern der Tool-Cache + fehlendes `--force-reinstall`.

## Fix

`install-iil-packages` (von allen Test-Jobs genutzt) macht jetzt `--force-reinstall --no-deps` für die iil-Familie → installierter **Code == Pin**, egal welcher Cache-Zustand. `--no-deps` hält es schnell (Deps schon via requirements.txt aufgelöst). Ein finaler Pass **re-asserted die requirements.txt-Pins des Consumers**, damit die loseren Action-Ranges keinen Cap überstimmen (z. B. `iil-aifw<0.11`).

## Blast Radius / Verifikation

Shared Action via `_ci-python.yml@main` → schützt **alle** Consumer-Repos, nicht nur dev-hub (= der Hebel). YAML validiert, grep-Logik gegen dev-hubs requirements.txt geprüft. Echter Beweis: die nächsten (bisher flaky) CI-Runs bleiben grün — am besten nach Merge einen zuvor roten dev-hub-PR re-runnen.

## Kein ADR nötig

Bugfix innerhalb des bestehenden reusable-CI-Musters (ADR-021/160), keine neue Architektur-Entscheidung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)