### PR TITLE
feat(infra): /infra-overview — read-only single-pane MVP (local/staging/prod)

### DIFF
--- a/.windsurf/workflows/infra-overview.md
+++ b/.windsurf/workflows/infra-overview.md
@@ -1,0 +1,91 @@
+---
+description: Read-only Single-Pane-Infra-Übersicht — Server, App×Umgebung-Ports, Drift (local/staging/prod)
+mode: read-only
+---
+
+# /infra-overview — Single Pane of Glass
+
+> **Wann:** schneller Gesamtblick „was läuft wo" über alle Umgebungen
+> (dev/staging/prod) — Server-Inventar, App×Umgebung-Port-Matrix, Compose-Drift.
+> **Wann NICHT:** Deep-Dive Container-Health/Logs eines Servers → `/infra-health`;
+> Config↔Server-State-Audit → `/drift-check`; Compose-Compliance → `/compose-audit`.
+> Dieses Skill **aggregiert** die SSoT, es ersetzt die Spezial-Audits nicht.
+
+## Verwendung
+
+```
+/infra-overview            # offline, deterministisch (kein SSH)
+/infra-overview --live     # + read-only TCP-Reachability je Server
+```
+
+## Step 0: Platform-Kontext (NICHT hardcoden)
+
+Die SSoT (`infra/ports.yaml`) lebt im **platform**-Repo. Pfad über die
+Umgebungs-Konvention, nie literal:
+
+```bash
+PLATFORM="${GITHUB_DIR:-$HOME/github}/platform"
+```
+
+## Step 1: Übersicht erzeugen (read-only)
+
+```bash
+python3 "$PLATFORM/infra/scripts/infra_overview.py"
+```
+
+Aggregiert aus `infra/ports.yaml`:
+- **Server-Inventar** (dev/staging/prod + IP/Name, ADR-157)
+- **App × Umgebung Port-Matrix** (alle Hubs, ein Web-Port pro Umgebung)
+- **Compose-Drift** (Port in `ports.yaml` ≠ Compose-File → deploy-blocker)
+- **Staging≠Prod-Skew** (ADR-164 will `staging=prod`; markiert bewusste Ausnahmen)
+
+Exit-Code: `0` = keine Compose-Drift, `1` = Drift (CI-tauglich).
+
+## Step 2: Live-Reachability (optional)
+
+```bash
+python3 "$PLATFORM/infra/scripts/infra_overview.py" --live
+```
+
+Hängt read-only TCP-Probe + Uptime je Server an (delegiert an
+`server_probe.py --all`; umgeht ICMP-Blocking). **Kein Write, kein Deploy.**
+
+## Output-Format
+
+```
+=== Infra-Overview (read-only) — Quelle: ports.yaml, 24 Apps ===
+
+SERVER
+  dev      88.99.38.75      Dev Desktop (Development)
+  staging  178.104.184.168  Hetzner Staging (Dedicated)
+  prod     88.198.191.108   Hetzner Dedicated (Production)
+
+APP                            dev  staging   prod   drift
+  risk-hub                    8090     8099   8090   compose+skew
+  trading-hub                 8088     8088   8088   compose
+  coach-hub                   8007     8007   8007   ok
+  ...
+
+COMPOSE-DRIFT (7/24 betroffen — deploy-blocker)
+  ! trading-hub: docker-compose.yml uses 8000:8000 — must change to 8088:8000
+  ...
+
+STAGING≠PROD-SKEW (1 — ADR-164 will staging=prod; ggf. bewusste Ausnahme)
+  ~ risk-hub: staging=8099 prod=8090
+
+=== DRIFT (compose): 7 (0 = sauber) ===
+```
+
+## Anti-Patterns
+
+- ❌ Server-IPs / Ports / Pfade im Skill hardcoden — alles kommt aus `ports.yaml`
+  bzw. der `GITHUB_DIR`-Konvention.
+- ❌ `--live` als „Health-Check" verkaufen: es ist nur TCP-Reachability, kein
+  Container-/App-Health (dafür `/infra-health`).
+- ❌ Drift hier „fixen": read-only. Fixes laufen über `/compose-audit` + Deploy.
+
+## Changelog
+
+- 2026-05-30: Initial. MVP-Aggregator (offline-Matrix + Drift; `--live`
+  Passthrough an `server_probe.py`). Dogfood: 24 Apps, 7 Compose-Drift,
+  1 Staging-Skew, exit 1.

