### PR TITLE
feat(adr-234): registry_api Accessor + P0 abgeschlossen (Views = End-Zustand)

### DIFF
--- a/docs/adr/ADR-234-clean-state-invariant.md
+++ b/docs/adr/ADR-234-clean-state-invariant.md
@@ -312,3 +312,11 @@ respektierte die „nicht neu aufrollen"-Liste.
   Fail) verhindert Divergenz. Sicherheits-Vorabcheck: **0 Text-grep-Konsumenten** (alle 25 yaml-parsen;
   klickdummy-host-`repos.yaml` ist ein anderes File) → semantisch verlustfrei. **Offen:** Konsumenten
   schrittweise auf `canonical.yaml` umziehen, dann Views retiren.
+- **2026-06-01:** **P0 effektiv abgeschlossen.** Befund: **kein** Konsument liest beide Registries
+  (8 nur flach, 10 nur reich) → eine Migration auf canonicals verschachteltes Schema wäre rein
+  kosmetisch + netto-negativ (Mehr-Komplexität, kein funktionaler Gewinn). **Entscheidung: die
+  generierten Views sind der legitime, divergenzsichere End-Zustand** (Read-API); bestehende Konsumenten
+  bleiben unverändert. Für *neuen* Code: `tools/registry_api.py` (`flat()`/`rich()`/`repos()`/`repo()`,
+  liest canonical; die Projektion-Logik `gen_flat`/`gen_rich` lebt dort und wird von der CLI/dem
+  Drift-Gate importiert → eine Implementierung). View-Retire ist damit **nicht** erforderlich. Die
+  Dual-SSoT (P0-Kernproblem) ist aufgelöst.

--- a/tools/registry-canonical.py
+++ b/tools/registry-canonical.py
@@ -82,21 +82,9 @@ def build() -> dict:
     }
 
 
-def gen_flat(canon: dict) -> dict:
-    out = {"server": canon["meta"].get("server", {}), "repos": {}}
-    for n, e in canon["repos"].items():
-        if e.get("in_flat"):
-            out["repos"][n] = e["flat"]
-    return out
-
-
-def gen_rich(canon: dict) -> dict:
-    order = canon["meta"].get("domain_order", [])
-    by_dom: dict[str, list] = {d: [] for d in order}
-    for n, e in canon["repos"].items():
-        if e.get("in_rich"):
-            by_dom.setdefault(e.get("domain"), []).append(e["rich"])
-    return {"domains": [{"name": d, "systems": by_dom[d]} for d in by_dom if by_dom[d]]}
+# Projektion-Logik lebt in registry_api (eine Implementierung → Accessor + Drift-Gate
+# laufen nie auseinander). Sibling-Import: beim Direktaufruf ist tools/ in sys.path[0].
+from registry_api import gen_flat, gen_rich  # noqa: E402
 
 
 def _norm(x):

