### PR TITLE
feat(workflows): /repo-audit — tiefes evidenzbasiertes Single-Repo-Audit

### DIFF
--- a/.claude/workflows/repo-audit-deep.js
+++ b/.claude/workflows/repo-audit-deep.js
@@ -7,13 +7,18 @@ export const meta = {
     { title: 'Review', detail: '1 Agent pro Dimension, Befunde mit Evidence-Ledger' },
     { title: 'Verify', detail: 'adversariale Refutation jedes Befunds' },
     { title: 'Synth', detail: 'Steelman + 3 Rollen + Top-5 + Roadmap + Schlussurteil' },
+    { title: 'Persist', detail: 'Datum via date +%F, Report nach audits/ schreiben' },
   ],
 }
 
 // args: { repo: "<pfad oder ORG/REPO>", goal?: "<1-5 Sätze>", date?: "YYYY-MM-DD" }
-const repo = (args && args.repo) || '.'
-const goal = (args && args.goal) || '(kein expliziter Kontext übergeben — aus dem Repo selbst ableiten)'
-const stamp = (args && args.date) || 'undatiert'
+// Robust gegen fehlende/teilweise args (Inline-Invocation reicht args nicht immer durch):
+const A = args || {}
+const repo = (typeof A === 'string' ? A : A.repo) || '.'
+const goal = A.goal || '(kein expliziter Kontext übergeben — aus dem Repo selbst ableiten)'
+// stamp bleibt ein Hinweis; das ECHTE Datum setzt der Persist-Agent via `date +%F`
+// (Skripte haben kein Date.now()). 'auto' => Persist-Agent ermittelt es selbst.
+const stamp = A.date || 'auto'
 
 // --- Platform-Verträge P1–P9 (als Prompt-Fragment für jeden Agent) ---
 const PLATFORM = `
@@ -133,4 +138,29 @@ const report = await agent(
   { label: 'synth', phase: 'Synth' },
 )
 
-return { repo, datum: stamp, modus: 'DEEP', befunde_valide: valide.length, flach_geprueft: flachGeprueft, report }
+// Persist: ein Agent (Skripte selbst haben keinen FS-Zugriff) ermittelt das echte
+// Datum und schreibt den Report nach <repo>/audits/repo-audit-<date>.md.
+phase('Persist')
+const PERSIST_SCHEMA = {
+  type: 'object',
+  properties: {
+    pfad: { type: 'string', description: 'absoluter Pfad der geschriebenen Datei' },
+    datum: { type: 'string', description: 'YYYY-MM-DD, via `date +%F` ermittelt' },
+    bytes: { type: 'number' },
+  },
+  required: ['pfad', 'datum'],
+}
+const persisted = await agent(
+  `Repo-Pfad: ${repo}\nDatums-Hinweis: ${stamp} (wenn 'auto', ermittle das Datum selbst via \`date +%F\`).\n\nAufgabe: (1) Ermittle das heutige Datum mit \`date +%F\`. (2) Lege \`${repo}/audits/\` an (mkdir -p). (3) Schreibe den folgenden Markdown-Report exakt und unverändert nach \`${repo}/audits/repo-audit-<DATUM>.md\` (ersetze im Report-Kopf 'Datum: auto' bzw. 'undatiert' durch das ermittelte Datum). Verändere den Inhalt sonst NICHT. Gib Pfad, Datum und Byte-Größe zurück.\n\n--- REPORT ---\n${report}`,
+  { label: 'persist', phase: 'Persist', schema: PERSIST_SCHEMA },
+)
+
+return {
+  repo,
+  datum: (persisted && persisted.datum) || stamp,
+  modus: 'DEEP',
+  befunde_valide: valide.length,
+  flach_geprueft: flachGeprueft,
+  report_pfad: persisted && persisted.pfad,
+  report,
+}