--- a/infra/scripts/infra_overview.py
+++ b/infra/scripts/infra_overview.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""infra_overview.py — read-only Single-Pane Infra-Übersicht (platform, ADR-157/164).
+
+Aggregiert die SSoT `infra/ports.yaml` zu EINER Ansicht:
+  - Server-Inventar (dev/staging/prod)
+  - App × Umgebung Port-Matrix (die kein bestehendes Tool druckt)
+  - Compose-Drift (Port in ports.yaml ≠ Compose-File) + Staging≠Prod-Skew
+
+Default = OFFLINE/deterministisch (kein SSH, CI-tauglich). `--live` hängt die
+read-only TCP-Reachability je Server an, indem es an `server_probe.py --all`
+delegiert (kein eigener Netz-Code). **Reines Reporting — schreibt nichts.**
+
+Exit: 0 = keine Compose-Drift, 1 = Compose-Drift gefunden (deploy-blocker).
+"""
+import argparse, os, subprocess, sys
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML fehlt — pip install pyyaml")
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_PORTS = os.path.normpath(os.path.join(HERE, "..", "ports.yaml"))
+ENVS = ["dev", "staging", "prod"]  # 'dev' = Dev-Desktop / lokal
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Read-only Single-Pane Infra-Übersicht (platform)")
+    ap.add_argument("--ports", default=DEFAULT_PORTS, help="Pfad zu ports.yaml")
+    ap.add_argument("--live", action="store_true",
+                    help="read-only TCP-Probe je Server (delegiert an server_probe.py --all)")
+    args = ap.parse_args()
+
+    with open(args.ports, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    servers = data.get("servers", {}) or {}
+    services = data.get("services", {}) or {}
+
+    print(f"=== Infra-Overview (read-only) — Quelle: {os.path.basename(args.ports)}, "
+          f"{len(services)} Apps ===\n")
+
+    # --- Server-Inventar ---
+    print("SERVER")
+    for env in ENVS:
+        s = servers.get(env)
+        if s:
+            print(f"  {env:<8} {str(s.get('ip','')):<16} {s.get('name','')}")
+        else:
+            print(f"  {env:<8} {'—':<16} (kein Server definiert)")
+    print()
+
+    # --- App × Umgebung Matrix + Drift-Klassifikation ---
+    compose_drift = {}
+    skew = {}
+    for name, svc in services.items():
+        if svc.get("compose_drift"):
+            compose_drift[name] = svc["compose_drift"]
+        sp, st = svc.get("prod"), svc.get("staging")
+        if isinstance(sp, int) and isinstance(st, int) and sp != st:
+            skew[name] = (st, sp)
+
+    print(f"{'APP':<28} {'dev':>5} {'staging':>8} {'prod':>6}   drift")
+    for name in sorted(services):
+        svc = services[name]
+        tags = []
+        if name in compose_drift:
+            tags.append("compose")
+        if name in skew:
+            tags.append("skew")
+        flag = "+".join(tags) if tags else "ok"
+        print(f"  {name:<26} {str(svc.get('dev','—')):>5} {str(svc.get('staging','—')):>8} "
+              f"{str(svc.get('prod','—')):>6}   {flag}")
+    print()
+
+    # --- Drift-Detail ---
+    print(f"COMPOSE-DRIFT ({len(compose_drift)}/{len(services)} betroffen — deploy-blocker)")
+    for n in sorted(compose_drift):
+        print(f"  ! {n}: {compose_drift[n]}")
+    if not compose_drift:
+        print("  ok — keine")
+    if skew:
+        print(f"\nSTAGING≠PROD-SKEW ({len(skew)} — ADR-164 will staging=prod; ggf. bewusste Ausnahme)")
+        for n in sorted(skew):
+            st, sp = skew[n]
+            print(f"  ~ {n}: staging={st} prod={sp}")
+    print()
+
+    # --- Live (optional, read-only Passthrough) ---
+    if args.live:
+        print("LIVE-REACHABILITY (server_probe.py --all, read-only TCP)\n")
+        probe = os.path.join(HERE, "server_probe.py")
+        rc = subprocess.run([sys.executable, probe, "--all"]).returncode
+        print(f"\n  (server_probe exit={rc})")
+    else:
+        print("LIVE: übersprungen — '--live' für TCP-Probe + Uptime je Server")
+
+    drift_total = len(compose_drift)
+    print(f"\n=== DRIFT (compose): {drift_total} (0 = sauber) ===")
+    return 1 if drift_total else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Was & Warum

Schließt die **Infra-Transparenz-Lücke**: bisher zeigt **kein** Skill „was läuft wo" über dev/staging/prod in *einer* Ansicht — die Info ist über `infra-health` (prod), `drift-check`, `compose-audit` u.a. verstreut. `/infra-overview` ist der read-only **Single-Pane-Aggregator** über die SSoT `infra/ports.yaml`.

## Scope (bewusst MVP, read-only)
- **Server-Inventar** dev/staging/prod (ADR-157)
- **App × Umgebung Port-Matrix** (24 Hubs, ein Web-Port je Umgebung)
- **Compose-Drift** (Port in ports.yaml ≠ Compose-File → deploy-blocker)
- **Staging≠Prod-Skew** (ADR-164 will staging=prod; markiert bewusste Ausnahmen)
- `--live`: read-only TCP-Reachability je Server — **delegiert** an `server_probe.py --all` (kein eigener Netz-Code, DRY)

Kein Web-UI, keine Historie, kein Deploy — das ist nicht Ziel des MVP.

## Dogfood (offline, deterministisch)
```
$ python3 infra/scripts/infra_overview.py
=== Infra-Overview (read-only) — Quelle: ports.yaml, 24 Apps ===
SERVER
  dev      88.99.38.75      Dev Desktop (Development)
  staging  178.104.184.168  Hetzner Staging (Dedicated)
  prod     88.198.191.108   Hetzner Dedicated (Production)
APP                            dev  staging   prod   drift
  risk-hub                    8090     8099   8090   compose+skew
  ...
COMPOSE-DRIFT (7/24 betroffen — deploy-blocker)
STAGING≠PROD-SKEW (1) ~ risk-hub: staging=8099 prod=8090
=== DRIFT (compose): 7 (0 = sauber) ===   # exit 1
```
Befund nebenbei: **7** Compose-Drifts (nicht 6) + risk-hub-Skew — beides reale ports.yaml-Einträge.

## Konventionen
- `mode: read-only`, kein Hardcode (Pfade über `GITHUB_DIR`, IPs/Ports aus `ports.yaml`), Anti-Patterns + Output-Format + Changelog vorhanden (policies/claude-skills.md).
- Round-Trip-Gate `cc-skill-dist-doctor.yml` deckt das neue Skill ab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
