### PR TITLE
feat(deploy): ADR-021 §2.17 — fail-loud on missing prod compose (v1-spine)

### DIFF
--- a/.github/workflows/_deploy-unified.yml
+++ b/.github/workflows/_deploy-unified.yml
@@ -246,6 +246,21 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # ADR-021 §2.17 (Verified Deploy-Bundle Contract) — fail-loud, no silent
+      # fallback. A prod deploy REQUIRES docker-compose.prod.yml in the repo; if
+      # it is absent we must NOT proceed against whatever (possibly stale) compose
+      # sits on the host. That silent fallback is how a repo-removed service kept
+      # running on prod (the Discord-Bot crash-loop, 2026-06). The migration sweep
+      # is complete — every prod-deploying repo has docker-compose.prod.yml — so
+      # this gate fails only genuine misconfigurations.
+      - name: Assert prod compose present (ADR-021 §2.17 fail-loud)
+        run: |
+          if [ ! -f docker-compose.prod.yml ]; then
+            echo "::error title=ADR-021 §2.17::docker-compose.prod.yml is required for a production deploy but is absent. Refusing to deploy against the host's existing (possibly stale) compose. Add docker-compose.prod.yml to the repo."
+            exit 1
+          fi
+          echo "✅ docker-compose.prod.yml present — sync will run."
+
       # Sync production compose file from the consuming repo to the host.
       # Self-hosted runners run on the prod server itself — direct cp works.
       # Without this step deploy.sh works against a stale compose file


### PR DESCRIPTION
First implementation step of the **Verified Deploy-Bundle Contract** (ADR-021 amendment §2.17, accepted #388 / concept #387).

## What
In `_deploy-unified.yml` (the shared prod deploy for ~23 repos): add a fail-loud guard in the `deploy-production` job — a prod deploy now **hard-fails if `docker-compose.prod.yml` is absent**, instead of the previous silent `hashFiles(...)` skip that let `deploy.sh` run against the host's stale compose.

## Why
That silent fallback is the exact root cause of the incident: a repo-removed service (discord-bot) kept crash-looping on prod for weeks because mcp-hub had no `docker-compose.prod.yml` → sync skipped → stale host compose still defined it.

## Safe to flip now (gate satisfied)
Migration-sweep audit (this session): **every** prod-deploying repo already has `docker-compose.prod.yml` (mcp-hub was the last gap, closed by #83). The 3 repos without it (`platform`, `platform-pinned`, `platform-workflows`) are not deployed services. So this gate fails only genuine misconfigurations, not any current valid repo. Prod-only; staging path unchanged.

## Scope / not-merging-blind
This changes the **shared prod pipeline for all repos** → opened as PR for review, **not** auto-merged (a parallel session is actively on mcp-hub deploys). Merge = the governance act.

## v1-spine sequence (this is step 1 of the shared-pipeline work)
- ✅ mcp-hub `docker-compose.prod.yml` (#83, parallel session)
- 👉 **this PR**: fail-loud (§2.17)
- next (separate, tested PRs): atomic sync + host `compose_sha` verify (§2.17), ownership labels (§2.18), prod `COMPOSE_PROJECT_NAME` pin (§2.19 — needs care, can strand containers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)