### PR TITLE
feat(adr-233): main-tree-guard + repo-session-Wrapper (enforcing core, getestet)

### DIFF
--- a/docs/adr/ADR-233-parallel-session-worktree-convention.md
+++ b/docs/adr/ADR-233-parallel-session-worktree-convention.md
@@ -110,9 +110,15 @@ strukturell. Darum ist der Guard Teil der **Entscheidung**, nicht der Risiko-Mit
 - `tools/worktree-reaper.py` ✅ gebaut + dry-run-validiert (7 merged erkannt, 2 dirty geschützt) — als
   **versioniertes Plattformtool** (Changelog, Test-Fixtures für squash-merged-PR-Erkennung, fester
   `--dry-run`/`--apply`-Contract; REC-13/M28-8) weiterführen.
-- **`main-tree-guard`** (REC-1) + **`repo-session start`-Wrapper** (REC-2) bauen — der enforcende Kern;
-  ohne sie ist die Invariante nicht erreicht.
-- **Lease-Ledger** (REC-7) an Wrapper + Reaper koppeln; Reaper-Stale-Logik von mtime auf Lease umstellen.
+- **`tools/main-tree-guard.sh`** (REC-1) ✅ gebaut + getestet: post-checkout-Hook → Snap-back auf `main`
+  + Guard-Event-Log; `report` liefert `unauthorized_head_flips/30d` (Kill-Gate-Metrik §8). Ehrliche
+  Grenze: git hat keinen Pre-switch-Block → Hook ist Sicherheitsnetz + Messung, der **Wrapper ist der
+  eigentliche Enforcer**.
+- **`tools/repo-session.sh`** (REC-2) ✅ gebaut + getestet: `start`/`list`/`end`; legt Worktree **von
+  `origin/main`** an, Branch-Schema `session/<date>/<owner>/<slug>`, schreibt Lease (REC-7), Dirty-Guard
+  bei `end`.
+- **Lease-Ledger** (REC-7) ✅ vom Wrapper geschrieben; **offen:** Reaper-Stale-Logik von mtime auf Lease
+  umstellen (Folge-Item).
 - Konvention + Entry Point in `CORE_CONTEXT.md`/Session-Start-Ritual verankern (ein offizieller Einstieg).
 - Einmaliger Cleanup bestehender stale Worktrees — **nur nach Einzel-Freigabe** (fremde/evtl. aktive
   Sessions; destruktive Shared-State-Aktion). *(In dieser Session bereits durchgeführt: 7 gemergte gereapt.)*