--- a/.claude/workflows/repo-audit-deep.js
+++ b/.claude/workflows/repo-audit-deep.js
@@ -1,0 +1,136 @@
+export const meta = {
+  name: 'repo-audit-deep',
+  description: 'Tiefes Multi-Agent Single-Repo-Audit: Inventar → 9 Dimensionen fan-out → adversariale Verifikation jedes Befunds → Synthese (Steelman + 3 Rollen + Top-5 + Roadmap)',
+  whenToUse: 'DEEP-Pfad von /repo-audit. Due-Diligence/vollständige Tiefe eines Repos. Teuer (Opus × ~9 Agents + Verify) — opt-in, nicht für schnelle Checks.',
+  phases: [
+    { title: 'Inventar', detail: 'Repo-Inventar + Hochrisiko-Zonen (1 Agent)' },
+    { title: 'Review', detail: '1 Agent pro Dimension, Befunde mit Evidence-Ledger' },
+    { title: 'Verify', detail: 'adversariale Refutation jedes Befunds' },
+    { title: 'Synth', detail: 'Steelman + 3 Rollen + Top-5 + Roadmap + Schlussurteil' },
+  ],
+}
+
+// args: { repo: "<pfad oder ORG/REPO>", goal?: "<1-5 Sätze>", date?: "YYYY-MM-DD" }
+const repo = (args && args.repo) || '.'
+const goal = (args && args.goal) || '(kein expliziter Kontext übergeben — aus dem Repo selbst ableiten)'
+const stamp = (args && args.date) || 'undatiert'
+
+// --- Platform-Verträge P1–P9 (als Prompt-Fragment für jeden Agent) ---
+const PLATFORM = `
+Platform-Verträge (iil.gmbh) — Verstöße als eigene Befunde mit Präfix PLAT-:
+- P1 Service-Layer: kein ORM (.objects./.filter(/.save() direkt in views.py
+- P2 Integer-PK: kein UUIDField(primary_key=True)
+- P3 HTMX-Triple: jedes hx-* mit hx-target + hx-swap + hx-indicator (alle drei)
+- P4 PG-only Tests (ADR-179): kein sqlite in Test-Settings
+- P5 Test-Naming: test_should_{verhalten}
+- P6 Shared-CI: uses achimdehnert/platform/.github/workflows/_ci-python.yml@main statt Inline-CI
+- P7 Commit-Konvention: [feat|fix|refactor|docs|test|chore](scope): …
+- P8 Secrets-Hygiene: keine Klartext-Secrets getrackt, secrets.env gitignored
+- P9 ADR-Pflicht: neue Dep/Service-Grenze/Cross-Cutting ohne ADR = Lücke (reine Addition braucht keinen ADR)
+Bekannte Stolpersteine: Index-Rename-Migration → SeparateDatabaseAndState; gitleaks-403 = fehlende pull-requests:write Permission; ttz-lif/meiki-lra = Data-Sovereignty der repo-CLAUDE.md.`
+
+const LEDGER = `
+Evidence-Ledger (bindend): jede Aussage braucht E1 (Datei+Zeile) / E2 (Befehl+Output) / E3 (CI/PR/Commit) / E4 (extern/CVE) / H (Hypothese, MUSS markiert sein). Kein hoher/kritischer Befund ohne E1–E4. Aktiv Gegenbelege suchen. Keine erfundenen Dateien/Zeilen. Nicht-prüfbares explizit sagen. Secrets nie vollständig ausgeben.`
+
+const DIMENSIONS = [
+  { key: 'architektur', prompt: 'Schichten/Verantwortlichkeiten (P1 Service-Layer), zyklische Deps, globaler State, Abstraktion externer Systeme, Fehler-als-Architektur, God-Module, Code-vs-Doku, ADR-Abdeckung (P9).' },
+  { key: 'daten', prompt: 'Datenmodell-Konsistenz (P2 Integer-PK), Migrationsrisiken (Index-Rename→SeparateDatabaseAndState), Transaktionen/Idempotenz, Races/Lost-Updates, Daten-Ownership, fehlende Constraints, Retention/Löschung, gefährliche Datenkopien.' },
+  { key: 'security', prompt: 'Secrets in Repo/Tests/Config/Logs (P8), zentrale vs verstreute AuthZ, Objekt-/Mandanten-Zugriffskontrolle, Injection/SSRF/Path-Traversal/Deser/Template-Injection, Supply-Chain, CI-Rechte/Tokens, unsichere Defaults, Rate-Limits, Debug/Admin-Endpunkte, Krypto/Session/Token-Lifetime.' },
+  { key: 'datenschutz', prompt: 'PII, sensibles Logging, Retention/Export/Löschung/Zweckbindung, Mandantentrennung, prod-nahe Testdaten, Abfluss via Monitoring/Analytics, Data-Sovereignty (ttz-lif/meiki-lra).' },
+  { key: 'tests', prompt: 'Testarten, echte vs Schein-Coverage, brittle/flaky, fehlende Negativtests, Contract/Integration an Grenzen, Determinismus, PG-only (P4, kein sqlite), Fehlerfälle/Rechtewechsel/Parallelität/Migrationen, test_should_* (P5), Happy-Path-Bias, Snapshot-Tests die Änderungen verdecken.' },
+  { key: 'cicd', prompt: 'Reproduzierbarkeit (P6 Shared-CI _ci-python.yml), getrennte Envs (ADR-210), Release/Rollback, Migrations-Validierung, Health-Checks (/livez/), Observability, Artefakt-Versionierung, minimale CI-Rechte (gitleaks pull-requests:write sonst 403), Gates, gefährliche continue-on-error/skip/allow_failure (legitim vs stille Umgehung), Local↔CI-Drift.' },
+  { key: 'performance', prompt: 'N+1, unbounded Queries/Loops/Queues/Payloads, Caching, Backpressure, Timeouts/Retries, Leaks, unbegrenzte Parallelität, synchrone Großoperationen im Request-Pfad, fehlende Pagination/Limits.' },
+  { key: 'codequalitaet', prompt: 'riskante Duplikation, überladene Module, tote Pfade, God-Funktionen, Fehlerbehandlung, Typisierung, Lint/Format enforced (ruff), magische Strings, nur-kommentierte statt enforcete Verträge, Framework-Interna-Kopplung.' },
+  { key: 'doku', prompt: 'README/ADR/Kommentar/Code-Konsistenz, Onboarding-Lücken, realistische Setup-Schritte, dokumentierte Betriebs-/Security-/Migrations-Annahmen, gefährlich veraltete Doku, CLAUDE.md/CORE_CONTEXT.md/AGENT_HANDOVER.md aktuell.' },
+  { key: 'platform', prompt: 'Reiner Platform-Konformitäts-Pass: jeden Vertrag P1–P9 einzeln prüfen und mit konkretem grep/Datei-Beleg als erfüllt/verletzt/nicht-zutreffend deklarieren.' },
+]
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  properties: {
+    dimension: { type: 'string' },
+    flach_geprueft: { type: 'boolean', description: 'true wenn aus Zeit/Evidenz-Mangel nur oberflächlich' },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Präfix AD-/SEC-/PRIV-/TEST-/OPS-/ARCH-/PERF-/DOC-/PLAT-/M28-/PRO-' },
+          befund: { type: 'string' },
+          evidenz: { type: 'string', description: 'E1 Datei+Zeile / E2 Befehl+Output / E3 / E4 / H' },
+          evidenz_typ: { type: 'string', enum: ['E1', 'E2', 'E3', 'E4', 'H'] },
+          schweregrad: { type: 'string', enum: ['kritisch', 'hoch', 'mittel', 'niedrig', 'positiv', 'stark positiv'] },
+          confidence: { type: 'string', enum: ['hoch', 'mittel', 'niedrig'] },
+          betroffener_teil: { type: 'string' },
+        },
+        required: ['id', 'befund', 'evidenz', 'evidenz_typ', 'schweregrad', 'confidence'],
+      },
+    },
+  },
+  required: ['dimension', 'findings'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    bestaetigt: { type: 'boolean', description: 'true nur wenn Befund der Refutation standhält' },
+    begruendung: { type: 'string' },
+    korrigierter_schweregrad: { type: 'string', enum: ['kritisch', 'hoch', 'mittel', 'niedrig', 'positiv', 'stark positiv'] },
+  },
+  required: ['id', 'bestaetigt', 'begruendung'],
+}
+
+// ---------------------------------------------------------------------------
+
+phase('Inventar')
+const inventar = await agent(
+  `Du auditierst das Repo: ${repo}\nKontext/Ziel: ${goal}\n\nErstelle Zwischenlieferung A: (1) Repo-Inventar (Sprachen/Frameworks/Lockfiles/Einstiegspunkte/Module/DBs/Queues/Auth/Deploy/Config/Migrationen/Observability — jedes mit Datei-Evidenz), (2) die 3-5 wahrscheinlichsten Hochrisiko-Zonen mit Begründung. NUR lesen, keine destruktiven Befehle.\n${LEDGER}`,
+  { label: 'inventar', phase: 'Inventar' },
+)
+
+// Phase 4: pro Dimension review → adversariale Verifikation jedes Befunds.
+// Pipeline: Dimension D wird verifiziert, während Dimension E noch reviewt — keine Barriere.
+const auditiert = await pipeline(
+  DIMENSIONS,
+  (d) => agent(
+    `Repo: ${repo}\nKontext: ${goal}\n\nInventar/Hochrisiko-Zonen aus Phase A:\n${inventar}\n\nAuditiere TIEF die Dimension "${d.key}": ${d.prompt}\n${PLATFORM}\n${LEDGER}\n\nGib strukturierte Befunde zurück. Wenn du eine Dimension aus Evidenz-Mangel nur flach prüfen konntest, setze flach_geprueft=true (ehrlich, nicht vortäuschen).`,
+    { label: `review:${d.key}`, phase: 'Review', schema: FINDINGS_SCHEMA },
+  ),
+  (review, d) => {
+    const findings = (review && review.findings) || []
+    // Nur substanzielle Befunde adversarial prüfen; positive/niedrige direkt übernehmen.
+    const zuPruefen = findings.filter((f) => ['kritisch', 'hoch', 'mittel'].includes(f.schweregrad))
+    const direkt = findings.filter((f) => !['kritisch', 'hoch', 'mittel'].includes(f.schweregrad))
+    return parallel(
+      zuPruefen.map((f) => () =>
+        agent(
+          `Repo: ${repo}\n\nVersuche diesen Audit-Befund zu WIDERLEGEN (Advocatus Diabolus gegen den Befund selbst). Default: bestaetigt=false bei Unsicherheit. Prüfe die zitierte Evidenz real nach.\n\nBefund [${f.id}] (${f.schweregrad}): ${f.befund}\nZitierte Evidenz: ${f.evidenz}\n${LEDGER}`,
+          { label: `verify:${d.key}:${f.id}`, phase: 'Verify', schema: VERDICT_SCHEMA },
+        ).then((v) => ({ ...f, dimension: d.key, verdict: v })),
+      ),
+    ).then((geprueft) => ({
+      dimension: d.key,
+      flach_geprueft: !!(review && review.flach_geprueft),
+      bestaetigt: geprueft.filter(Boolean).filter((f) => f.verdict && f.verdict.bestaetigt),
+      direkt_uebernommen: direkt.map((f) => ({ ...f, dimension: d.key })),
+    }))
+  },
+)
+
+// Sammeln (plain code, keine Barriere nötig — pipeline ist schon durch)
+const valide = []
+const flachGeprueft = []
+for (const a of auditiert.filter(Boolean)) {
+  if (a.flach_geprueft) flachGeprueft.push(a.dimension)
+  valide.push(...a.bestaetigt, ...a.direkt_uebernommen)
+}
+log(`Verifizierte/übernommene Befunde: ${valide.length} · flach geprüfte Dimensionen: ${flachGeprueft.join(', ') || 'keine'}`)
+
+phase('Synth')
+const report = await agent(
+  `Repo: ${repo}\nKontext: ${goal}\nDatum: ${stamp}\n\nInventar (Phase A):\n${inventar}\n\nVerifizierte Befunde (JSON):\n${JSON.stringify(valide, null, 2)}\n\nFlach geprüfte Dimensionen (ehrlich deklarieren): ${flachGeprueft.join(', ') || 'keine'}\n\nSynthetisiere das vollständige Audit als Markdown in dieser Struktur:\n1. Executive Summary (max 10 Sätze: Urteil/Stärke/Risiko/Maßnahme/Unsicherheit)\n2. Scope & Evidenzbasis (Modus=DEEP, Branch/Commit, flach geprüfte Dimensionen)\n3. Repo-Inventar\n4. Steelman (3-7 evidenzbasierte Sätze ZUERST)\n5. Befunde (Tabelle: ID|Rolle|Kategorie|Befund|Evidenz|Schweregrad|Confidence|Teil)\n6. Top-5-Risiken (je: Schadensszenario/Wahrscheinlichkeit/Dringlichkeit/kleinster Fix/Evidenz/geprüfte Gegenbelege)\n7. Rollenanalyse (🟢 Proponent · 😈 Advocatus Diabolus · 🔮 Maintainer 2028)\n8. Platform-Konformität P1–P9\n9. Out-of-the-Box (≥3 Ansätze: Idee/Vorteil/Nachteil/wann/warum verwerfen)\n10. Empfehlungen REC-N (je: Befund-ID/Ziel/Änderung/Aufwand S-M-L/Risiko/Verifikation/Akzeptanzkriterium)\n11. 30/60/90-Tage-Roadmap\n12. Schlussurteil (gesund/brauchbar mit Risiken/riskant aber sanierbar/architektonisch gefährdet/nicht belastbar)\n\nSteelman zuerst, dann Kritik. Keine erfundenen Belege. Hypothesen als H markiert lassen.`,
+  { label: 'synth', phase: 'Synth' },
+)
+
+return { repo, datum: stamp, modus: 'DEEP', befunde_valide: valide.length, flach_geprueft: flachGeprueft, report }

