### PR TITLE
infra(orchestrator): nginx-Config für orchestrator.iil.pet als IaC spiegeln

### DIFF
--- a/infra/orchestrator-host/README.md
+++ b/infra/orchestrator-host/README.md
@@ -1,0 +1,39 @@
+# orchestrator.iil.pet — Prod-nginx (IaC-Spiegel)
+
+SoR für die Reverse-Proxy-Config von `orchestrator.iil.pet` (MCP/Orchestrator,
+`mcp-hub`). Bisher war diese Config **nur host-lokal** auf `88.198.191.108`
+(hetzner-prod) und damit unsichtbar/driftanfällig — dieser Spiegel schließt das.
+
+## Topologie
+Cloudflare-Tunnel (catch-all, s. `../cloudflared-tunnels.yaml`) → nginx auf
+`88.198.191.108` (`server_name orchestrator.iil.pet`) → Container
+`mcp_hub_orchestrator_http` auf `127.0.0.1:8000`.
+
+## ⚠️ Pfad-Whitelist (Drift-Lehre 2026-06-01)
+nginx leitet **nur die explizit deklarierten `location`-Pfade** an `:8000`. Eine
+neue App-Route (`mcp-hub` `orchestrator_mcp/server.py`) ohne passenden
+`location`-Block ⇒ **nginx-eigener 404**, der Request erreicht den Container nie.
+
+Symptom-Falsifikation (billig, ohne SSH): 404-**Body** prüfen —
+App-404 = JSON (`{"ok":false,...}`), nginx-404 = HTML mit `<hr><center>nginx</center>`.
+
+Konkreter Vorfall: `/api/discovery/klickdummy/upsert` (platform:ADR-215) +
+`/readyz`/`/livez` fehlten in der Whitelist → 404, fälschlich auf Image/Build-Cache
+geschoben (mehrere Deploy-Zyklen verloren). Fix = `location /api/`, `= /readyz`,
+`= /livez` ergänzt (am 2026-06-01 live).
+
+## Apply auf dem Host
+```bash
+scp orchestrator.iil.pet.conf hetzner-prod:/tmp/
+ssh hetzner-prod '
+  sudo cp /etc/nginx/sites-available/orchestrator.iilpet.conf \
+          /etc/nginx/sites-available/orchestrator.iilpet.conf.bak-$(date +%F)
+  sudo cp /tmp/orchestrator.iil.pet.conf /etc/nginx/sites-available/orchestrator.iilpet.conf
+  sudo nginx -t && sudo systemctl reload nginx'
+```
+
+## Checkliste „neue Orchestrator-Route geht live"
+1. Route in `mcp-hub` `orchestrator_mcp/server.py` (`app = Starlette(routes=[...])`).
+2. **Hier** einen `location`-Block ergänzen (sonst nginx-404).
+3. `orchestrator.iil.pet.conf` auf den Host applyen (s.o.).
+4. Verifizieren: `curl -i https://orchestrator.iil.pet/<route>` — App-Antwort, kein nginx-404.

--- a/infra/orchestrator-host/orchestrator.iil.pet.conf
+++ b/infra/orchestrator-host/orchestrator.iil.pet.conf
@@ -1,0 +1,123 @@
+# SoR (IaC-Spiegel) der Prod-nginx-Config für orchestrator.iil.pet.
+# Host: 88.198.191.108 (hetzner-prod) · Live-Pfad:
+#   /etc/nginx/sites-available/orchestrator.iilpet.conf
+#   (enabled via Symlink sites-enabled/orchestrator.iilpet.conf)
+# Cloudflare-Tunnel (catch-all) → dieser nginx (server_name) → Container :8000.
+#
+# WICHTIG — Pfad-Whitelist (Drift-Lehre 2026-06-01):
+#   nginx leitet NUR die hier deklarierten location-Pfade an :8000 weiter.
+#   Eine NEUE App-Route (z.B. /api/..., /readyz) OHNE location-Block ⇒ nginx
+#   gibt seinen EIGENEN 404, der Request erreicht den Container nie. Das kostete
+#   am 2026-06-01 mehrere Deploy-Zyklen (fälschlich auf Image/Cache geschoben).
+#   ⇒ Neue Route in der App = hier einen location-Block ergänzen.
+#
+# Apply auf dem Host:
+#   sudo cp orchestrator.iil.pet.conf /etc/nginx/sites-available/orchestrator.iilpet.conf
+#   sudo nginx -t && sudo systemctl reload nginx
+
+server {
+    listen 443 ssl http2;
+    server_name orchestrator.iil.pet;
+
+    # Cloudflare Origin Certificate (iil.pet wildcard)
+    ssl_certificate /etc/nginx/ssl/cf-origin/iil-pet.crt;
+    ssl_certificate_key /etc/nginx/ssl/cf-origin/iil-pet.key;
+
+    # SSL Hardening (ADR-056)
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+
+    # SSE Timeout Settings (ADR-194)
+    proxy_read_timeout 3600s;
+    proxy_send_timeout 3600s;
+
+    # Health Check
+    location /health {
+        proxy_pass http://127.0.0.1:8000/health;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # SSE Endpoint
+    location /sse {
+        proxy_pass http://127.0.0.1:8000/sse;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # SSE requires no buffering
+        proxy_buffering off;
+        proxy_cache off;
+        chunked_transfer_encoding on;
+    }
+
+    # Messages endpoint (SSE transport)
+    location /messages {
+        proxy_pass http://127.0.0.1:8000/messages;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_buffering off;
+        proxy_cache off;
+        chunked_transfer_encoding on;
+    }
+
+    # REST tool dispatch (PR mcp-hub#31 — Bearer-auth'd, headless_run timeouts to 15min)
+    location /run {
+        proxy_pass http://127.0.0.1:8000/run;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        client_max_body_size 1m;
+        proxy_read_timeout 900s;
+        proxy_send_timeout 900s;
+    }
+
+    # REST API (Klickdummy-Discovery, platform:ADR-215 — Bearer-auth'd Upsert + List).
+    # proxy_pass OHNE URI → volle Request-URI bleibt erhalten (/api/discovery/...).
+    location /api/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        client_max_body_size 5m;
+    }
+
+    # Readiness/Liveness (DB-Probe bzw. Prozess-Probe) — für Monitoring/Health.
+    location = /readyz {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /livez {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Kontext
Beim Live-Schalten des ADR-215-Discovery-Endpoints (`POST /api/discovery/klickdummy/upsert`) zeigte sich: der Prod-nginx für `orchestrator.iil.pet` hat eine **Pfad-Whitelist** und leitet nur explizit deklarierte `location`-Pfade an `:8000`. `/api/`, `/readyz`, `/livez` fehlten → **nginx-eigener 404**, der Request erreichte den Container nie. Das wurde mehrere Deploy-Zyklen lang fälschlich auf das Image / den gha-Build-Cache geschoben.

Die Config lag bislang **nur host-lokal** (88.198.191.108) — unsichtbar und driftanfällig.

## Inhalt
- `infra/orchestrator-host/orchestrator.iil.pet.conf` — IaC-Spiegel der **jetzt live** geschalteten Config (inkl. ergänzter `location /api/`, `= /readyz`, `= /livez`).
- `infra/orchestrator-host/README.md` — Topologie, Whitelist-Drift-Lehre (404-Body-Falsifikation: App-JSON vs. nginx-HTML), Apply-Recipe, Checkliste „neue Route → location-Block".

Reiner Doku-/IaC-Spiegel; keine Wirkung auf laufende Systeme. Host-Apply bleibt bewusster manueller Schritt (im README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)