--- a/tools/main-tree-guard.sh
+++ b/tools/main-tree-guard.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# main-tree-guard — schützt den "heiligen" Haupt-Tree vor HEAD-Flips (ADR-233 §2.1).
+#
+# git bietet keinen sauberen PRE-switch-Hook zum harten Blocken. Dieser Guard ist
+# darum zweistufig und EHRLICH dokumentiert:
+#   1) Enforcer (best effort): als post-checkout-Hook installiert, schnappt er den
+#      Haupt-Tree nach einem versehentlichen Branch-Wechsel sofort auf main zurück
+#      (symbolic-ref) UND protokolliert ein Guard-Event. Working-Tree-Dateien werden
+#      NICHT angefasst (kein Datenverlust) — nur HEAD wird zurückgesetzt + Warnung.
+#   2) Metrik: `report` zählt `unauthorized_head_flips` der letzten 30 Tage — die
+#      messbare Kill-Gate-Größe aus ADR-233 §8.
+#
+# Die eigentliche Durchsetzung ist der `repo-session`-Wrapper (verbindlicher Entry
+# Point). Dieser Guard ist das Sicherheitsnetz + die Messung dafür.
+#
+# Usage:
+#   main-tree-guard.sh install <repo-path>   # Sentinel + post-checkout-Hook setzen
+#   main-tree-guard.sh report  [repo-path]   # unauthorized_head_flips/30d
+#   main-tree-guard.sh hook <prev> <new> <flag>   # (intern, von git aufgerufen)
+set -euo pipefail
+
+SENTINEL=".git/iil-main-tree-protected"
+LOG=".git/iil-guard-events.log"
+
+die() { echo "FEHLER: $*" >&2; exit 1; }
+
+cmd_install() {
+  local repo="${1:-}"; [ -n "$repo" ] || die "repo-path fehlt"
+  local gitdir; gitdir="$(git -C "$repo" rev-parse --git-dir)" || die "kein git-Repo"
+  ( cd "$repo" && touch "$SENTINEL" )
+  local hookdir="$gitdir/hooks"; mkdir -p "$hookdir"
+  local hook="$hookdir/post-checkout"
+  local self; self="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+  if [ -e "$hook" ] && ! grep -q 'main-tree-guard' "$hook" 2>/dev/null; then
+    die "post-checkout-Hook existiert bereits und ist fremd: $hook — manuell prüfen."
+  fi
+  cat > "$hook" <<HOOK
+#!/usr/bin/env bash
+# installed by main-tree-guard (ADR-233)
+exec "$self" hook "\$@"
+HOOK
+  chmod +x "$hook"
+  echo "✓ Guard installiert: Sentinel $repo/$SENTINEL + post-checkout-Hook."
+  echo "  Hinweis: harte Blockade nur via repo-session-Wrapper; dieser Hook = Snap-back + Metrik."
+}
+
+# git post-checkout args: <prev-HEAD> <new-HEAD> <branch-checkout-flag(1=branch,0=file)>
+cmd_hook() {
+  local prev="${1:-}" new="${2:-}" flag="${3:-0}"
+  # nur Branch-Checkouts interessieren (flag=1); File-Checkouts ignorieren
+  [ "$flag" = "1" ] || exit 0
+  # nur im geschützten Haupt-Tree aktiv
+  [ -e "$SENTINEL" ] || exit 0
+  local head; head="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || echo DETACHED)"
+  if [ "$head" != "main" ]; then
+    local ts; ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "$ts unauthorized_head_flip from=$prev to=$new head=$head" >> "$LOG"
+    git symbolic-ref HEAD refs/heads/main 2>/dev/null || true
+    echo "⚠️  main-tree-guard (ADR-233): Haupt-Tree ist heilig — HEAD auf 'main' zurückgesetzt." >&2
+    echo "    Für editierende Arbeit: 'repo-session start <repo> --task <slug>' nutzen." >&2
+    echo "    (Working-Tree-Dateien unverändert; Event protokolliert in $LOG)" >&2
+  fi
+  exit 0
+}
+
+cmd_report() {
+  local repo="${1:-.}"
+  local gitdir; gitdir="$(git -C "$repo" rev-parse --git-dir)" || die "kein git-Repo"
+  local log="$gitdir/iil-guard-events.log"
+  if [ ! -e "$log" ]; then echo "unauthorized_head_flips/30d: 0 (kein Log)"; return 0; fi
+  local cutoff; cutoff="$(date -u -d '-30 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo 0000)"
+  local n; n="$(awk -v c="$cutoff" '$1 >= c' "$log" | grep -c unauthorized_head_flip || true)"
+  echo "unauthorized_head_flips/30d: ${n:-0}"
+  [ "${n:-0}" = "0" ] || { echo "  → Kill-Gate (ADR-233 §8): Konvention nicht erzwingbar (>0)."; tail -3 "$log"; }
+}
+
+case "${1:-}" in
+  install) shift; cmd_install "$@";;
+  hook)    shift; cmd_hook "$@";;
+  report)  shift; cmd_report "$@";;
+  *) echo "usage: main-tree-guard.sh {install <repo> | report [repo] | hook <prev> <new> <flag>}" >&2; exit 2;;
+esac

