### PR TITLE
feat(adr-234): P0 Registry-Konsistenz-Check + Union-Canonical-Korrektur

### DIFF
--- a/.github/workflows/registry-consistency.yml
+++ b/.github/workflows/registry-consistency.yml
@@ -1,0 +1,39 @@
+# Registry-Konsistenz (ADR-234 P0) — macht die Dual-SSoT-Divergenz sichtbar.
+# INFORMATIONAL: schlägt CI nie fehl (kann so nicht zu Lärm werden, der abgeschaltet
+# wird) — Muster wie ADR-226 Adoption-Gate. Hard-Gate (--strict) erst nach der
+# Union-Canonical-Migration (ADR-234 P0), wenn Divergenz==0 erreichbar ist.
+name: Registry-Konsistenz (ADR-234 P0)
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'        # Montags 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      strict:
+        description: 'Exit non-zero bei Divergenz (Default: informational)'
+        type: boolean
+        default: false
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/repo-registry.yaml'
+      - 'registry/repos.yaml'
+      - 'tools/registry-consistency-check.py'
+
+permissions:
+  contents: read
+
+jobs:
+  consistency:
+    name: Registry-Konsistenz prüfen
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - run: pip install pyyaml --quiet
+      - name: Konsistenz-Check
+        run: |
+          python3 tools/registry-consistency-check.py \
+            ${{ inputs.strict && '--strict' || '' }}

--- a/docs/adr/ADR-234-clean-state-invariant.md
+++ b/docs/adr/ADR-234-clean-state-invariant.md
@@ -74,13 +74,23 @@ Bausteine in der Reihenfolge **P0 → P0.5a → R1 → P0.5b → R3-minimal → 
 Review-Runde 2 neu geschnitten — R3 sitzt am irreversibelsten Pfad und darf nicht hinter voller R2
 warten; AD-4/M28-5):
 
