### PR TITLE
docs(adr): ADR-236 Amendment — GOV in Enterprise (central-gov) + S1 ausgeführt

### DIFF
--- a/docs/adr/ADR-236-altd-enterprise-boundary.md
+++ b/docs/adr/ADR-236-altd-enterprise-boundary.md
@@ -1,6 +1,9 @@
 ---
 status: accepted
-implementation_status: none
+implementation_status: partial
+implementation_evidence:
+  - "S1 ausgeführt 2026-06-03 (live verifiziert via Enterprise-PAT): Enterprise iilgmbh hat 4 Member-Orgs (bahn-sqf, iilgmbh, meiki-lra, ttz-lif); Seats 2/2 (kostenneutral bestätigt)."
+  - "Amendment 2026-06-03: GOV-Orgs ttz-lif/meiki-lra BEWUSST in die Enterprise aufgenommen (Träger-Sign-off deckt volle Mitgliedschaft, owner-attestiert) → exit_class central-gov (governance/exit-classes.yaml)."
 date: 2026-06-03
 decision-makers: Achim Dehnert
 domains: [governance, security, secrets, ci-cd]
@@ -46,7 +49,7 @@ Wir adoptieren **ALT-D** als Org-Topologie-Boundary:
 
 1. **Konsolidieren** (`central-ok`): die Org `iilgmbh` in die Enterprise `iilgmbh` aufnehmen. `pactive-de` ebenfalls `central-ok`, aber **nur mit Zustimmung der Dritt-Owner** (kein einseitiger Move — `achimdehnert` ist dort nur `member`).
 2. **Security-Config scharfstellen** (KONZ REC-2): eine **schlanke Config** (nur Secret Scanning + Push Protection) als **apply-to-all** — vermeidet CodeQL-Blast-Radius auf Nicht-Code-Repos (B3); **Config 17** (volle Suite) nur als **Default-for-new** + Opt-in. Beides erst `unenforced` beobachten → dann `enforced`.
