### PR TITLE
chore(ci): retire sync-workflows-to-repos.yml — Stufe 1 (dispatch-only + guardrails)

### DIFF
--- a/.github/workflows/sync-workflows-to-repos.yml
+++ b/.github/workflows/sync-workflows-to-repos.yml
@@ -1,15 +1,19 @@
-name: Sync Workflows to all Repos
+# ⚠️ LEGACY — ADR-230 Retire pending (Stufe 1). Dieser per-Repo-.windsurf-Distributor
+# ist die Ursache von Audit-F1 (~1.000 typechange-Phantom-Dirty-Files): er committet
+# Workflows als Regular Files in jedes Repo, lokal werden sie zu Symlinks → dauerhaft dirty.
+# Unter ADR-229 (consumed not mirrored) + ADR-230 (kein per-Repo .windsurf) ist er tot.
+# Der automatische push-Trigger ist ENTFERNT; nur noch manueller Emergency-Reissue mit
+# bewusster Bestätigung. Stufe 2 (Datei entfernen) nach erfolgreichem F1-Sweep + 2 grünen
+# Dist-Runs. Kontext: audits/f1-retire-sync-workflows-rollout-item.md
+name: "⚠️ LEGACY: Sync Workflows to Repos (ADR-230 retire pending — emergency only)"
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - '.windsurf/workflows/**'
-      - 'registry/github_repos.yaml'
-      - 'docs/onboarding/**'
-      - 'docs/governance/**'
   workflow_dispatch:
     inputs:
+      confirm_emergency:
+        description: 'Tippe RETIRE-PENDING, um den Legacy-Distributor bewusst auszuführen (ADR-230)'
+        required: true
+        default: ''
       workflow_name:
         description: 'Workflow to sync (leer = alle UNIVERSAL+DJANGO_HUB+PACKAGE)'
         required: false
@@ -23,7 +27,19 @@ jobs:
   sync:
     name: Push workflows to repos
     runs-on: ubuntu-latest
+    # Schutz-Gate: manuelle Approval über GitHub-Environment-Protection-Rules.
+    # WICHTIG: Im Repo unter Settings → Environments das Environment 'legacy-distributor'
+    # anlegen + Required reviewers setzen, sonst läuft der Job ohne Approval.
+    environment: legacy-distributor
     steps:
+      - name: Guard — bewusste Emergency-Ausführung (ADR-230 Retire pending)
+        run: |
+          if [ "${{ inputs.confirm_emergency }}" != "RETIRE-PENDING" ]; then
+            echo "::error::LEGACY-Distributor (ADR-230 Retire pending). Ausführung nur mit confirm_emergency=RETIRE-PENDING."
+            echo "::error::Per-Repo-.windsurf-Distribution ist abgelöst; siehe audits/f1-retire-sync-workflows-rollout-item.md"
+            exit 1
+          fi
+          echo "::warning::LEGACY-Distributor bewusst ausgeführt (per-Repo .windsurf-Push, ADR-230 Retire pending)."
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2


### PR DESCRIPTION
## Was (ADR-230-Rollout, Stufe 1)

Entschärft den per-Repo-`.windsurf`-Distributor `sync-workflows-to-repos.yml` — die belegte **Root Cause von Audit-F1** (committet Workflows als Regular Files in 45 Repos → lokal Symlinks → ~1.000 `typechange`-Phantom-Dirty-Files). Unter **ADR-229** (consumed not mirrored) + **ADR-230** (kein per-Repo `.windsurf`) ist er tot.

## Änderung
- **`on: push`-Trigger entfernt** → stoppt die automatische F1-Maschine. Nur noch `workflow_dispatch`.
- **Emergency-Guard**: Pflicht-Input `confirm_emergency=RETIRE-PENDING`, sonst `exit 1`.
- **`environment: legacy-distributor`** am Job (manuelle Approval).
- Banner im Workflow-Namen + Header-Kommentar mit Verweis auf `audits/f1-retire-sync-workflows-rollout-item.md`.

## ⚠️ Manueller Folgeschritt (nicht im PR möglich)
Im Repo **Settings → Environments** das Environment **`legacy-distributor`** anlegen + **Required reviewers** setzen — sonst greift die Approval-Schutzregel nicht (der `confirm_emergency`-Guard bleibt aber wirksam).

## Vorbedingung erfüllt
Windsurf liest seit `windsurf-subset.py --allow-live` (9 Review-Workflows live) aus dem **globalen Subset**, nicht mehr per-Repo → Abschalten des per-Repo-Syncs ist sicher.

## Reihenfolge
Stufe 1 (dieser PR, entschärfen) → **F1-Sweep** (`tools/f1-windsurf-sweep.sh`, 45 Repos) → Stufe 2 (Datei entfernen, nach erfolgreichem Sweep + 2 grünen Dist-Runs).

Review via Windsurf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)