--- a/.windsurf/workflows/repo-audit.md
+++ b/.windsurf/workflows/repo-audit.md
@@ -200,7 +200,12 @@ synth: Steelman + 3 Rollen + Top-5 + Roadmap aus den verifizierten Befunden
 ```
 
 Kosten beachten (`session-routing.md`): Fan-out × Opus ist teuer — `--deep` ist **opt-in**, nicht default.
-Implementierung als echter Workflow-Skript = **Stufe 3** dieses Skills (folgt, wenn LITE sich bewährt).
+
+**Implementierung (Stufe 3):** `.claude/workflows/repo-audit-deep.js` — echtes Workflow-Skript
+(Inventar → 9-Dimensionen-pipeline mit review→adversarialer-verify → Synthese).
+Start: `Workflow({ name: "repo-audit-deep", args: { repo: "<pfad>", goal: "<kontext>", date: "<YYYY-MM-DD>" } })`.
+`date` muss übergeben werden (Skripte haben kein `Date.now()`). Nur substanzielle Befunde (kritisch/hoch/mittel)
+durchlaufen die Refutation; positive/niedrige werden direkt übernommen. Flach geprüfte Dimensionen werden ehrlich deklariert.
 
 ---
 

--- a/.windsurf/workflows/repo-audit.md
+++ b/.windsurf/workflows/repo-audit.md
@@ -1,0 +1,209 @@
+---
+description: Tiefes evidenzbasiertes Single-Repo-Audit — Steelman + Advocatus Diabolus + Maintainer 2028, Platform-Konformität (P1–P9), optionaler --deep Fan-out. Gegenstück zu /platform-audit (Breite) und /repo-health-check (Gate).
+---
+
+# /repo-audit
+
+> **Ziel:** EIN Repo tief, evidenzbasiert und kontrovers auditieren — nicht nur Fehler finden,
+> sondern Systemqualität aus 3 Rollen + 15 Dimensionen bewerten und in actionable Befunde + Roadmap überführen.
+>
+> **Abgrenzung (nicht duplizieren):**
+> - `/repo-health-check` = mechanisches Vollständigkeits-**Gate** vor Publish/Deploy (pyproject, README, Lockfiles).
+> - `/platform-audit` = **Breite über ALLE Repos**.
+> - `/compose-audit` = nur docker-compose vs ADR-021.
+> - **`/repo-audit` = Tiefe + Urteil in EINEM Repo.**
+
+**Trigger:** `/repo-audit <repo>` · `/repo-audit <repo> --deep` · vor Übernahme/Refactor eines fremden Repos, nach größeren Changes, bei Due-Diligence.
+
+**Argumente:**
+- `<repo>` — Pfad unter `~/github/` oder `ORG/REPO` oder URL. Default: aktuelles Repo.
+- `--deep` — Multi-Agent-Fan-out (1 Sub-Agent pro Dimension). Ohne Flag: **LITE** (Single-Pass, priorisiert).
+
+---
+
+## ⚠️ Modus-Entscheidung (erster Schritt, ehrlich deklarieren)
+
+„Sehr tief" × 15 Dimensionen × 3 Rollen sprengt ein Context-Window. Wähle bewusst:
+
+| Modus | Wann | Verhalten |
+|-------|------|-----------|
+| **LITE** (default) | schneller Überblick, 1 Pass, Tier-3-Kosten | Priorisiere die in Phase A als Hochrisiko erkannten Dimensionen tief; übrige bewusst flacher. **Benenne explizit, welche Dimensionen nur flach geprüft wurden.** |
+| **DEEP** (`--deep`) | Due-Diligence, vollständige Tiefe, höhere Kosten (Opus × N Agents) | Phase 4: je 1 Sub-Agent pro Dimension parallel → adversarial verify → synth. Siehe Block „DEEP-Fan-out" unten. |
+
+> **Niemals** „sehr tief über alles" behaupten, wenn faktisch LITE läuft. Modus in §2 des Reports nennen.
+
+---
+
+## Phase 0 — Zugriff sichern
+
+```bash
+REPO_ARG="${1:-$(basename $(pwd))}"
+# Pfad auflösen
+if [ -d "$HOME/github/$REPO_ARG" ]; then REPO="$HOME/github/$REPO_ARG"
+elif [ -d "$REPO_ARG" ]; then REPO="$REPO_ARG"
+else echo "⚠️ Repo nicht lokal — Connector/Clone nötig: $REPO_ARG"; fi
+echo "Audit-Ziel: ${REPO:-$REPO_ARG}"
+git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null && git -C "$REPO" log -1 --format='%h %s' 2>/dev/null
+```
+
+Kein Repo-Zugriff → **nicht breit nach Kontext fragen**, sondern minimal anfordern: Repo-Link / ZIP / relevante Dateien.
+
+**Safety (nicht verhandelbar):** Keine Deployments, keine Prod-Zugriffe, keine Migrationen gegen echte Umgebungen, keine Secret-Exfiltration. Secrets nie vollständig ausgeben — nur Fundort + Typ + Redaction.
+
+---
+
+## Phase A — Zwischenlieferung (Inventar + Evidenzkarte + Plan)
+
+**A1 Repo-Inventar** (jedes Element mit Evidenz: Datei/Pfad/Symbol/Config-Key/Workflow/Commit):
+Sprachen·Frameworks·Runtimes · Package-Manager+Lockfiles · Einstiegspunkte · Module/Services · Build/Test/CI · DBs/Queues/externe APIs/Auth · Deploy/Infra · Config/Env · Migrationssystem · Observability · auffällige Struktur-Risiken.
+
+**A2 Evidenzkarte:**
+
+| Bereich | Evidenzquellen | Erste Beobachtung | Risiko-Hypothese | Nächster Prüfschritt |
+|---|---|---|---|---|
+
+Bereiche mind.: Architektur · Daten/Persistenz · Security · AuthN/AuthZ · Dependencies/Supply-Chain · Tests · CI/CD · Deployment · Observability · Performance · Doku · Wartbarkeit · **Platform-Konformität (P1–P9)**.
+
+**A3 Audit-Plan:** Welche Bereiche tief? Welche Dateien kritisch? Welche Befehle/externen Quellen? Was nicht prüfbar? Welche Risiken zuerst falsifizieren?
+
+→ Danach **automatisch** ins Vollaudit, ohne auf Bestätigung zu warten.
+
+---
+
+## Phase 1 — Evidence Ledger (bindend)
+
+Jede relevante Aussage braucht ≥1 Evidenzart:
+- **E1** Repo-Evidenz: Datei + Zeilen/Symbol/Config
+- **E2** Ausführung: Test/Build/Lint/Script-Output + reproduzierbarer Befehl
+- **E3** Prozess: CI-Workflow / PR / Issue / Release / Commit-History
+- **E4** Extern: offizielle Doku / CVE / Advisory
+- **H** Hypothese: plausibel, unbewiesen — **muss als H markiert sein**
+
+Regeln (= `~/.claude/policies/evidence-discipline.md`):
+- Kein kritischer/hoher Befund ohne E1–E4.
+- Aktiv Gegenbelege suchen, **bevor** ein Befund final formuliert wird.
+- Widersprüchliche Evidenz dokumentieren statt glattbügeln.
+- Tests/Builds nicht ausführbar → explizit sagen, **nicht** scheinbar auf Runtime-Evidenz stützen.
+
+---
+
+## Phase 2 — Steelman (zuerst, vor jeder Kritik)
+
+3–7 evidenzbasierte Sätze: Was ist gut? Welche Entscheidungen wirken bewusst? Wo ist das Repo robuster als es aussieht? Welche Risiken sind schon abgefedert? Wo schlägt Pragmatismus Over-Engineering?
+
+---
+
+## Phase 3 — Drei Rollen
+
+**🟢 Proponent** — Warum ist die Lösung vertretbar? Bewusste Trade-offs? Sinnvoll vermiedene Komplexität? Passend zum Reifegrad?
+
+**😈 Advocatus Diabolus** (Kernfokus) — Leistet das Repo, was es behauptet? Wo klaffen Doku/Tests/Code/Runtime? Versteckte Kopplung, Schein-Sicherheit, Schein-Coverage, Schein-Automation? Was bricht unter Last / bösen Inputs / Parallelität / Rechtewechsel / Netzfehlern / Migrationen / Teamwechsel? Wo sind Risiken nur kommentiert statt enforced? Wo „works on my machine"? Wo erzeugt ein kleiner Refactor ein Security-/Daten-/Betriebsproblem?
+
+**🔮 Maintainer 2028** — Was ist in 2 Jahren schwer verständlich? Was bricht durch Wachstum/Teamwechsel? Welche Deps/Patterns altern schlecht? Wo drohen Legacy/Migration/Security/Test-Debt? Welche heutigen Entscheidungen blockieren spätere Optionen?
+
+---
+
+## Phase 4 — Deep-Dive (LITE: priorisiert · DEEP: je 1 Sub-Agent)
+
+Pro Dimension prüfen, soweit Evidenz vorhanden. **Fett = Platform-Vertrag (Phase 4P).**
+
+- **Architektur:** Schichten/Verantwortlichkeiten **(P1 Service-Layer)** · Zyklen · globaler State · Abstraktion externer Systeme · Fehler als Architektur · God-Module · Architektur im Code vs nur Doku · **(P9 ADR-Abdeckung)**
+- **Daten:** Konsistenz **(P2 Integer-PK)** · Migrationsrisiken **(Index-Rename → `SeparateDatabaseAndState` prüfen)** · Transaktionen/Idempotenz · Races/Lost-Updates · Daten-Ownership · fehlende Constraints · Retention/Löschung · gefährliche Datenkopien
+- **Security:** Secrets in Repo/Tests/Config/Logs **(P8)** · zentrale vs verstreute AuthZ · Objekt-/Mandanten-Zugriffskontrolle · Injection/SSRF/Path-Traversal/Deser/Template-Injection · Supply-Chain · CI-Rechte/Tokens · unsichere Defaults · Rate-Limits · Fehlerausgaben · Debug/Admin-Endpunkte · Krypto/Session/Token-Lifetime
+- **Datenschutz:** PII · sensibles Logging · Retention/Export/Löschung/Zweckbindung · Mandantentrennung · prod-nahe Testdaten · Abfluss via Monitoring/Analytics · **(ttz-lif/meiki-lra: Data-Sovereignty der repo-CLAUDE.md beachten)**
+- **Tests:** Testarten · echte Abdeckung · Schein-Coverage · brittle/flaky · fehlende Negativtests · Contract/Integration an Grenzen · Determinismus · **(P4 PG-only, nicht SQLite)** · Fehlerfälle/Rechtewechsel/Parallelität/Migrationen · **(P5 `test_should_*`)** · Happy-Path-Bias · Snapshot-Tests die fachliche Änderungen verdecken
+- **CI/CD:** Reproduzierbarkeit **(P6 Shared-CI `_ci-python.yml`)** · getrennte Envs **(ADR-210)** · Release/Rollback · Migrations-Validierung · Health-Checks (`/livez/`) · Observability · Artefakt-Versionierung · minimale CI-Rechte **(z.B. gitleaks braucht `pull-requests: write`, sonst 403)** · richtige Gates · gefährliche `continue-on-error`/`skip`/`allow_failure` (legitime Doku vs stille Umgehung unterscheiden) · Local↔CI-Drift
+- **Performance:** N+1 · unbounded Queries/Loops/Queues/Payloads · Caching · Backpressure · Timeouts/Retries · Leaks · unbegrenzte Parallelität · synchrone Großoperationen im Request-Pfad · fehlende Pagination/Limits
+- **Codequalität:** riskante Duplikation · überladene Module · tote Pfade · God-Funktionen · Fehlerbehandlung · Typisierung · Lint/Format enforced (ruff) · magische Strings · nur-kommentierte statt enforcete Verträge · Framework-Interna-Kopplung
+- **Doku:** README/ADR/Kommentar/Code-Konsistenz · Onboarding-Lücken · realistische Setup-Schritte · dokumentierte Betriebs-/Security-/Migrations-Annahmen · gefährlich veraltete Doku · **CLAUDE.md/CORE_CONTEXT.md/AGENT_HANDOVER.md aktuell?**
+
+### Phase 4P — Platform-Konformität (eigene Befunde, Präfix `PLAT-`)
+
+| # | Vertrag | grep-Signal für Verstoß |
+|---|---|---|
+| P1 | Service-Layer (views→services→models) | `.objects.`/`.filter(`/`.save(` direkt in `views.py` |
+| P2 | Integer-PK | `UUIDField(primary_key=True` |
+| P3 | HTMX-Triple | `hx-`-Element ohne alle drei: `hx-target`+`hx-swap`+`hx-indicator` |
+| P4 | PG-only Tests (ADR-179) | `sqlite` in Test-Settings |
+| P5 | Test-Naming | Testfn ohne `test_should_` |
+| P6 | Shared-CI | Inline-CI statt `uses: achimdehnert/platform/.github/workflows/_ci-python.yml@main` |
+| P7 | Commit-Konvention | letzte ~20 Commits gg. `[feat\|fix\|...](scope):` |
+| P8 | Secrets-Hygiene | Klartext-Secret getrackt; `secrets.env` nicht gitignored |
+| P9 | ADR-Pflicht | neue Dep/Service-Grenze/Cross-Cutting ohne ADR (≠ reine Addition, s. `adr-threshold.md`) |
+
+---
+
+## Phase 5 — Suchraster
+
+`TODO`/`FIXME`/`HACK`/`XXX`/`workaround` · `skip`/`xfail`/`continue-on-error`/`allow_failure` · `password`/`secret`/`token`/`apikey`/`private_key` · `admin`/`debug`/`bypass`/`unsafe`/`insecure` · `eval`/`exec`/`pickle`/`deserialize`/`shell=True` · `SELECT *`/rohe SQL · `UUIDField(primary_key` (P2) · ORM-in-`views.py` (P1) · `sqlite` in Test-Settings (P4) · fehlende HTTP/DB/Queue-Timeouts · Catch-all-Except · unbounded loops/retries · permissive CORS/CSRF/Cookie · env-spezifische Sonderlogik.
+
+→ Treffer **nicht mechanisch** werten — jeder braucht Kontext + Gegenprüfung.
+
+---
+
+## Phase 6 — Out-of-the-Box (≥3 Ansätze)
+
+Je: Idee · Vorteil · Nachteil · Wann sinnvoll · Warum evtl. verwerfen. Unkonventionell erlaubt, technisch plausibel zwingend. (z.B. P1–P9 als CI-Linter / Policy-as-code, Strangler-Fig, Read/Write-Model-Split, Property-based Testing, Subsystem entfernen, Observability-first Refactor.)
+
+---
+
+## Phase 7 — Befunde (Tabelle, stabile IDs)
+
+| ID | Rolle | Kategorie | Befund | Evidenz | Schweregrad | Confidence | Betroffener Teil |
+|---|---|---|---|---|---|---|---|
+
+Präfixe: `PRO-` (positiv) · `AD-` (Risiko/Lücke) · `M28-` (Zukunft) · `SEC-` · `PRIV-` · `TEST-` · `OPS-` · `ARCH-` · `PERF-` · `DOC-` · **`PLAT-` (P1–P9)**.
+Schweregrad: kritisch·hoch·mittel·niedrig·positiv·stark positiv. Confidence: hoch·mittel·niedrig.
+Triviale Stilfragen nur bei systematischem Risiko. Jeder Befund → klare Handlung.
+
+---
+
+## Phase 8 — Top-5-Risiken
+
+Je: Warum wichtig · Schadensszenario · Wahrscheinlichkeit · Dringlichkeit · kleinster wirksamer Fix · stützende Evidenz · **geprüfte Gegenbelege**.
+
+---
+
+## Phase 9 — Empfehlungen (`REC-N`)
+
+Je: Bezug auf Befund-ID · Ziel · konkrete Änderung · Aufwand S/M/L · Risiko der Änderung · **Verifikation (wie beweist man die Lösung?)** · Akzeptanzkriterium. Keine generischen „Tests verbessern" ohne Testart+Ort+Akzeptanzkriterium.
+
+---
+
+## Phase 10 — Schlussurteil
+
+`gesund` · `brauchbar mit gezielten Risiken` · `riskant, aber sanierbar` · `architektonisch gefährdet` · `nicht belastbar`.
++ wichtigste Begründung/Stärke/Schwäche/Sofortmaßnahme/Unsicherheit + 30/60/90-Tage-Roadmap.
+
+---
+
+## Report sichern
+
+```bash
+mkdir -p "$REPO/audits"
+# Report schreiben nach:  $REPO/audits/repo-audit-{YYYY-MM-DD}.md
+```
+Datumsstempel über `date +%F` einsetzen. Optional via `/knowledge-capture` nach Outline.
+
+---
+
+## DEEP-Fan-out (nur bei `--deep`)
+
+Phase 4 als Multi-Agent-Workflow statt Single-Pass:
+
+```
+pipeline über die 9 Dimensionen aus Phase 4:
+  stage 1 (review):  je 1 Sub-Agent → Befunde mit Evidence-Ledger (E1–E4/H), strukturiert
+  stage 2 (verify):  je Befund 1 adversarialer Sub-Agent → "refute or confirm" (default: refuted bei Unsicherheit)
+  → nur bestätigte Befunde übernehmen
+synth: Steelman + 3 Rollen + Top-5 + Roadmap aus den verifizierten Befunden
+```
+
+Kosten beachten (`session-routing.md`): Fan-out × Opus ist teuer — `--deep` ist **opt-in**, nicht default.
+Implementierung als echter Workflow-Skript = **Stufe 3** dieses Skills (folgt, wenn LITE sich bewährt).
+
+---
+
+## Qualitätsregeln (bindend)
+
+Hart in der Sache, fair in der Interpretation · Steelman zuerst · Evidenz/Interpretation/Vermutung trennen · keine Best-Practice-Predigt ohne Repo-Bezug · **keine erfundenen Dateien/Befehle/Testergebnisse/Zeilennummern** · nicht-prüfbares klar sagen · aktiv Gegenbelege suchen · reale Ausfall-/Security-/Daten-/Wartungsrisiken priorisieren · konkrete Fixes statt Diagnosen · keine Secrets vollständig ausgeben · keine destruktiven Aktionen · kein kritischer/hoher Befund ohne Evidenz · Hypothesen als H markieren · **Modus LITE/DEEP ehrlich deklarieren, flach geprüfte Dimensionen benennen**.

--- a/.windsurf/workflows/repo-audit.md
+++ b/.windsurf/workflows/repo-audit.md
@@ -202,10 +202,17 @@ synth: Steelman + 3 Rollen + Top-5 + Roadmap aus den verifizierten Befunden
 Kosten beachten (`session-routing.md`): Fan-out × Opus ist teuer — `--deep` ist **opt-in**, nicht default.
 
 **Implementierung (Stufe 3):** `.claude/workflows/repo-audit-deep.js` — echtes Workflow-Skript
-(Inventar → 9-Dimensionen-pipeline mit review→adversarialer-verify → Synthese).
-Start: `Workflow({ name: "repo-audit-deep", args: { repo: "<pfad>", goal: "<kontext>", date: "<YYYY-MM-DD>" } })`.
-`date` muss übergeben werden (Skripte haben kein `Date.now()`). Nur substanzielle Befunde (kritisch/hoch/mittel)
-durchlaufen die Refutation; positive/niedrige werden direkt übernommen. Flach geprüfte Dimensionen werden ehrlich deklariert.
+(Inventar → 9-Dimensionen-pipeline mit review→adversarialer-verify → Synthese → **Persist**).
+Start: `Workflow({ name: "repo-audit-deep", args: { repo: "<pfad>", goal: "<kontext>" } })`.
+
+- **`date` ist optional** — ein finaler **Persist-Agent** ermittelt es selbst via `date +%F` und schreibt den
+  Report nach `<repo>/audits/repo-audit-<date>.md` (Workflow-Skripte haben weder `Date.now()` noch FS-Zugriff,
+  daher übernimmt das ein Agent). Rückgabe enthält `report_pfad` + `datum`.
+- Nur substanzielle Befunde (kritisch/hoch/mittel) durchlaufen die Refutation; positive/niedrige direkt übernommen.
+- Flach geprüfte Dimensionen werden ehrlich deklariert.
+- **Inline-Start ohne `name`:** wenn das Skript per `scriptPath` aus einem aktiv umgeschalteten Repo läuft, kann
+  der Pfad verschwinden (Branch-Wechsel paralleler Sessions). Robust: via `name` aus der Registry starten, oder
+  ein git-`worktree` für den Skill-Branch nutzen.
 
 ---
 


### PR DESCRIPTION
## Was

Neuer Skill **`/repo-audit`** — tiefes, evidenzbasiertes Audit **eines** Repos (Stufe 2 von 3: Prompt → Lite-Skill → Workflow).

## Abgrenzung (keine Duplikation)

| Skill | Scope |
|---|---|
| `/repo-health-check` | mechanisches Vollständigkeits-**Gate** vor Publish/Deploy |
| `/platform-audit` | **Breite** über ALLE Repos |
| `/compose-audit` | nur docker-compose vs ADR-021 |
| **`/repo-audit`** | **Tiefe + Urteil in EINEM Repo** |

## Inhalt

- **LITE** (default, Single-Pass) + optionaler **`--deep`** Fan-out-Pfad (Stufe 3 folgt als echter Workflow)
- 3 Rollen: 🟢 Proponent · 😈 Advocatus Diabolus · 🔮 Maintainer 2028
- **Evidence-Ledger E1–E4/H** = direkte Umsetzung von `policies/evidence-discipline.md` (kein hoher Befund ohne Evidenz, Hypothesen markiert, aktiv Gegenbelege)
- **Platform-Verträge P1–P9** als eigene `PLAT-`-Befunde mit grep-Signalen: Service-Layer, Integer-PK, HTMX-Triple, PG-only (ADR-179), `test_should_*`, Shared-CI (`_ci-python.yml`), Commit-Konvention, Secrets-Hygiene, ADR-Pflicht (`adr-threshold.md`)
- Eingebautes Drift-Wissen: Index-Rename-Migration → `SeparateDatabaseAndState`, gitleaks-403-Permissions, ttz-lif/meiki-lra Data-Sovereignty

## ADR nötig?

**Nein** — neuer Skill nach bestehendem Muster (`platform-audit`/`repo-health-check`) = Addition, kein Architektur-Entscheid (`policies/adr-threshold.md`). CHANGELOG/PR genügt.

## Verteilung

Nach Merge via `cc-skill-dist` (`generate.py`) nach `~/.claude/commands/` — **nicht** in diesem PR (erst nach Merge auf main).

## Quelle

Gehärteter Ausgangs-Prompt: `~/shared/repo-audit-prompt.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)