--- a/tools/registry_api.py
+++ b/tools/registry_api.py
@@ -1,0 +1,77 @@
+"""registry_api — importierbarer Accessor für die kanonische Registry (ADR-234 P0).
+
+Single Source of Truth ist `registry/canonical.yaml`. Die zwei Altdateien
+(`scripts/repo-registry.yaml`, `registry/repos.yaml`) sind generierte, gate-
+erzwungene Views (kein Edit von Hand). **Neuer Code** liest die Registry über
+dieses Modul — bestehende View-Leser bleiben unverändert (Views sind eine
+legitime, divergenzsichere Read-API).
+
+Dies ist die EINE Projektion-Implementierung (`gen_flat`/`gen_rich`); die CLI
+`registry-canonical.py` (build/flip/verify) **importiert** sie, damit Accessor
+und Drift-Gate nie auseinanderlaufen.
+
+Verwendung (neuer Code):
+    import sys; sys.path.insert(0, "<…>/platform/tools")
+    import registry_api as reg
+    reg.flat()           # {server, repos:{name:{type,prod_url,port,health,…}}}  (= scripts/repo-registry.yaml-Form)
+    reg.rich()           # {domains:[{name, systems:[…]}]}                        (= registry/repos.yaml-Form)
+    reg.repos()          # sortierte Repo-Namen (alle ~44)
+    reg.repo("risk-hub") # zusammengeführter Datensatz (flat+rich+meta) für EIN Repo
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+CANON = ROOT / "registry" / "canonical.yaml"
+
+
+def load_canonical() -> dict:
+    """Lädt die kanonische Union-Registry."""
+    return yaml.safe_load(CANON.read_text())
+
+
+def gen_flat(canon: dict) -> dict:
+    """Projiziert die flache View (scripts/repo-registry.yaml-Form)."""
+    out = {"server": canon["meta"].get("server", {}), "repos": {}}
+    for n, e in canon["repos"].items():
+        if e.get("in_flat"):
+            out["repos"][n] = e["flat"]
+    return out
+
+
+def gen_rich(canon: dict) -> dict:
+    """Projiziert die reiche View (registry/repos.yaml-Form, domains[])."""
+    order = canon["meta"].get("domain_order", [])
+    by_dom: dict[str, list] = {d: [] for d in order}
+    for n, e in canon["repos"].items():
+        if e.get("in_rich"):
+            by_dom.setdefault(e.get("domain"), []).append(e["rich"])
+    return {"domains": [{"name": d, "systems": by_dom[d]} for d in by_dom if by_dom[d]]}
+
+
+# ── Convenience-Accessoren für neuen Code ──────────────────────────────────────
+
+def flat() -> dict:
+    return gen_flat(load_canonical())
+
+
+def rich() -> dict:
+    return gen_rich(load_canonical())
+
+
+def repos() -> list[str]:
+    """Alle Repo-Namen der Union (sortiert)."""
+    return sorted(load_canonical()["repos"])
+
+
+def repo(name: str) -> dict | None:
+    """Zusammengeführter Datensatz für EIN Repo (flat+rich+meta) — None wenn unbekannt."""
+    e = load_canonical()["repos"].get(name)
+    if e is None:
+        return None
+    merged = {**(e.get("flat") or {}), **(e.get("rich") or {})}
+    merged.update(domain=e.get("domain"), in_flat=e.get("in_flat", False), in_rich=e.get("in_rich", False))
+    return merged


### PR DESCRIPTION
## Was
Schließt **ADR-234 P0** ab — nach dem evidenzbasierten Befund, dass die Konsumenten-Migration **kosmetisch** wäre.

## Befund (warum keine Migration der 18 Konsumenten)
**Kein** Konsument liest beide Registries (8 nur flach, 10 nur reich). Eine Umstellung auf canonicals verschachteltes Schema wäre **netto-negative Komplexität** ohne funktionalen Gewinn. → **Entscheidung: generierte Views = legitimer, divergenzsicherer End-Zustand** (Read-API). Bestehende Konsumenten bleiben unverändert; **kein View-Retire nötig**.

## Geliefert (additiv, nicht-brechend)
- **`tools/registry_api.py`** — importierbarer Accessor für **neuen** Code: `flat()` / `rich()` / `repos()` / `repo(name)` (liest canonical). Getestet: 44 repos, flat=42, rich=7 domains, `repo('risk-hub')` merged, unbekannt→None.
- **CLI refaktoriert:** `gen_flat`/`gen_rich` leben jetzt in `registry_api`; `registry-canonical.py` (build/flip/verify + Drift-Gate) **importiert** sie → **eine** Projektion-Implementierung, kein Divergenz-Risiko. `verify` weiter grün (getestet).
- ADR-234 Changelog: P0 effektiv abgeschlossen, Dual-SSoT aufgelöst.

## Ergebnis
P0-Kernproblem (zwei „SSoT"-Registries, die divergieren können) ist **gelöst**: eine kanonische Quelle, zwei gate-erzwungene Views, Accessor für neuen Code. Kein Architektur-Risiko offen.

Relates: ADR-234 (P0), KONZ-platform-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
