### PR TITLE
docs(adr-211): Rev 18 — Executable-Parity-Bridge (Spec-as-SoR über den Lebenszyklus)

### DIFF
--- a/docs/adr/ADR-211-klickdummy-benutzeranforderungen-entwicklungsprozess.md
+++ b/docs/adr/ADR-211-klickdummy-benutzeranforderungen-entwicklungsprozess.md
@@ -70,9 +70,9 @@ Drift-Memory (meiki-hub-Auto-Memory, `drift: true`) **und** Followup-Issue
 
 | # | Invariante | Erzwingung |
 |---|---|---|
-| **I1 Spec-first** | Maschinenlesbares, versioniertes Spec-Artefakt (YAML/JSON/strukturiertes Frontmatter); Markdown-Bullets zählen nicht. Klickdummy rendert es, ist nicht die Quelle. **Bidirektionale Coverage:** jede Impl-Route hat einen Spec-Eintrag *und* jeder Spec-Eintrag eine Route/Screen — kein einseitiges „Datei existiert & rendert". *Rev 12:* die Spec ist auch der **Eingang für Anforderungs-Updates** — optional über Co-Creation-Loop (§Co-Creation, opt-in) und **Ausgang** für abgeleitete Requirements (§Requirements-Bridge, opt-in). *Rev 17 — Daten-Treue der Anzeige (Klarstellung, kein neues Gate):* ausgegebene Zahlen/Aggregate (Counts, Summen, KPIs) sind aus den im Klickdummy vorhandenen Daten **berechnet**, nicht als Literal geschrieben — auch in `class: mock` (Daten dürfen synthetisch sein, die **Berechnung** muss echt sein). Cross-Screen-Aggregate (Eltern-Kachel = Summe der Kind-Liste) aus **einer** Quelle rechnen. | `make -C <repo> klickdummy-i1` (Exit-Code), CI-verifiziert — prüft Spec↔Route-Coverage, nicht nur Spec==Render · *Rev 17:* Daten-Treue = **Review-Gate** (kein sauberer Exit-Code; optional heuristischer Lint, der Zahl-Literale in Anzeige-Elementen ohne Datenbindung flaggt) |
+| **I1 Spec-first** | Maschinenlesbares, versioniertes Spec-Artefakt (YAML/JSON/strukturiertes Frontmatter); Markdown-Bullets zählen nicht. Klickdummy rendert es, ist nicht die Quelle. **Bidirektionale Coverage:** jede Impl-Route hat einen Spec-Eintrag *und* jeder Spec-Eintrag eine Route/Screen — kein einseitiges „Datei existiert & rendert". *Rev 12:* die Spec ist auch der **Eingang für Anforderungs-Updates** — optional über Co-Creation-Loop (§Co-Creation, opt-in) und **Ausgang** für abgeleitete Requirements (§Requirements-Bridge, opt-in). *Rev 17 — Daten-Treue der Anzeige (Klarstellung, kein neues Gate):* ausgegebene Zahlen/Aggregate (Counts, Summen, KPIs) sind aus den im Klickdummy vorhandenen Daten **berechnet**, nicht als Literal geschrieben — auch in `class: mock` (Daten dürfen synthetisch sein, die **Berechnung** muss echt sein). Cross-Screen-Aggregate (Eltern-Kachel = Summe der Kind-Liste) aus **einer** Quelle rechnen. *Rev 18 — Ausführbare Parity-Ableitung (Klarstellung, kein neues Gate):* `parity_acceptance`-Einträge dürfen einen optionalen ausführbaren `assert`-Block tragen; ein forward-only deterministischer Generator (`klickdummy-gen-e2e`, §Executable-Parity-Bridge) erzeugt daraus eine Suite, die per `SPEC_RENDERER_BASE_URL` Renderer #1 (Klickdummy) **und** #2 (echte App) gegen dieselbe Assertion prüft (parity-grün gegen #2 = I3-Off-Ramp-Gate). Die Tests sind **abgeleitetes, regenerierbares** Artefakt — die Spec bleibt normativer Acceptance-Record, **weder Produktionscode noch Test-Harness-Quelle**; Prosa-`check` bleibt normativ und gewinnt bei Konflikt mit `assert`. | `make -C <repo> klickdummy-i1` (Exit-Code), CI-verifiziert — prüft Spec↔Route-Coverage, nicht nur Spec==Render · *Rev 17:* Daten-Treue = **Review-Gate** (kein sauberer Exit-Code; optional heuristischer Lint, der Zahl-Literale in Anzeige-Elementen ohne Datenbindung flaggt) · *Rev 18:* Determinismus + Drift-Gate `klickdummy-parity-drift` (Exit-Code, Reuse S10-Muster); Prosa↔`assert`-Konflikt = Review-Gate; Coverage/Skip-Debt im Manifest |
 | **I2 Prod-Sicherheit (4-Pattern, Rev 11)** | Genau **ein** Pattern je Klickdummy, **explizit deklariert**: `mock` / `stub-demo` / `story` / `spec-demo` (Achsen: *Datenquelle × Code-Pfad-Identität*; vollständige Definition siehe Glossar). „Kein Pattern deklariert" = I2-Verstoß (kein vacuous pass). Die Vereinfachung *Mock-Prototyp/Demo-Render* (Rev ≤10) wird hier verfeinert, weil die drei Nicht-`mock`-Patterns *distinkte* Prod-Probes erfordern. | **Zwei Schichten:** (a) repo-definierter `make -C <repo> klickdummy-i2` (Selbstaussage des Patterns); (b) **plattform-externer Prod-Probe** `klickdummy_prod_guard.sh` mit pattern-spezifischem Verhalten: `mock` ⇒ N/A (Pfad nicht in Prod-Deploy); `stub-demo` ⇒ deklarierte Demo-Route 404; `story` ⇒ Catalog-Route (z. B. `/storybook/`) 404; `spec-demo` ⇒ `?demo=<state>` 404/disabled. (b) bleibt das **bindende Cross-Repo-Signal** (F3) |