-3. **Government-Orgs `ttz-lif`/`meiki-lra` bleiben standalone** (`must-stay-local`) mit **gespiegelter Security-Posture** + CI-Gleichheits-Audit; **nicht** in die Enterprise aufgenommen. *Präzisierung ggü. KONZ §8-ALT-D* (dort „per-Org Secret Protection/ALT-B" = gekaufte Lizenz): hier **Config-Spiegelung statt Lizenzkauf** — mit der von **REC-9** belegten Grenze: native Push-Protection/Secret-Scanning wirkt auf **privaten** GOV-Repos nur mit eigener GHAS-/Secret-Protection-Entitlement der GOV-Org; auf öffentlichen Repos nativ gratis. Wo das Entitlement fehlt, bleibt CI-gitleaks (ADR-235) dort Layer 1.
+3. **Government-Orgs `ttz-lif`/`meiki-lra`** — **Amendment 2026-06-03:** ~~bleiben standalone~~ → **bewusst in die Enterprise aufgenommen** (`exit_class: central-gov`). Möglich geworden durch einen **formalen Träger-Souveränitäts-Sign-off, der volle Enterprise-Mitgliedschaft deckt** (owner-attestiert, DR-B). Damit erben sie die Enterprise-Security-Posture direkt (kein Mirror/CI-Gleichheits-Audit mehr nötig). **Bedingung:** sie müssen rückgabefähig bleiben (Exit = Übergabe an Träger) → keine nicht-exportierbaren Kopplungen (`central-gov`-`forbidden_features`); Souveränität ruht jetzt als **Single Point** auf Scope + Bestand des Sign-offs. *Damit verschiebt sich die Topologie-Wahl faktisch von ALT-D (GOV standalone) zu **ALT-C (Voll-Konsolidierung), dessen Souveränitäts-Blocker der Sign-off aufhebt** — siehe §3.*
 4. **Reversal von ADR-235 für org-/enterprise-eigene Repos:** dort wird native Push-Protection (auch privat, via Enterprise-Config) **Layer 1**; CI-gitleaks → **Defense-in-depth**. Die ADR-235-Aufteilung **bleibt** für `achimdehnert`-User-Account-Repos bestehen, bis diese migriert/ausgetrocknet sind (Done-Kriterium = KONZ D1 „User-Account-Done").
 5. **`exit_class` als abgeleitete Policy-SSoT** (OOTB-8) — **noch zu erstellen, Vorbedingung für S1:** die SSoT existiert heute *nicht* (weder `scripts/repo-registry.yaml` noch `tools/exit-plan.py` tragen sie). Anzulegen als deklarative Datei (Vorschlag `governance/exit-classes.yaml`), Schema `org → {exit_class, placement, allowed_features, required_checks, exit_tests, teardown_authority}`. Heutige Tags: `iilgmbh`,`pactive-de` = `central-ok`; **`bahn-sqf` = `exit-likely`**; `ttz-lif`,`meiki-lra` = `must-stay-local`. `teardown_authority: none` ist für `exit-likely`/`must-stay-local` unzulässig. **Kein S1/S2/S3- und kein Placement-Gate ist ausführbar, bevor diese Datei existiert.**
 6. **Portabilität by construction:** Exit-Readiness ist abgeleitet/getestet/getaggt (`make exit-plan`, Exit-Feuerübung), kein gepflegtes Dokument.
@@ -60,7 +63,9 @@ Wir adoptieren **ALT-D** als Org-Topologie-Boundary:
 | **ALT-A** (Status quo) | Keine Moves; Config 17 nur auf `bahn-sqf`, ADR-235 CI-gitleaks überall sonst | private Org-/User-Repos bleiben ohne native Prävention; 4 Team-Pläne bleiben. (= Fallback/Kill-Gate-Ziel) |
 | **ALT-B** (per-Org Secret Protection) | Jede Org kauft „Secret Protection" (Team) einzeln | teurer pro Org; keine zentrale Kontrollebene; löst Souveränität nicht sauber |
 | **ALT-C** (Voll-Konsolidierung) | **Alle** Orgs inkl. Government in die Enterprise | **Souveränitätsbruch** — Behörden-Org unter zentrales Ownership ist Compliance-Risiko |
-| **ALT-D** (Hybrid) ✅ | Nicht-Government konsolidieren; Government standalone + gespiegelt | **gewählt** — trennt Souveränitätsrisiko sauber ab, nutzt Kostenneutralität |
+| **ALT-D** (Hybrid) | Nicht-Government konsolidieren; Government standalone + gespiegelt | ursprünglich gewählt; **2026-06-03 überholt** (s.u.) |
+
+> **Amendment 2026-06-03:** Der **ALT-C-Ablehnungsgrund („Souveränitätsbruch")** ist durch den **formalen Träger-Sign-off** entfallen — die verantwortliche Trägerorganisation hat der vollen Enterprise-Mitgliedschaft schriftlich zugestimmt (owner-attestiert). Die realisierte Topologie ist damit **ALT-C mit Sign-off**: alle eigenen Orgs (inkl. `ttz-lif`/`meiki-lra` = `central-gov`) in der Enterprise; nur `pactive-de` (Fremd-Eigentum) bleibt außen. **Trade-off der Verschiebung:** die Souveränität ist nicht mehr *strukturell* (Standalone-Trennung) abgesichert, sondern *vertraglich* (Sign-off) — ein Single Point, dessen Scope/Bestand zu überwachen ist (§6).
 
 ## 4. Begründung im Detail
 
@@ -91,7 +96,7 @@ Org-Ops = Web-UI/SCIM (Owner führt aus); CC pflegt Plan/Audit. Regel: **reversi
 
 | Risiko | Mitigation |
 |---|---|
-| **Souveränitätsbruch** (B4) | ALT-D — GOV standalone + gespiegelt; Ownership-/Transfer-Schritte hart gesperrt bis **schriftlicher** Träger-Sign-off |
+| **Souveränitätsbruch** (B4) | **Amendment 2026-06-03:** GOV nun *in* der Enterprise (`central-gov`), abgesichert durch **formalen Träger-Sign-off** (owner-attestiert) statt Standalone-Trennung. **Neues Rest-Risiko:** Souveränität ist jetzt *Single Point* am Sign-off — zu überwachen sind dessen **Scope** (deckt volle Mitgliedschaft) und **Bestand** (Widerruf → Rückgabepflicht). Mitigation: `central-gov` verbietet nicht-exportierbare Kopplungen (rückgabefähig); **GOV-Exit-Feuerübung (Handover-Readiness) steht aus** → offener Punkt. |
 | **Einbahn-Exit / Kontrollverlust** beim Transfer in Fremd-Org (REC-8) | `teardown_authority`-Pflichtfeld; Transfer nur in admin-kontrollierte Ziele |
 | **Config-Drift** auf gespiegelten GOV-Orgs | CI-Gleichheits-Audit (deklarativer Soll/Ist-Vergleich) |
 | **Kosten** — €-Sätze extern unbestätigt | DR-A-Restlücke: Account-Team-Mail **vor** Team-Plan-Kündigung |
@@ -152,3 +157,4 @@ Fehlt eine Bedingung → keine Org-Aufnahme; Sunset auf ALT-A. **Nach Fristablau
 - 2026-06-03: Initial (Proposed) — ALT-D Boundary aus KONZ-002; Umsetzung gegated (Kill-Gate a/b/c). Amends ADR-235 (Reversal für org/enterprise-Repos).
 - 2026-06-03: **Amendment nach adversarialem 3-Linsen-Review** (Steelman/Diabolus/Maintainer-2028): §8c Gate (c) ehrlich gemacht (Reversibilität *falsifiziert*, nicht „bewiesen"); §2.5 `exit_class`-SSoT als nicht-existente Vorbedingung mit Pfad/Schema + `bahn-sqf`=exit-likely; §2.2 schlanke PP+Scan-Config für apply-to-all (Config 17 nur Default-for-new, KONZ REC-2); §2.3 ALT-D-Mechanik-Drift offengelegt (Config-Spiegel statt Lizenzkauf) + REC-9-Grenze; §4 Kosten „Mengen verifiziert, Preismodell offen" + Committer-Mechanik + Asymmetrie-Pull-Argument; §6 KONZ-D2 „Mirror ≠ Compliance" + GOV-Gate verschärft; §7.2 REC-9-Lock-in-Trade-off; §5 „admin"=Org-Rolle (REC-8) + S1-setzt-ADR-accepted-voraus; Mengen/Owner durch Live-Check-Befehle entschärft.
 - 2026-06-03: **Accepted.** Kill-Gate a/b/c erfüllt — (a) schriftliche Kostenbestätigung + (b) formaler Träger-Sign-off owner-attestiert (in Privatunterlagen; *attestiert ≠ repo-verifiziert*), (c) bewiesen (D1). GOV-Hard-Lock aufgehoben; `exit_class`-SSoT angelegt (PR #432). Boundary entschieden; Ausführung S1–S4 phasenweise gegated (Runbook), `implementation_status: none` bis S1.
+- 2026-06-03: **Amendment + S1 ausgeführt.** (1) **S1 live verifiziert** (Enterprise-PAT): Enterprise hat 4 Member-Orgs, Seats 2/2 → `implementation_status: partial`. (2) **GOV bewusst in die Enterprise** (`ttz-lif`/`meiki-lra` → `central-gov`): der Träger-Sign-off deckt **volle Mitgliedschaft**. Topologie faktisch **ALT-C mit Sign-off** statt ALT-D; §2.3/§3/§6 + `governance/exit-classes.yaml` entsprechend geändert. Neues Rest-Risiko: Souveränität = Single Point am Sign-off; **GOV-Exit-Feuerübung steht aus**.

--- a/docs/runbooks/KONZ-002-consolidation-rollout.md
+++ b/docs/runbooks/KONZ-002-consolidation-rollout.md
@@ -2,7 +2,8 @@
 
 > Operativer Ausführungsplan zu **[KONZ-platform-002](../konzepte/KONZ-platform-002-enterprise-consolidation.md)** (Richtung **ALT-D**).
 > Governance-Bezug: **[ADR-235](../adr/ADR-235-org-secret-prevention-posture.md)** (Secret-Prevention-Posture).
-> Stand: 2026-06-03 · Owner: Achim Dehnert · **Rollout vom Owner freigegeben** (für reversible/eigene Phasen).
+> Stand: 2026-06-03 · Owner: Achim Dehnert · **Rollout freigegeben**.
+> **Update 2026-06-03:** **S1 ausgeführt** (live verifiziert: Enterprise hat 4 Member-Orgs, Seats 2/2). **GOV bewusst mit aufgenommen** — `ttz-lif`/`meiki-lra` sind jetzt `central-gov` *in* der Enterprise (Träger-Sign-off deckt volle Mitgliedschaft), nicht mehr standalone. Topologie faktisch **ALT-C mit Sign-off**. Details: ADR-236-Amendment.
 
 ## Grundprinzip
 
@@ -39,7 +40,7 @@ die gegateten UI-Schritte führt der **Owner** je Phase aus. Jede Phase hat ein
 
 ### DR-B — GOV-Datensouveränität (Kill-Gate b)
 - **Datum:** 2026-06-03 · **Protokolliert von:** Achim Dehnert
-- **Inhalt:** **Formaler Datensouveränitäts-Sign-off der Trägerorganisation(en)** für **GOV-A** (`ttz-lif`) und **GOV-B** (`meiki-lra`). Identität der Träger **anonymisiert** (Projektkonvention GOV-A/GOV-B).
+- **Inhalt:** **Formaler Datensouveränitäts-Sign-off der Trägerorganisation(en)** für **GOV-A** (`ttz-lif`) und **GOV-B** (`meiki-lra`). Identität der Träger **anonymisiert** (Projektkonvention GOV-A/GOV-B). **Update 2026-06-03:** der Sign-off deckt **volle Enterprise-Mitgliedschaft** (nicht nur standalone) → GOV-Orgs in die Enterprise aufgenommen (`central-gov`).
 - **Natur (Update 2026-06-03):** **Schriftlicher Träger-Sign-off** liegt vor (nicht mehr nur mündlich), vom Owner **attestiert**, abgelegt in dessen Privatunterlagen.
 - **Wirkung:** Kill-Kriterium (b) **erfüllt**. Die **GOV-Hard-Lock ist aufgehoben** — sowohl Ownership-Fragen als auch eine zentral betriebene Audit-/Eingriffsrolle auf GOV-Orgs sind durch den Sign-off gedeckt. (Unter ALT-D bleiben GOV-Orgs ohnehin standalone; es findet kein Ownership-/Datentransfer statt.)
 - **Restlücke (benannt):** Beleg liegt **nicht im Repo** → *attestiert, nicht repo-verifiziert*. **Billigster Check:** (anonymisierte) Kopie nach `~/shared/` legen oder bei Audit nachreichen.
@@ -51,11 +52,11 @@ die gegateten UI-Schritte führt der **Owner** je Phase aus. Jede Phase hat ein
 
 | Phase | Inhalt | Gate (Vorbedingung) | Executor | Akzeptanz | Rollback |
 |---|---|---|---|---|---|
-| **S1** | **Nur `iilgmbh`-Org** in Enterprise `iilgmbh` aufnehmen (`central-ok`) | DR-A vorhanden | Owner (Web-UI/SCIM) | Org erscheint unter `enterprises/iilgmbh/organizations`; Member-Count unverändert; Seats weiterhin 2 | Org wieder entkoppeln (reversibel, keine Daten betroffen) |
+| **S1** ✅ | `iilgmbh` (+ GOV `ttz-lif`/`meiki-lra`, s. Update) in Enterprise aufnehmen | DR-A + DR-B vorhanden | Owner (Web-UI/SCIM) | **erfüllt 2026-06-03:** 4 Member-Orgs live verifiziert; Seats 2/2 | Org wieder entkoppeln (reversibel) |
 | **S2** | Config 17 als Enterprise-**Default** setzen → erst `unenforced` beobachten → dann `enforced` | S1 grün; FP-Rate + blockierte Pushes + Coverage ausgewertet | Owner/CC (API `repo`-Scope) | `code-security/configurations/.../defaults` gesetzt; Drift-Audit grün; FP-Rate akzeptabel | zurück auf `unenforced`; Default entfernen |
 | **S3** | Wertvolle private `achimdehnert`-Repos in Enterprise-Org migrieren (Wellen — Detail-Checkliste: [`KONZ-002-s3-repo-transfer.md`](./KONZ-002-s3-repo-transfer.md)) | S2 `enforced`; **Ziel admin-kontrolliert** (REC-8); Push-Protection am Ziel aktiv (REC-9) | Owner (Transfer-UI) | je Welle: Repo unter Enterprise-Org, Push-Protection aktiv, CI grün | Repo zurücktransferieren (gleiche Welle, Ziel = Quelle) |
 | **S4** | User-Account `achimdehnert` austrocknen (Deploy-Keys/Webhooks/Package-Owner/Secrets/Integrationen) | S3-Welle verifiziert | Owner | keine prod-kritischen Artefakte mehr am User-Account | — (irreversibel → deshalb zuletzt, nur nach S3-Verifikation) |
-| **GOV** | `ttz-lif`/`meiki-lra` **standalone + gespiegelte Config** (must-stay-local) | DR-B Sign-off ✅ vorhanden | Owner/CC (admin auf GOV-Orgs) | Security-Posture gespiegelt; CI-Gleichheits-Audit grün | Config zurücknehmen (reversibel) |
+| **GOV** ✅ | `ttz-lif`/`meiki-lra` **in Enterprise** (`central-gov`) — geändert: nicht mehr standalone, Sign-off deckt volle Mitgliedschaft | DR-B Sign-off ✅ (volle Mitgliedschaft) | Owner (Web-UI) | **erfüllt 2026-06-03:** beide Member-Orgs; erben Enterprise-Posture | aus Enterprise entkoppeln + an Träger rückgeben (Handover) |
 | **`pactive-de`** | Konsolidierung | ⛔ **Owner-Zustimmung Dritter** (DasRed/ghry5/philipp-eicher/ratpic83) | gesperrt | — | — |
 
 ### Harte Sperren

--- a/governance/exit-classes.yaml
+++ b/governance/exit-classes.yaml
@@ -58,6 +58,21 @@ classes:
     exit_tests: [exit-plan-runbook, handover-readiness]
     teardown_authority_rule: not-none    # none UNZULÄSSIG (ADR-236 §2.5)
 
+  central-gov:
+    description: >
+      Government-/Souveränitäts-Workload, der **in die Enterprise** aufgenommen ist
+      (ADR-236-Amendment 2026-06-03). Zulässig NUR mit formalem Träger-Souveränitäts-
+      Sign-off, der **volle Enterprise-Mitgliedschaft** deckt (owner-attestiert).
+      Muss rückgabefähig bleiben (Exit = Übergabe an Träger) → keine nicht-
+      exportierbaren Kopplungen; Sign-off-Scope + -Bestand sind die Single-Point-
+      Souveränitätsabhängigkeit.
+    placement: in-enterprise
+    allowed_features: [secret-scanning, push-protection]
+    forbidden_features: [emu, sso, enterprise-only-apps, non-exportable-secret, unreviewed-app-coupling]
+    required_checks: [secret-scanning, push-protection, sovereignty-signoff]
+    exit_tests: [exit-plan-runbook, handover-readiness]
+    teardown_authority_rule: not-none    # none UNZULÄSSIG — muss an Träger rückgabefähig sein
+
 # ---------------------------------------------------------------------------
 # Org → Klasse (Stand 2026-06-03)
 # teardown_authority ∈ {self-owner | contractual-clause | none}
@@ -84,22 +99,22 @@ orgs:
       - "teardown_authority=none ist hier toleriert (central-ok hat keinen Exit-Anspruch), markiert aber Fremd-Eigentum: kein einseitiger Move/Teardown möglich."
 
   ttz-lif:
-    exit_class: must-stay-local
-    owner: achimdehnert            # role=admin (verifiziert 2026-06-03)
+    exit_class: central-gov        # geändert 2026-06-03: in Enterprise aufgenommen (Träger-Sign-off deckt volle Mitgliedschaft)
+    owner: achimdehnert            # role=admin (verifiziert 2026-06-03); Enterprise-Member (S1 live verifiziert)
     teardown_authority: self-owner
     review_by: 2026-09-15
-    rationale: Government/öffentlicher Sektor (GOV-A) — Souveränität → standalone + gespiegelt.
+    rationale: Government (GOV-A) — bewusst in die Enterprise (ADR-236-Amendment); Souveränität via formalem Träger-Sign-off statt Standalone-Trennung.
     deviations:
-      - "Realer Exit = Behörden-Übergabe an die Trägerorganisation → erfordert contractual-clause (Handover-/Rückgabe-Klausel); self-owner deckt nur den heutigen Betrieb. DR-B-Restrisiko."
+      - "Souveränität ruht allein auf dem Träger-Sign-off (owner-attestiert, nicht repo-verifiziert). Fällt er weg → Rückgabe an Träger nötig → Handover-/Rückgabe-Klausel (contractual-clause) wird kritisch; GOV-Exit-Feuerübung steht aus."
 
   meiki-lra:
-    exit_class: must-stay-local
-    owner: achimdehnert            # role=admin (verifiziert 2026-06-03)
+    exit_class: central-gov        # geändert 2026-06-03: in Enterprise aufgenommen (Träger-Sign-off deckt volle Mitgliedschaft)
+    owner: achimdehnert            # role=admin (verifiziert 2026-06-03); Enterprise-Member (S1 live verifiziert)
     teardown_authority: self-owner
     review_by: 2026-09-15
-    rationale: LRA/Bürgerdaten (GOV-B) — Souveränität → standalone + gespiegelt.
+    rationale: LRA/Bürgerdaten (GOV-B) — bewusst in die Enterprise (ADR-236-Amendment); Souveränität via formalem Träger-Sign-off.
     deviations:
-      - "Wie ttz-lif: realer Exit = Träger-Übergabe → contractual-clause nötig. DR-B-Restrisiko."
+      - "Wie ttz-lif: Souveränität Single-Point am Sign-off; GOV-Exit-Feuerübung (Handover-Readiness) steht aus."
 
   bahn-sqf:
     exit_class: exit-likely


### PR DESCRIPTION
## Was
**S1 ausgeführt** (live verifiziert via Enterprise-PAT): Enterprise `iilgmbh` hat **4 Member-Orgs** (`bahn-sqf`, `iilgmbh`, `meiki-lra`, `ttz-lif`), Seats **2/2** → `implementation_status: partial`.

**Bewusste Entscheidung:** GOV-Orgs `ttz-lif`/`meiki-lra` wurden **in die Enterprise** aufgenommen — der **formale Träger-Sign-off deckt volle Mitgliedschaft** (owner-attestiert). Damit ist die Topologie faktisch **ALT-C mit Sign-off** statt ALT-D.

## Änderungen
- **`governance/exit-classes.yaml`:** neue Klasse **`central-gov`** (in-enterprise, rückgabefähig, `teardown_authority` not-none, `required_check: sovereignty-signoff`); `ttz-lif`/`meiki-lra` `must-stay-local → central-gov`. Invariante grün.
- **ADR-236** §2.3/§3/§6 + Changelog: Verschiebung ALT-D→ALT-C-mit-Sign-off dokumentiert (nicht still). ALT-C-Blocker „Souveränitätsbruch" durch Sign-off aufgehoben.
- **Runbook:** S1 + GOV als erfüllt; DR-B deckt volle Mitgliedschaft.

## Neues Rest-Risiko (ehrlich benannt)
Souveränität ist nun **kein struktureller** Schutz (Standalone) mehr, sondern **vertraglich** — ein **Single Point** am Sign-off (Scope + Bestand überwachen). **GOV-Exit-Feuerübung (Handover-Readiness) steht aus.** Sign-off ist owner-attestiert, *nicht repo-verifiziert*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)