### PR TITLE
feat(deploy): ADR-021 §2.17 atomic sync + compose_sha verify + §2.20 intent-token

### DIFF
--- a/.github/workflows/_deploy-unified.yml
+++ b/.github/workflows/_deploy-unified.yml
@@ -246,42 +246,68 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # ADR-021 §2.17 (Verified Deploy-Bundle Contract) — fail-loud, no silent
-      # fallback. A prod deploy REQUIRES docker-compose.prod.yml in the repo; if
-      # it is absent we must NOT proceed against whatever (possibly stale) compose
-      # sits on the host. That silent fallback is how a repo-removed service kept
-      # running on prod (the Discord-Bot crash-loop, 2026-06). The migration sweep
-      # is complete — every prod-deploying repo has docker-compose.prod.yml — so
-      # this gate fails only genuine misconfigurations.
-      - name: Assert prod compose present (ADR-021 §2.17 fail-loud)
-        run: |
-          if [ ! -f docker-compose.prod.yml ]; then
-            echo "::error title=ADR-021 §2.17::docker-compose.prod.yml is required for a production deploy but is absent. Refusing to deploy against the host's existing (possibly stale) compose. Add docker-compose.prod.yml to the repo."
-            exit 1
-          fi
-          echo "✅ docker-compose.prod.yml present — sync will run."
-
-      # Sync production compose file from the consuming repo to the host.
-      # Self-hosted runners run on the prod server itself — direct cp works.
-      # Without this step deploy.sh works against a stale compose file
-      # (e.g. wrong image path after a path-refactor in the repo).
-      - name: Sync docker-compose.prod.yml to app path (self-hosted)
-        if: ${{ !startsWith(inputs.runs_on, 'ubuntu') && hashFiles('docker-compose.prod.yml') != '' }}
+      # ADR-021 §2.17 — fail-loud + atomic sync + compose_sha verify.
+      # ADR-021 §2.20 — deploy-intent manifest (Intent-Token).
+      #
+      # 1. Assert docker-compose.prod.yml present (fail-loud — no silent fallback).
+      # 2. Compute SHA-256 of the compose file.
+      # 3. Write .deploy-manifest.json: commit + run_id + compose_sha + timestamp.
+      #    deploy.sh reads this manifest as the CI Intent-Token (§2.20) and verifies
+      #    the on-host sha256 matches before running `docker compose up` (§2.17).
+      # 4. Atomic sync: copy compose to temp path, verify sha, rename atomically.
+      - name: Assert compose + write manifest + atomic sync (ADR-021 §2.17/§2.20)
+        id: compose_sync
         run: |
           set -euo pipefail
-          cp docker-compose.prod.yml "${{ inputs.app_path }}/docker-compose.prod.yml"
-          echo "✅ Compose file synced to ${{ inputs.app_path }}/docker-compose.prod.yml"
 