-| **I3 Lebenszyklus + TTL + Sunset (Rev 11)** | **A ohne Zielsystem:** Pflicht-Frontmatter `sunset_after: <ISO-Datum>` in der Repo-Klickdummy-ADR (Default ADR-Datum + 12 Monate); nach Fristablauf ohne PR-Extension ⇒ ADR auto-`deprecated`, Pfad `klickdummy/archive/` (siehe §Frontmatter-Konvention). **B Transition:** ab erstem Screen mit Impl-Route greift I3 je Screen. **C mit Zielsystem:** Doppelquelle endet bei **`min(prod-Release, Parity-grün + N Tagen)`** (N Default **30 d**, repo-tunbar) — schließt das „ewig auf Staging"-Leck (F4). Staging ist erlaubter Doppelquell-Raum *innerhalb* der TTL. | `make -C <repo> klickdummy-i3` (Phase B/C); `platform/scripts/checks/adr_sunset.sh` (Phase A, nightly — öffnet Issue bei passierter Frist) |
+| **I3 Lebenszyklus + TTL + Sunset (Rev 11)** | **A ohne Zielsystem:** Pflicht-Frontmatter `sunset_after: <ISO-Datum>` in der Repo-Klickdummy-ADR (Default ADR-Datum + 12 Monate); nach Fristablauf ohne PR-Extension ⇒ ADR auto-`deprecated`, Pfad `klickdummy/archive/` (siehe §Frontmatter-Konvention). **B Transition:** ab erstem Screen mit Impl-Route greift I3 je Screen. **C mit Zielsystem:** Doppelquelle endet bei **`min(prod-Release, Parity-grün + N Tagen)`** (N Default **30 d**, repo-tunbar) — schließt das „ewig auf Staging"-Leck (F4). Staging ist erlaubter Doppelquell-Raum *innerhalb* der TTL. *Rev 18 — Off-Ramp-Beweis statt -Behauptung:* Parity-grün erfüllt den Off-Ramp eines Screens nur mit (1) Renderer-#1-Entfernung (`off_ramp_status: removed`, Pfad `klickdummy/archive/`) **und** (2) negativem Reachability-Beleg (alte statische Route ⇒ Prod-404). **Max. eine lebende UI-Impl pro Spec-Screen**; Archiv = read-only (Reaktivierung re-triggert I3). **F4 nur für inventarisierte Routen geschlossen** — Alias-/Preview-Restrisiko offen (F20). | `make -C <repo> klickdummy-i3` (Phase B/C); `platform/scripts/checks/adr_sunset.sh` (Phase A, nightly — öffnet Issue bei passierter Frist) · *Rev 18:* Reachability-Beleg über F11-Prod-Guard (Doppel-Geltung I2+I3); bis Bau manueller, im PR dokumentierter Ersatzbeleg |
 | **I4 Namensraum** | Klickdummy-ADRs tragen reserviertes Titel-Präfix; Cross-Repo-Refs **nur** `repo:ADR-NNN` (inkl. `conforms_to: platform:ADR-211`). Drift-Schutz (vgl. Drift-Memory `klickdummy-adr180-collision`). | `platform/scripts/checks/adr_cross_repo_refs.sh` (plattformseitig, kein repo-Make-Target — generischer ADR-Lint) |
 
 **Auswahlhilfe Rev 11 (illustrativ; Mapping bekannter Implementierungen auf
@@ -221,6 +221,12 @@ platform/scripts/checks/adr_sunset.sh
 #     Pro Repo: ja/nein. Wenn ja: NEUE Features mit User-facing Surface
 #     durchlaufen das KD-first-Gate (Spec + KD + Signoff VOR Impl, §KD-first-Gate).
 #     Misst Velocity-Vorteil; gatet plattformweit NICHT.
+#
+# S13 Executable-Parity-Bridge-Adoption (Rev 18, optional, nicht status-gatend)
+#     Pro Repo: ja/nein. Wenn ja: `klickdummy-parity-drift` läuft in CI
+#     (re-generieren + git diff --exit-code, analog S10); Manifest als Artefakt;
+#     org-weiter Mindestdatensatz (spec_id, executable/skipped, Skip-Owner/-Grund,
+#     fragile-count, letztes-Grün, off_ramp_status). Misst Operationalisierung; gatet NICHT.
 ```
 
 ## §Co-Creation-Loop (optional, Rev 12)
@@ -435,6 +441,30 @@ behoben).
 CLI-Flags (`--out-dir`, `--no-cleanup`, `--strict-class`). Bis dahin gilt
 die meiki-hub-Implementierung als Referenz; copy-paste-Adoption erlaubt;
 Migration auf Plattform-Heimat innerhalb 30 Tagen nach Bereitstellung.
+
+## §Executable-Parity-Bridge (optional, Rev 18)
+
+**Opt-in-Capability** (additiv, nicht status-gatend — wie §Co-Creation/§Requirements-Bridge). Spec → ausführbare Parity-/Acceptance-Suite, **forward-only, deterministisch, drift-aware**. Schwester der §Requirements-Bridge (dort Spec → Markdown; hier Spec → *ausführbare* Tests). Empirie: `iil-klickdummy` v1.6.0 (`klickdummy-gen-e2e`), zwei externe Review-Runden (R1 Richtung, R2 Amendment-Text).
+
+**Mechanik.** `parity_acceptance[]` trägt optional `assert: {action, selector, expect}` (`action ∈ {visible, text, clickable, url, count}`); Prosa-`check` bleibt Pflicht ⇒ rückwärtskompatibel. Der Generator emittiert eine pytest/Playwright-Suite, die per `SPEC_RENDERER_BASE_URL` Renderer #1 (Klickdummy) und #2 (echte App) gegen *dieselbe* Assertion fährt. **Parity-grün gegen #2 = I3-Off-Ramp-Gate** (siehe I3 Rev 18). Die Tests überleben den Off-Ramp — die Kontinuität liegt in Spec + Tests, nicht im Wegwerf-Renderer.
+
+**Determinismus + Anti-Drift (operatives Gate).** Generierte Dateien tragen `AUTO-GENERATED` + `Spec-SHA256` und **keinen Zeitstempel**; ein Repo mit aktiver Bridge fährt `make klickdummy-parity-drift` in CI (re-generieren + `git diff --exit-code`, exakt analog `klickdummy-requirements-drift`, S10). Manuelle Edits / veraltete Generate ⇒ CI rot.
+
+**Grenzen (bewusst, gegen Über-Claim).**
+- Tests sind regenerierbares Derivat — Spec ≠ Produktionscode, ≠ Test-Harness-Quelle. Bei Prosa↔`assert`-Widerspruch gewinnt die Prosa (Review-Gate; der Generator erkennt Freitext-Konflikte nicht maschinell).
+- `parity_acceptance` prüft **Acceptance/Parity**, nicht tiefe Produkt-E2E; handgeschriebene E2E, die eine *bestehende* Spec-Acceptance prüfen, **müssen** deren Spec-ID referenzieren.
+- **NFR/Security/A11y/Performance/Audit** sind nicht aus `assert` ableitbar (Requirements-Bridge-Asymmetrie); das Manifest weist das als `uncovered_note` aus.
+- Kommunikation: „idee→E2E-**fähig**, mit sichtbarer Operationalisierungsquote" — nicht „geschlossen". `assert`-lose Einträge bleiben sichtbarer `skip` (Skip-Debt), nie stilles Weglassen.
+
+**Manifest.** Je Lauf `*.manifest.json`: `spec_id`, `spec_sha256`, `spec_schema_version`, `generator_version`, `base_url_env`, Coverage (`executable`/`skipped`), `skipped_detail`, `fragile_selectors`, `uncovered_note`.
+
+**Selector-Konvention.** Bevorzugt stabile fachliche Anker (`data-testid`/`data-acceptance-id`); fragile CSS-/Text-Pfade werden markiert (Manifest-Warnung), ab Off-Ramp status-relevant (F18). Locator-Registry zurückgestellt (Doppelquell-Risiko, F18).
+
+**Ownership nach Prod.** Org-weites Minimum (wer darf Spec / `check` / `assert` / Skip-Debt / `off_ramp_status` ändern); lokale Klickdummy-ADRs **konkretisieren** nur, divergieren nicht. Anti-Abschwächung: eine Änderung, die `check`/`assert` entfernt/abschwächt oder einen Selektor verfragilisiert, braucht PR-Label `parity-weakening` + fachliche Begründung (fachlicher Reviewer Soll).
+
+**F11-Doppel-Geltung.** Wird `klickdummy_prod_guard.sh` gebaut (F11, offen), erhält es zwei Geltungsgründe statt eines zweiten Checkers (SSoT): **I2** (Demo-/Catalog-/`?demo=`-Route ⇒ Prod-404) **und** **I3** (archivierte Klickdummy-Route nach Off-Ramp ⇒ 404). Bis dahin: manueller, im PR dokumentierter Ersatzbeleg.
+
+Scoreboard **+S13**.
 
 ## §Distribution — Plattform-Heimat (Rev 13)
 
@@ -898,6 +928,8 @@ Sechs Cascade-Adversarial-Pässe + Schema-/YAML-Härtung:
 
 - **Rev 17 (2026-05-29 — Daten-Treue der Anzeige)** — **Klarstellung, kein neuer Entscheid**; `status` bleibt `accepted`. Pre-Check per `adr-threshold.md`: **kein 5. Invariant (I5), kein eigener ADR** — als Klarstellung an I1 angehängt (analog Rev-16 „KI-/Daten-Qualitäts-Zusatz“). Regel: im Klickdummy ausgegebene Zahlen sind **berechnet, nicht literal** (Mock-Daten synthetisch, Berechnung echt); Cross-Screen-Aggregate aus **einer** Quelle. Enforcement = **Review-Gate** (nicht exit-code-prüfbar). **Empirie bewusst dünn benannt: 1 Instanz** (design-hub `tenant-angebote`, hartkodierte „4“ doppelt in Liste + Dashboard-Kachel) — daher als Klarstellung statt Gate **right-sized**; Promotion zu I-Status erst bei Cross-Repo-Evidenz (vgl. Rev-16-Logik + Steel-Man #1 „I5 unter Tarnnamen“, bewusst nicht umgesetzt).
 
+- **Rev 18 (2026-05-31 — Executable-Parity-Bridge)** — **Erweiterung, kein neuer Entscheid**; `status` bleibt `accepted`. Pre-Check per `adr-threshold.md`: keine Boundary, **kein 5. Invariant (I5)**, kein eigener ADR-21X — opt-in-§-Erweiterung von I1 (Muster Rev 12/16), die die **bestehende** These „Parity-Test ist das Konformitäts-Gate" *ausführbar* macht (kristallisiert, kehrt nicht). **I1-Klarstellung:** ausführbare Parity-Tests sind regenerierbares Derivat (Spec ≠ Prod-Code/Test-Harness); Determinismus (kein Zeitstempel im File) + Drift-Gate `klickdummy-parity-drift` (Reuse S10); Prosa↔`assert`-Konflikt = Review-Gate. **I3-Härtung:** Off-Ramp nur mit Renderer-#1-Entfernung (`off_ramp_status: removed`) **und** negativem Reachability-Beleg; „max. eine lebende UI-Impl/Screen"; Archiv read-only (Reaktivierung re-triggert I3). **Ehrliche Reichweite (zentrale Runde-2-Korrektur):** F4 **nur für inventarisierte Routen** geschlossen — Alias-/Preview-Risiko offen (F20). **Neue §Executable-Parity-Bridge** (opt-in): `assert`-Vokabular, Selector-Konvention, Reproduzierbarkeits-Manifest mit Coverage-/Skip-Transparenz, Parity≠Deep-E2E (Deep-E2E *muss* Spec-IDs referenzieren), org-weites Ownership-Minimum. Scoreboard **+S13**. **F11** Doppel-Geltung (I2+I3, ein Checker) — bis Bau provisorischer manueller Ersatzbeleg. Neue offene **F17** (`assert`-DSL-Lebenszyklus), **F18** (Selector-Fragilität / Locator-Registry zurückgestellt), **F19** (Operationalisierung cross-repo via Genesor), **F20** (Spec-ID-Route-Inventar gegen Alias-/Preview-Leck). **Empirie:** Keystone `iil-klickdummy` v1.6.0 (`klickdummy-gen-e2e`, 34 Tests grün, inkl. Determinismus-Fix aus Runde 2) + **zwei** externe LLM-Zweitmeinungen (R1 25 RECs, R2 15 RECs), Step-5-getaggt. **Implementations-PRs:** iilgmbh/iil-klickdummy #9 (Keystone, gemergt), #10 (CI-Node24, gemergt).
+
 ## Bezug
 
 - **Playbook:** `docs/concepts/CONCEPT-003-klickdummy-playbook.md` — Begleit-Dokument zu diesem ADR (wie konkret implementieren, Stack-Patterns, Lessons Learned, Repo-Adoptions-Status)
@@ -930,3 +962,25 @@ Sechs Cascade-Adversarial-Pässe + Schema-/YAML-Härtung:
   prüfen ob das Pattern trägt oder eine alternative Mechanik nötig ist
   (z. B. separates Sign-Off-Repo, signed digital token, OAuth-Flow für
   Workshop-Teilnehmer).
+
+- **F17 (`assert`-DSL-Lebenszyklus, Rev 18)**: Erweiterungsregel für `action`-
+  Typen (Semantik + Negativbeispiel + Generator-Fixture + Kompat-Notiz) **und**
+  Schema-Versions-Deprecation/Migration (`spec_schema_version`). Ohne das:
+  DSL-Drift + Legacy-Generator-Matrix bis 2028. Schließung-Pfad: erster RFC für
+  eine neue Action erzwingt die Regel.
+- **F18 (Selector-Fragilität / Locator-Registry zurückgestellt, Rev 18)**: die
+  `data-*`-Konvention + Manifest-Warnung *mildern* das UI-Refactor-Risiko, lösen
+  es nicht. Eine Locator-Registry (Spec nennt fachliche ID, App mappt Selektor)
+  ist bewusst zurückgestellt (Risiko, selbst Doppelquelle zu werden).
+  Schließung-Pfad: realer Cross-Repo-UI-Refactor belegt die Konvention als
+  unzureichend → Registry evaluieren; Schwellenwert/Owner+Frist ab Off-Ramp.
+- **F19 (Operationalisierungsquote cross-repo, Rev 18)**: Skip-Debt/fragile-count
+  sind pro Lauf im Manifest sichtbar, aber nicht org-weit aggregiert.
+  Schließung-Pfad: Genesor zeigt `pipeline_status` + Parity-Status + Skip-Quote
+  in **einem** Statusmodell (S13-Mindestdatensatz).
+- **F20 (Spec-ID-Route-Inventar — Anti-F4-Restlücke, Rev 18)**: der I3-
+  Reachability-Beleg schließt F4 nur für **bekannte/inventarisierte** Routen;
+  Alias-, CDN-, Preview-, Storybook- und neu entstandene Einstiegspfade bleiben
+  Restrisiko. Schließung-Pfad: maschinenlesbares Inventar erlaubter lebender
+  Routen je Spec-Screen-ID — minimal als CI-Artefakt startend, später Scanner
+  über Build-/Deploy-Metadaten (F11-Erweiterung).

--- a/policies/klickdummy.md
+++ b/policies/klickdummy.md
@@ -115,6 +115,29 @@ prüft zusätzlich gegen `origin/main`.
   (`{mock-prototyp→mock, demo-render→spec-demo}`); Strict-Mode wird via
   Scoreboard-Item S11 nach Cross-Repo-Migration aktiviert. Iteration-
   Typologie erweitert (stakeholder- + compliance-getriggert).
+- 2026-05-20: Rev-13-Angleichung (Decider-Pivot). **Erweiterung.** Initialer
+  ADR-214-Draft (Distribution-Service) als advocatus diabolus zurückgezogen;
+  §Distribution wird ADR-211-§ (pip-Paket `iil-klickdummy` mit Schemas/Skripten/
+  Widget). §Co-Creation Pfade A neu (A-light / A-User-Direct via GitHub-API /
+  A-Agent); zentraler Endpoint gestrichen. Plugin-Hooks im Widget.
+- 2026-05-21: Rev-14-Angleichung (Multi-Klickdummy-Browser + public PyPI).
+  **Erweiterung.** `iil-klickdummy` v1.1 mit `registry.py` + `klickdummy-browser`
+  (Versions-/Repo-Browser). public PyPI (`pip install iil-klickdummy`) wird
+  Default, Git-URL Fallback; Trusted Publishing (OIDC).
+- 2026-05-21: Rev-15-Angleichung (Repo-Extraktion). **Kein Invarianten-Change.**
+  `packages/iil-klickdummy` → `iilgmbh/iil-klickdummy` extrahiert (Historie
+  erhalten). Trennung festgeklopft: ADR-211 (Konvention) bleibt
+  achimdehnert/platform; `iilgmbh:iil-klickdummy:ADR-001` ist Implementations-ADR;
+  Schwester-Impls via `sister_of`.
+- 2026-05-25/28: Rev-16-Angleichung (zwei Amends). **Erweiterung.** Optionale §-
+  Erweiterungen von I1: **§Acceptance-Marker** (`spec_signed`/`ui_walked`, append-
+  only mit Evidence `by`+`date`+`ref`) und **§UC-Coverage** (UC↔Screen-Lint,
+  Cross-Repo-Namespace `<repo>:UC-NNN`); offene F13–F16. Dazu **§KD-first-Gate**
+  (opt-in; NEUE User-facing Features erst als KD), Scoreboard +S12.
+- 2026-05-29: Rev-17-Angleichung (Daten-Treue der Anzeige). **Klarstellung.**
+  Im Klickdummy ausgegebene Zahlen sind **berechnet, nicht literal** (Mock-Daten
+  synthetisch, Berechnung echt); Cross-Screen-Aggregate aus **einer** Quelle.
+  Enforcement = Review-Gate. An I1 angehängt; kein I5.
 - 2026-05-31: Rev-18-Angleichung (Executable-Parity-Bridge). **Erweiterung, kein
   neuer Entscheid.** Optionale §-Erweiterung von I1: `parity_acceptance.assert`
   → forward-only deterministischer Generator (`klickdummy-gen-e2e`) erzeugt eine

--- a/policies/klickdummy.md
+++ b/policies/klickdummy.md
@@ -115,3 +115,14 @@ prüft zusätzlich gegen `origin/main`.
   (`{mock-prototyp→mock, demo-render→spec-demo}`); Strict-Mode wird via
   Scoreboard-Item S11 nach Cross-Repo-Migration aktiviert. Iteration-
   Typologie erweitert (stakeholder- + compliance-getriggert).
+- 2026-05-31: Rev-18-Angleichung (Executable-Parity-Bridge). **Erweiterung, kein
+  neuer Entscheid.** Optionale §-Erweiterung von I1: `parity_acceptance.assert`
+  → forward-only deterministischer Generator (`klickdummy-gen-e2e`) erzeugt eine
+  Playwright/pytest-Suite, die Renderer #1 (Klickdummy) und #2 (echte App) per
+  `SPEC_RENDERER_BASE_URL` gegen dieselbe Assertion prüft — parity-grün gegen #2
+  = I3-Off-Ramp-Gate. **I3 gehärtet:** Off-Ramp nur mit Renderer-#1-Entfernung
+  (`off_ramp_status: removed`) + negativem Reachability-Beleg; „max. eine lebende
+  UI-Impl pro Spec-Screen"; F4 nur für inventarisierte Routen geschlossen (F20
+  offen). Drift-Gate `klickdummy-parity-drift` (Reuse S10). Scoreboard +S13.
+  Empirie: iil-klickdummy v1.6.0 + zwei externe Review-Runden. (Hinweis: dieser
+  Changelog lag bei Rev-12 — Rev 13–17 betrafen die Kern-Invarianten nicht.)


### PR DESCRIPTION
**Erweiterung, kein neuer Entscheid** — `status` bleibt `accepted`. Opt-in-§-Erweiterung von I1 (Muster Rev 12 §Requirements-Bridge / Rev 16), die die **bestehende** These „Parity-Test ist das Konformitäts-Gate" *ausführbar* macht (kristallisiert, kehrt nicht).

## Was sich ändert (2 Dateien: ADR-211 + policies/klickdummy.md)

- **I1-Klarstellung:** `parity_acceptance.assert` → forward-only Generator (`klickdummy-gen-e2e`) erzeugt eine Suite, die per `SPEC_RENDERER_BASE_URL` Renderer #1 (Klickdummy) **und** #2 (echte App) prüft. Tests sind regenerierbares Derivat — Spec ≠ Prod-Code/Test-Harness. Determinismus + Drift-Gate `klickdummy-parity-drift` (Reuse S10).
- **I3-Härtung:** Off-Ramp nur mit Renderer-#1-Entfernung (`off_ramp_status: removed`) **und** negativem Reachability-Beleg; „max. eine lebende UI-Impl/Screen"; Archiv read-only.
- **Ehrliche Reichweite:** F4 **nur für inventarisierte Routen** geschlossen — Alias-/Preview-Risiko offen (**F20**).
- **Neue §Executable-Parity-Bridge** (opt-in) + Scoreboard **S13**.
- **F11** Doppel-Geltung (I2+I3, ein Checker) statt zweitem 404-Checker.
- Neue offene **F17/F18/F19/F20**.

## Provenance

Empirie: **iil-klickdummy v1.6.0** (`klickdummy-gen-e2e`, 34 Tests grün, live auf PyPI) + **zwei externe LLM-Review-Runden** (R1 25 RECs Richtung, R2 15 RECs Text), Step-5-getaggt; realer Determinismus-Bug gefunden + gefixt. Implementations-PRs: iilgmbh/iil-klickdummy #9, #10 (gemergt).

## adr-threshold-Check

Reine Erweiterung nach bestehendem §-Muster → Amendment an ADR-211, **kein** neuer ADR. Keine neue Boundary, kein I5.

## Beobachtung (nicht in diesem PR gefixt)

`policies/klickdummy.md`-Changelog lag bei Rev-12; Rev 13–17 wurden nie nachgetragen (betrafen die Kern-Invarianten nicht). Hier nur Rev-18 ergänzt — Back-Fill wäre separater Scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)