### PR TITLE
docs(core-context): Parallel-Session-Hygiene verankern (ADR-233)

### DIFF
--- a/CORE_CONTEXT.md
+++ b/CORE_CONTEXT.md
@@ -68,6 +68,24 @@ und geteilte Werkzeuge der 45+ Hub-Repos.
 - **`bootstrap.sh` ist Public Interface** — Breaking Changes sind ADR-pflichtig
 - **Commits in `docs/adr/`**: scope = `adr`, nicht `docs`
 - **Workflows in `.windsurf/workflows/`**: Änderungen brauchen `/workflow-review` vor Merge
+- **Parallele Sessions — Haupt-Tree heilig (ADR-233)**: der geteilte Checkout `~/github/platform`
+  bleibt auf `main`; **kein** Branch-Switch im Haupt-Tree. Editierende Arbeit läuft in einem eigenen
+  Worktree via `tools/repo-session.sh start <repo> --task <slug>` (Branch `session/<date>/<owner>/<slug>`
+  von `origin/main` + Lease). Aufräumen: `tools/worktree-reaper.py` (dry-run default, squash-aware,
+  Dirty-Guard). Read-only-Analyse darf im Haupt-Tree bleiben.
+
+### Parallel-Session-Hygiene (ADR-233) — Werkzeuge
+
+| Werkzeug | Zweck |
+|---|---|
+| `tools/repo-session.sh` | verbindlicher Entry Point: `start`/`list`/`end` — Worktree von `origin/main`, Branch-Schema, Lease |
+| `tools/worktree-reaper.py` | GC gemergter/stale Worktrees (dry-run default; `--apply`; entfernt nie einen Branch) |
+| `tools/main-tree-guard.sh` | `install` = Snap-back-Hook (aktiv erst nach Skill-Migration); `report` = `unauthorized_head_flips/30d` (Kill-Gate-Metrik) |
+
+> **Rollout-Hinweis:** Der harte `main-tree-guard` (Snap-back) wird **erst aktiviert**, wenn die
+> Session-Skills den geteilten Tree nicht mehr per `git switch` umschalten — sonst bricht er
+> bestehende Abläufe. Bis dahin: Konvention als Lesestoff + `repo-session` als empfohlener Einstieg;
+> `main-tree-guard.sh report` misst Verstöße. Kill-Gate-Termin: 2026-09-01.
 
 ## Verwandte Skills
 


### PR DESCRIPTION
## Was

Verankert die ADR-233-Worktree-Konvention in **CORE_CONTEXT.md** — der Pflicht-Lektüre, die in *jeder* Session (Phase 1 von /session-start) geladen wird. Damit wird ADR-233 für Agenten **wirksam**, nicht nur dokumentiert.

## Inhalt
- Konventions-Bullet: **Haupt-Tree heilig** (auf `main`, kein Branch-Switch); editieren via `tools/repo-session.sh start`; Cleanup via `worktree-reaper.py`; Read-only darf im Haupt-Tree bleiben.
- Werkzeug-Tabelle (repo-session / worktree-reaper / main-tree-guard).

## Bewusst NICHT in diesem PR (ehrlich sequenziert)
- **Aktiver Snap-back-Guard** (`main-tree-guard.sh install`) wird **erst** scharf geschaltet, wenn die Session-Skills den geteilten Tree nicht mehr per `git switch` umschalten — sonst bricht er bestehende Abläufe. Bis dahin: Konvention als Lesestoff + `repo-session` als Einstieg; `report` misst Verstöße.
- **session-start.md**-Step: separater PR, weil Workflow-Änderungen `/workflow-review` brauchen (CORE_CONTEXT-Konvention).

Reine Doku-Änderung. Relates: ADR-233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)