### PR TITLE
feat(adr-233): 3 Skills worktree-safe (#392)

### DIFF
--- a/.windsurf/workflows/hotfix.md
+++ b/.windsurf/workflows/hotfix.md
@@ -65,12 +65,17 @@ Zeigt die letzten Commits — verdächtigen Commit identifizieren.
 // turbo
 ```bash
 set -euo pipefail
-git checkout main
-git pull --rebase origin main
-git checkout -b hotfix/$(date +%Y%m%d)-BESCHREIBUNG
+# ADR-233: KEIN Branch-Switch im geteilten Haupt-Tree — eigener Worktree von origin/main.
+REPO=$(git rev-parse --show-toplevel)
+git -C "$REPO" fetch origin main -q
+BR="hotfix/$(date +%Y%m%d)-BESCHREIBUNG"
+WT="/tmp/$(basename "$REPO")-${BR//\//-}"
+git -C "$REPO" worktree add "$WT" -b "$BR" origin/main
+cd "$WT"
 ```
 
-Beispiel: `hotfix/20260226-books-500-error`
+Beispiel: `hotfix/20260226-books-500-error` · Worktree nach Merge per
+`tools/worktree-reaper.py` aufräumen (squash-aware, Dirty-Guard).
 
 ---
 

--- a/.windsurf/workflows/issues-abarbeiten.md
+++ b/.windsurf/workflows/issues-abarbeiten.md
@@ -41,9 +41,10 @@
    neu anlegen**.
 2. **Scope-Lock (ADR-081):** nur was die Aktion/das Issue benennt.
    Nebenbefunde → Folge-Issue, nicht mitfixen.
-3. **Branch-Hygiene:** Änderungen nie auf `main`; Branch off
-   `origin/main`; bei dirty/fremdem lokalen Checkout **git worktree**
-   statt `git checkout`.
+3. **Branch-Hygiene (ADR-233):** Änderungen nie auf `main`; **kein
+   `git switch`/`checkout` im geteilten Haupt-Tree** — editieren im eigenen
+   Worktree via `tools/repo-session.sh start <repo> --task <slug>` (Branch von
+   `origin/main` + Lease). Read-only-Analyse darf im Haupt-Tree bleiben.
 
 ## Phase 3: Stopp-Gates (HART — fragen, nicht handeln)
 

--- a/.windsurf/workflows/ship.md
+++ b/.windsurf/workflows/ship.md
@@ -247,7 +247,7 @@ Dann Health Check wiederholen. User über Rollback informieren.
 | Container crasht | `container_logs container_id={web_container} lines=80` |
 | Migration fehlt | `container_exec container_id={web_container} command="python manage.py migrate --noinput"` |
 | Image nicht aktuell | CI-Log prüfen: `run_logs owner=achimdehnert repo={scope} run_id=<id>` |
-| Branch falsch | `git checkout main && git pull origin main` |
+| Branch falsch | im Ziel-Repo-Checkout `git pull origin main`; NICHT den geteilten Haupt-Tree switchen (ADR-233) |
 
 **Wichtig:** Bei JEDEM Fehler in diesem Workflow ein `error_pattern` Memory-Entry via `mcp1_agent_memory` schreiben (siehe Schritt 6).
 Beim nächsten `/session-start` findet `mcp1_agent_memory(operation: "query", filter_type: "error_pattern")` wiederkehrende Probleme.


### PR DESCRIPTION
Closes #392. hotfix nutzt jetzt `git worktree` von origin/main statt Switch im geteilten Haupt-Tree; issues-abarbeiten + ship präzisiert. **Guard-Aktivierung bleibt separat gegated** (nach Beobachtung `main-tree-guard.sh report==0`). Merge-Gate: /workflow-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)