### PR TITLE
fix(ci): tolerate legacy aifw distribution in freshness probe (install-iil-packages)

### DIFF
--- a/.github/actions/install-iil-packages/action.yml
+++ b/.github/actions/install-iil-packages/action.yml
@@ -112,7 +112,18 @@ runs:
             print("::warning::aifw present but a dependency is missing (%s) — freshness probe skipped (platform#413)" % e.name)
             sys.exit(0)
         from packaging.version import Version
-        meta = M.version('iil-aifw')
+        # The action installs EITHER the PyPI dist `iil-aifw` OR, as a fallback,
+        # the legacy dist `aifw` (see --no-deps block above). The module is `aifw`
+        # in both cases, but the *distribution* name differs — so resolve metadata
+        # tolerantly. If neither resolves, the staleness gate can't run → advisory.
+        try:
+            meta = M.version('iil-aifw')
+        except M.PackageNotFoundError:
+            try:
+                meta = M.version('aifw')  # legacy distribution name
+            except M.PackageNotFoundError:
+                print("::warning::aifw module present but no iil-aifw/aifw distribution metadata — freshness probe skipped (platform#416)")
+                sys.exit(0)
         print('iil-aifw metadata=%s code=%s @ %s' % (meta, getattr(aifw, '__version__', '?'), aifw.__file__))
         _m = [s for s in ('get_action_config', 'QualityLevel', 'AIFWError') if not hasattr(aifw, s)]
         if Version(meta) >= Version('0.10') and _m:


### PR DESCRIPTION
Closes #416. Follow-up to #414.

Probe resolved `M.version('iil-aifw')`, but the action installs **either** `iil-aifw` (PyPI) **or** the legacy `aifw` dist (fallback). Where only legacy `aifw` lands, the module imports fine but `M.version('iil-aifw')` raised `PackageNotFoundError` → hard fail (exposed once #414 fixed the litellm crash that masked it; learn-hub #9 Unit Tests run 26839789324).

Now: try `iil-aifw` → fall back to `aifw` → if neither resolves, skip the staleness gate with an advisory. **Symbol-staleness gate semantics unchanged.**

Local: YAML parses, probe Python compiles. Unblocks learn-hub #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)