-      - name: Sync docker-compose.prod.yml to host (remote runner)
-        if: startsWith(inputs.runs_on, 'ubuntu') && hashFiles('docker-compose.prod.yml') != ''
+          # §2.17 fail-loud
+          if [ ! -f docker-compose.prod.yml ]; then
+            echo "::error title=ADR-021 §2.17::docker-compose.prod.yml absent — refusing to deploy against stale host compose."
+            exit 1
+          fi
+
+          # compute sha256
+          COMPOSE_SHA=$(sha256sum docker-compose.prod.yml | awk '{print $1}')
+          echo "compose_sha=${COMPOSE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "✅ compose sha256: ${COMPOSE_SHA}"
+
+          # write intent manifest (§2.20)
+          cat > .deploy-manifest.json <<JSON
+          {
+            "app":         "${{ inputs.app_name }}",
+            "commit":      "${{ github.sha }}",
+            "run_id":      "${{ github.run_id }}",
+            "compose_sha": "${COMPOSE_SHA}",
+            "written_at":  "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          JSON
+
+          # atomic sync — self-hosted runner runs ON the prod server
+          if [ "${{ inputs.runs_on }}" != "ubuntu-latest" ]; then
+            TMP="${{ inputs.app_path }}/docker-compose.prod.yml.tmp$$"
+            cp docker-compose.prod.yml "$TMP"
+            # verify copy is intact before rename
+            COPY_SHA=$(sha256sum "$TMP" | awk '{print $1}')
+            if [ "$COPY_SHA" != "$COMPOSE_SHA" ]; then
+              rm -f "$TMP"
+              echo "::error::sha256 mismatch after copy (corrupt transfer)"
+              exit 1
+            fi
+            mv -f "$TMP" "${{ inputs.app_path }}/docker-compose.prod.yml"
+            cp .deploy-manifest.json "${{ inputs.app_path }}/.deploy-manifest.json"
+            echo "✅ atomic sync complete (self-hosted)"
+          fi
+
+      - name: Sync compose + manifest to host (remote runner)
+        if: startsWith(inputs.runs_on, 'ubuntu')
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           fingerprint: ${{ secrets.DEPLOY_SSH_FINGERPRINT }}
-          source: "docker-compose.prod.yml"
-          target: "${{ inputs.app_path }}/docker-compose.prod.yml"
+          source: "docker-compose.prod.yml,.deploy-manifest.json"
+          target: "${{ inputs.app_path }}/"
           overwrite: true
 
       - name: Deploy to production (direct — self-hosted runner)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,8 +2,9 @@
 # /opt/scripts/deploy.sh — iil-Platform Unified Deploy Script (ADR-120, ADR-166)
 # Auf PROD (88.198.191.108) und DEV/Staging (88.99.38.75) installieren
 #
-# Usage: deploy.sh <APP_NAME> <APP_PATH> <IMAGE_TAG> <ENVIRONMENT> [HEALTH_CHECK_URL]
+# Usage: deploy.sh <APP_NAME> <APP_PATH> <IMAGE_TAG> <ENVIRONMENT> [HEALTH_CHECK_URL] [--break-glass "REASON"]
 # Example: deploy.sh risk-hub /opt/risk-hub v1.4.2 production https://schutztat.de/livez/
+# Manual:  deploy.sh risk-hub /opt/risk-hub latest production "" --break-glass "hotfix: rollback nginx config"
 set -euo pipefail
 
 APP_NAME="${1:?'APP_NAME fehlt'}"
@@ -11,6 +12,19 @@ APP_PATH="${2:?'APP_PATH fehlt'}"
 IMAGE_TAG="${3:?'IMAGE_TAG fehlt'}"
 ENVIRONMENT="${4:?'ENVIRONMENT fehlt (staging|production)'}"
 HEALTH_CHECK_URL="${5:-}"
+
+# ADR-021 §2.20 — Intent-Token / break-glass flag
+BREAK_GLASS_REASON=""
+for _i in "${@:6}"; do
+  if [[ "$_i" == "--break-glass" ]]; then
+    _next=false
+    for _j in "${@:6}"; do
+      [[ "$_next" == "true" ]] && { BREAK_GLASS_REASON="$_j"; break; }
+      [[ "$_j" == "--break-glass" ]] && _next=true
+    done
+    break
+  fi
+done
 
 # ADR-160: log to file only if writable — never break deploy for logging
 LOG_DIR="/var/log/iil-deploys"
@@ -93,6 +107,7 @@ rollback() {
     echo "❌ Deploy fehlgeschlagen (exit $ec) — Rollback auf $PREVIOUS_TAG"
     cd "$APP_PATH"
     export IMAGE_TAG="$PREVIOUS_TAG"
+    export _ROLLBACK_MODE=1  # bypass manifest/sha check during rollback
     docker compose -f "$COMPOSE_FILE" "${LABEL_ARGS[@]}" up -d --force-recreate 2>&1 || {
       echo "KRITISCH: Rollback fehlgeschlagen! Manuell: IMAGE_TAG=$PREVIOUS_TAG docker compose -f $COMPOSE_FILE up -d" >&2
       exit 10
@@ -125,6 +140,39 @@ fi
 
 # Deploy
 cd "$APP_PATH"
+
+# ADR-021 §2.17 + §2.20 — manifest verify + intent-token check (prod only).
+# Rollbacks bypass the check so a failing deploy can always be rolled back.
+_ROLLBACK_MODE="${_ROLLBACK_MODE:-0}"
+if [[ "$ENVIRONMENT" == "production" && "$_ROLLBACK_MODE" != "1" ]]; then
+  _MANIFEST="$APP_PATH/.deploy-manifest.json"
+
+  # §2.20 Intent-Token: CI must have written a manifest; manual deploys require --break-glass.
+  if [[ ! -f "$_MANIFEST" ]]; then
+    if [[ -n "$BREAK_GLASS_REASON" ]]; then
+      _BG_LOG="/var/log/iil-deploys/break-glass.log"
+      mkdir -p "$(dirname "$_BG_LOG")" 2>/dev/null || true
+      printf '%s [break-glass] app=%s image=%s reason="%s"\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$APP_NAME" "$IMAGE_TAG" "$BREAK_GLASS_REASON" \
+        >> "$_BG_LOG" 2>/dev/null || true
+      echo "⚠️  break-glass: proceeding without manifest. Reason: $BREAK_GLASS_REASON"
+    else
+      echo "::error::ADR-021 §2.20: No .deploy-manifest.json found. Production deploys require a CI-issued intent manifest. For manual deploys use: --break-glass \"REASON\""
+      exit 6
+    fi
+  else
+    # §2.17 compose_sha verify — fail-closed if on-host compose was tampered with.
+    _EXPECTED_SHA=$(python3 -c "import json; d=json.load(open('$_MANIFEST')); print(d.get('compose_sha',''))" 2>/dev/null || true)
+    if [[ -n "$_EXPECTED_SHA" && -f "$APP_PATH/$COMPOSE_FILE" ]]; then
+      _ACTUAL_SHA=$(sha256sum "$APP_PATH/$COMPOSE_FILE" | awk '{print $1}')
+      if [[ "$_ACTUAL_SHA" != "$_EXPECTED_SHA" ]]; then
+        echo "::error::ADR-021 §2.17: compose sha256 mismatch. expected=$_EXPECTED_SHA actual=$_ACTUAL_SHA. Host compose may have been modified after CI sync. Aborting (fail-closed)."
+        exit 7
+      fi
+      echo "✅ compose sha256 verified: $_ACTUAL_SHA"
+    fi
+  fi
+fi
 
 # Staging: vor dem Hochfahren den Altstack sauber abräumen.
 # `up -d --remove-orphans` entfernt nur Orphans DESSELBEN Compose-Projekts;


### PR DESCRIPTION
v1-spine step 4 (after #391 §2.17 fail-loud, #395 §2.18 labels, #398 §2.19 project-name). Completes the structural part of the Verified Deploy-Bundle Contract.

## §2.17 — atomic sync + compose_sha verify
**Workflow (`_deploy-unified.yml`):**
- Computes SHA-256 of `docker-compose.prod.yml` at CI time
- Writes `.deploy-manifest.json` (`app`, `commit`, `run_id`, `compose_sha`, `written_at`)
- Self-hosted: `cp → temp → sha256-verify copy → mv` (atomic rename, no partial overwrite)
- Remote runner: scp both `docker-compose.prod.yml` + `.deploy-manifest.json`

**`deploy.sh`:**
- Reads `compose_sha` from manifest, compares with `sha256sum` of on-host file before `docker compose up` → **fail-closed** (exit 7) on mismatch (catches post-sync tampering or corrupt transfer)

## §2.20 — deploy-intent manifest (Intent-Token)
**`deploy.sh` (prod only):**
- `.deploy-manifest.json` = CI intent token. Absent + no flag → **exit 6**
- Manual deploy without manifest: `--break-glass "REASON"` — logs to `/var/log/iil-deploys/break-glass.log`, proceeds
- **Rollback bypasses check** (`_ROLLBACK_MODE=1`) so a failing deploy can always be rolled back

## Safety
- `bash -n` clean, YAML valid
- Rollback is never blocked (explicit bypass)
- Remote-runner path (scp) still works as before — only adds the manifest file alongside
- Shared prod pipeline → **PR for review, not auto-merged**

🤖 Generated with [Claude Code](https://claude.com/claude-code)