-- **P0 — Registry-SSoT-Konsolidierung + vollständiges Schema:** zwei Registries → eine; Live-Repo-Liste
-  abgeleitet aus `gh repo list` mit **deterministischen Include/Exclude-Filtern** (archived, fork,
-  template, private/internal, infra-only, repo-type, Fremd-Org — AD-9/AD-21). Schema mit **einem
-  kanonischen Lifecycle-Feld** (`pipeline_status ∈ {live, maintenance, dead, archived}` — kein zweites
-  `sunset`-Vokabular; AD-1/M28-2) + Pflichtfeldern `owner_team`, `repo_type`, `staging_profile`,
-  `artifact_kind` und der **vollständigen Waiver-Semantik** (`waiver:[{gate, reason, expires}]`,
-  Max-Budget, Gate-Bezug — aus R4 vorgezogen, AD-2). Ohne dieses Schema kann R2/R3 nicht korrekt entscheiden.
+- **P0 — Registry-SSoT-Konsolidierung via Union-Canonical (korrigiert 2026-06-01, Befund unten):**
+  **Wichtig — kein „eine zur View der anderen":** Die zwei heutigen Registries sind **kein Superset**,
+  sondern unterschiedlicher *Scope*: `scripts/repo-registry.yaml` = flaches Flotten-Inventar (**42 Repos**,
+  operativ: type/prod_url/port/health), `registry/repos.yaml` = kuratiertes deployed-Subset (**18 Systeme**,
+  Deploy/Lifecycle/Tenancy/Coverage). Schnittmenge nur 16; **26 Repos nur flach, 2 nur reich.** Ein
+  Generator „reich → flach" würde 26 Repos verlieren (verifiziert via `tools/registry-consistency-check.py`).
+  → Der einzige verlustfreie Weg: eine **neue kanonische Union-Registry aller ~44 Repos** mit
+  **geschichtetem Schema** (operative Felder für *alle* + Deploy/Governance-Felder für das deployed-Subset);
+  **beide Altdateien werden daraus als Views generiert** (dann wirklich verlustfrei), Konsumenten danach
+  inkrementell migriert, Views retired. Live-Repo-Liste abgeleitet aus `gh repo list` mit **deterministischen
+  Include/Exclude-Filtern** (archived, fork, template, private/internal, infra-only, repo-type, Fremd-Org —
+  AD-9/AD-21). Union-Schema mit **einem kanonischen Lifecycle-Feld** (`pipeline_status ∈ {live, maintenance,
+  dead, archived}` — kein zweites `sunset`-Vokabular; AD-1/M28-2) + Pflichtfeldern `owner_team`, `repo_type`,
+  `staging_profile`, `artifact_kind` und der **vollständigen Waiver-Semantik** (`waiver:[{gate, reason,
+  expires}]`, Max-Budget, Gate-Bezug — aus R4 vorgezogen, AD-2).
+  **Erststep (nicht-brechend, bereits gebaut):** `tools/registry-consistency-check.py` + informational
+  CI-Job machen die Dual-SSoT-Divergenz sichtbar/nicht-driftend, bevor die Union-Migration startet.
 - **P0.5a — iil-Dependency-Cohort + Ledger-*Schema* (Primär-Hebel):** zentral erzeugter
   `constraints/iil-cohort-<YYYY.MM>.txt` (mit Supportfenster/Deprecation-Datum, M28-8) + die *Definition*
   des `clean_state`-Ledger-Schemas, **repo-typisiert** (Hub = Docker-`artifact_digest`; Library =
@@ -287,3 +297,7 @@ respektierte die „nicht neu aufrollen"-Liste.
   geschnitten (R3 früher, P0.5-Split), Schema/Waiver in P0 vorgezogen, Kill-Gate gestuft, Ledger als
   derived cache + repo-typisiert, R2-Mindestvertrag + quarantine-Lane, Alternativen E/F, R5 an
   Enforcement-Abdeckung gekoppelt. Step-5-Tag-Tabelle in §11.
+- **2026-06-01:** P0 korrigiert nach Verlustfrei-Check (`tools/registry-consistency-check.py`): die zwei
+  Registries sind **kein Superset** (flach 42 / reich 18, Schnitt 16, 26 nur-flach). „eine zur View der
+  anderen" verworfen → **Union-Canonical** ist der einzige verlustfreie Weg. Nicht-brechender Erststep
+  (Consistency-Check + informational CI) gebaut; Union-Migration bleibt das P0-Programm.

--- a/tools/registry-consistency-check.py
+++ b/tools/registry-consistency-check.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""registry-consistency-check — macht die Registry-Doppelquelle sichtbar (ADR-234 P0).
+
+Es existieren zwei Registries mit UNTERSCHIEDLICHEM Scope (kein Superset):
+  - scripts/repo-registry.yaml  — flaches Flotten-Inventar (alle Repos, operativ:
+                                  type/prod_url/port/health/pypi/staging_url)
+  - registry/repos.yaml         — kuratiertes deployed-Subset (domains[].systems[]),
+                                  Deploy-/Governance-Detail (lifecycle/tenancy/coverage/deploy)
+
+Solange beide „Single Source of Truth" beanspruchen, kann jede Adoptions-/Live-Repo-
+Messung je nach Quelle eine andere Zahl liefern. Dieser Check ELIMINIERT die Dual-Quelle
+noch NICHT (das ist die Union-Canonical-Migration, ADR-234 P0) — er macht die Divergenz
+deterministisch SICHTBAR, damit sie nicht still driftet:
+
+  1. Repos, die in genau EINER Registry stehen.
+  2. Überlappende Repos, deren gemeinsame Felder (z.B. `type`) DIVERGIEREN.
+
+INFORMATIONAL by default (exit 0) — nach Repo-Health-Regel-Disziplin (neue Regeln starten
+als SUGGEST, gegen echte Repos validiert, 0 FP, kein Hard-Fail der die Flotte einfriert).
+`--strict` macht Divergenz zum Exit-1 (für spätere, gewollte Gates).
+
+Deterministisch, kein LLM. ADR-234 P0 / KONZ-platform-001.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FLAT = REPO_ROOT / "scripts" / "repo-registry.yaml"
+RICH = REPO_ROOT / "registry" / "repos.yaml"
+
+
+def load_flat(path: Path) -> dict[str, dict]:
+    d = yaml.safe_load(path.read_text())
+    repos = d.get("repos", d) if isinstance(d, dict) else {}
+    return {k: (v or {}) for k, v in repos.items() if isinstance(v, dict)}
+
+
+def load_rich(path: Path) -> dict[str, dict]:
+    d = yaml.safe_load(path.read_text())
+    out: dict[str, dict] = {}
+    for dom in d.get("domains", []) if isinstance(d, dict) else []:
+        for s in dom.get("systems", []):
+            key = s.get("repo") or s.get("name")
+            if key:
+                out[key] = s
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Registry-Konsistenz-Check (ADR-234 P0).")
+    ap.add_argument("--strict", action="store_true", help="Exit 1 bei Divergenz (Default: informational).")
+    args = ap.parse_args()
+
+    if not FLAT.exists() or not RICH.exists():
+        print(f"FEHLER: Registry fehlt ({FLAT} / {RICH}).", file=sys.stderr)
+        return 2
+
+    flat, rich = load_flat(FLAT), load_rich(RICH)
+    fset, rset = set(flat), set(rich)
+    only_flat = sorted(fset - rset)
+    only_rich = sorted(rset - fset)
+
+    # Feld-Divergenz auf der Schnittmenge (gemeinsam vorhandenes Feld 'type').
+    type_mismatch = []
+    for r in sorted(fset & rset):
+        ft, rt = flat[r].get("type"), rich[r].get("type")
+        if ft is not None and rt is not None and ft != rt:
+            type_mismatch.append((r, ft, rt))
+
+    lines = [
+        "# Registry-Konsistenz (ADR-234 P0)",
+        "",
+        f"- `scripts/repo-registry.yaml` (flach): **{len(flat)}** Repos",
+        f"- `registry/repos.yaml` (reich): **{len(rich)}** Systeme",
+        f"- Schnittmenge: **{len(fset & rset)}**",
+        "",
+        f"## Nur in flach — fehlt in reich ({len(only_flat)})",
+        *([f"- `{r}`" for r in only_flat] or ["- (keine)"]),
+        "",
+        f"## Nur in reich — fehlt in flach ({len(only_rich)})",
+        *([f"- `{r}`" for r in only_rich] or ["- (keine)"]),
+        "",
+        f"## `type`-Divergenz auf der Schnittmenge ({len(type_mismatch)})",
+        *([f"- `{r}`: flach=`{ft}` ≠ reich=`{rt}`" for r, ft, rt in type_mismatch] or ["- (keine)"]),
+        "",
+        "_Dual-SSoT noch aktiv — Auflösung = Union-Canonical (ADR-234 P0). Dieser Check macht Drift sichtbar._",
+    ]
+    report = "\n".join(lines)
+    print(report)
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as f:
+            f.write(report + "\n")
+
+    diverged = bool(only_flat or only_rich or type_mismatch)
+    if args.strict and diverged:
+        print("\n[strict] Divergenz vorhanden → exit 1.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Was
Erster **nicht-brechender** Schritt von **ADR-234 P0** (Registry-SSoT) + die ADR-Korrektur, die ein Verlustfrei-Check erzwungen hat.

## Befund (warum die ursprüngliche (c)-Idee verworfen wurde)
Die zwei Registries sind **kein Superset**, sondern unterschiedlicher Scope:
- `scripts/repo-registry.yaml` (flach): **42** Repos, operativ
- `registry/repos.yaml` (reich): **18** Systeme, Deploy/Governance
- Schnitt **16**, **26 nur-flach**, 2 nur-reich

→ Ein Generator „reich → flach" würde 26 Repos verlieren. **„Eine zur View der anderen" ist unmöglich.** Der einzige verlustfreie Weg ist **Union-Canonical** (neue kanonische Registry aller ~44 Repos, geschichtetes Schema, beide Altdateien als Views) — im ADR-234-P0-Abschnitt korrigiert.

## Geliefert (nicht-brechend)
- **`tools/registry-consistency-check.py`** — macht die Divergenz deterministisch sichtbar (only-flat / only-rich / type-Divergenz). **Informational** (exit 0), `--strict` für später. Getestet: reproduziert 42/18/16/26.
- **`.github/workflows/registry-consistency.yml`** — informational CI (fällt nie), Muster wie ADR-226 Adoption-Gate; schedule + push auf die Registries.
- **ADR-234 §2 P0 + Changelog** auf Union-Canonical korrigiert.

## Bewusst NICHT
Kein Cutover, keine Konsumenten-Migration, kein Hard-Gate — die ~45 Konsumenten bleiben unangetastet. Die Union-Migration ist das eigentliche P0-Programm (mehrwöchig), separat.

Relates: ADR-234, KONZ-platform-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