--- a/tools/repo-session.sh
+++ b/tools/repo-session.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# repo-session — verbindlicher Entry Point fuer editierende Coding-Sessions (ADR-233).
+#
+# Statt im geteilten Haupt-Tree den Branch zu wechseln (HEAD-Flip-Kollision), legt
+# jede editierende Session hier einen isolierten git-Worktree VON origin/main an,
+# mit deterministischem Branch-Schema und einer maschinenlesbaren Lease, die der
+# worktree-reaper konsumiert. Der Haupt-Tree bleibt "heilig" auf main.
+#
+# Usage:
+#   repo-session.sh start <repo-path> --task <slug> [--base <ref>] [--ephemeral]
+#   repo-session.sh list
+#   repo-session.sh end <worktree-path>        # Worktree entfernen (nur wenn clean), Lease schliessen
+#
+# Lease-Felder (ADR-233 §2.4): session_id, owner, created_at, last_touch, branch,
+#   base_sha, repo, worktree, intended_pr, expires_at, ephemeral.
+#
+# Env:
+#   REPO_SESSION_DIR   (default ~/.repo-session)  — Leases + Worktree-Wurzel
+#   REPO_SESSION_TTL_DAYS (default 7)             — expires_at = created_at + TTL
+set -euo pipefail
+
+ROOT="${REPO_SESSION_DIR:-$HOME/.repo-session}"
+LEASE_DIR="$ROOT/leases"
+WT_ROOT="$ROOT/worktrees"
+EPHEMERAL_ROOT="/tmp/repo-session"   # ADR-233 R-5: /tmp nur fuer ephemere
+TTL_DAYS="${REPO_SESSION_TTL_DAYS:-7}"
+
+die() { echo "FEHLER: $*" >&2; exit 1; }
+
+slug() { printf '%s' "$1" | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9._-'; }
+
+cmd_start() {
+  local repo="" task="" base="origin/main" ephemeral="false"
+  repo="${1:-}"; shift || true
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --task) task="$2"; shift 2;;
+      --base) base="$2"; shift 2;;
+      --ephemeral) ephemeral="true"; shift;;
+      *) die "unbekannte Option: $1";;
+    esac
+  done
+  [ -n "$repo" ] || die "repo-path fehlt"
+  [ -n "$task" ] || die "--task <slug> fehlt"
+  [ -d "$repo/.git" ] || repo="$(git -C "$repo" rev-parse --show-toplevel 2>/dev/null)" || die "kein git-Repo: $repo"
+
+  # Haupt-Tree heilig: muss auf main stehen, bevor wir abzweigen.
+  local cur; cur="$(git -C "$repo" rev-parse --abbrev-ref HEAD)"
+  [ "$cur" = "main" ] || die "Haupt-Tree ($repo) ist auf '$cur', nicht 'main' — heiliger Tree verletzt (ADR-233)."
+
+  git -C "$repo" fetch --prune origin main -q
+  local base_sha; base_sha="$(git -C "$repo" rev-parse "$base")" || die "base_ref '$base' nicht auflösbar"
+
+  local owner date_s rname branch wt sid
+  owner="$(slug "$(git -C "$repo" config user.name 2>/dev/null || echo agent)")"; owner="${owner:-agent}"
+  date_s="$(date -u +%Y-%m-%d)"
+  rname="$(basename "$repo")"
+  task="$(slug "$task")"
+  branch="session/$date_s/$owner/$task"
+  sid="${date_s}-${owner}-${task}-$(date -u +%H%M%S)"
+  if [ "$ephemeral" = "true" ]; then
+    wt="$EPHEMERAL_ROOT/$rname/$sid"
+  else
+    wt="$WT_ROOT/$rname/$sid"
+  fi
+  mkdir -p "$(dirname "$wt")" "$LEASE_DIR"
+
+  git -C "$repo" worktree add -b "$branch" "$wt" "$base" >&2 \
+    || die "worktree add fehlgeschlagen (Branch '$branch' evtl. vergeben?)"
+
+  local now exp lease
+  now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  exp="$(date -u -d "+${TTL_DAYS} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)"
+  lease="$LEASE_DIR/$sid.json"
+  cat > "$lease" <<JSON
+{
+  "session_id": "$sid",
+  "owner": "$owner",
+  "repo": "$rname",
+  "branch": "$branch",
+  "base_sha": "$base_sha",
+  "worktree": "$wt",
+  "created_at": "$now",
+  "last_touch": "$now",
+  "expires_at": "$exp",
+  "intended_pr": null,
+  "ephemeral": $ephemeral
+}
+JSON
+  echo "$wt"                 # stdout = Worktree-Pfad (zum cd)
+  {
+    echo "✓ Session-Worktree angelegt (ADR-233):"
+    echo "  Branch : $branch  (von $base @ ${base_sha:0:12})"
+    echo "  Pfad   : $wt"
+    echo "  Lease  : $lease  (expires $exp, ephemeral=$ephemeral)"
+    echo "  cd \"$wt\""
+  } >&2
+}
+
+cmd_list() {
+  [ -d "$LEASE_DIR" ] || { echo "keine Leases."; return 0; }
+  local n=0
+  for l in "$LEASE_DIR"/*.json; do
+    [ -e "$l" ] || continue
+    n=$((n+1))
+    python3 - "$l" <<'PY'
+import json,sys
+d=json.load(open(sys.argv[1]))
+print(f"- {d['branch']:48} {d['worktree']}  (exp {d['expires_at']}, eph={d['ephemeral']})")
+PY
+  done
+  echo "$n Lease(s)."
+}
+
+cmd_end() {
+  local wt="${1:-}"; [ -n "$wt" ] || die "worktree-path fehlt"
+  local repo; repo="$(git -C "$wt" rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's#/\.git$##')" || true
+  # Dirty-Guard: nie einen Tree mit uncommitted changes entfernen
+  if [ -n "$(git -C "$wt" status --porcelain 2>/dev/null)" ]; then
+    die "Worktree $wt ist DIRTY — erst committen/pushen (Guard)."
+  fi
+  git -C "$wt" worktree remove "$wt" 2>/dev/null || git worktree remove "$wt"
+  # Lease schliessen
+  for l in "$LEASE_DIR"/*.json; do
+    [ -e "$l" ] || continue
+    grep -q "\"worktree\": \"$wt\"" "$l" && mv "$l" "$l.closed" && echo "Lease geschlossen: $l.closed"
+  done
+  echo "Worktree entfernt: $wt (Branch bleibt erhalten)"
+}
+
+case "${1:-}" in
+  start) shift; cmd_start "$@";;
+  list)  cmd_list;;
+  end)   shift; cmd_end "$@";;
+  *) echo "usage: repo-session.sh {start <repo> --task <slug> [--base <ref>] [--ephemeral] | list | end <wt>}" >&2; exit 2;;
+esac


### PR DESCRIPTION
## Was

Implementiert die **ADR-233-Bauverpflichtungen** (v1, der enforcing core), die das externe Review eingefordert hat — damit „Main-Tree heilig" strukturell statt nur sozial wird.

## Neu

- **`tools/main-tree-guard.sh`** — post-checkout-Hook: schnappt den geschützten Haupt-Tree nach versehentlichem Branch-Wechsel sofort auf `main` zurück (HEAD-symref, **Working-Tree-Dateien unangetastet**) + protokolliert ein Guard-Event. `report` liefert `unauthorized_head_flips/30d` — die **messbare Kill-Gate-Größe** aus §8.
- **`tools/repo-session.sh`** — der verbindliche Entry Point (`start`/`list`/`end`): legt Worktree **von `origin/main`** an, Branch-Schema `session/<date>/<owner>/<slug>`, schreibt **Lease** (REC-7), **Dirty-Guard** bei `end` (Branch bleibt erhalten).

## Ehrliche Grenze (dokumentiert)

git hat keinen sauberen Pre-switch-Block → der Hook ist **Sicherheitsnetz + Messung**, der **Wrapper ist der eigentliche Enforcer**. Kein Theater: beides ist getestet.

## Getestet (Wegwerf-Repos, read-only ggü. platform)
- Guard: `git switch -c x` → Snap-back auf main, Event geloggt, `report` = 1.
- Wrapper: `start` → Worktree + korrekter Branch + valide Lease, Haupt-Tree bleibt `main`; `end` verweigert dirty, entfernt clean, schließt Lease.

ADR-233 §5 auf „gebaut+getestet" aktualisiert. Offen (Folge-Item): Reaper-Stale-Logik von mtime auf Lease umstellen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
