### PR TITLE
feat(tools): OOTB-5 ref-sweep (dry-run) + Design-Runbook

### DIFF
--- a/docs/runbooks/KONZ-002-ootb5-ref-sweep.md
+++ b/docs/runbooks/KONZ-002-ootb5-ref-sweep.md
@@ -1,0 +1,40 @@
+# Runbook — KONZ-002 OOTB-5: Coupling-Indirektion (Ref-Sweep)
+
+> Baustein zu **[KONZ-platform-002](../konzepte/KONZ-platform-002-enterprise-consolidation.md)** OOTB-5; entsperrt **S3 Welle 3** (Prod-`-hub`-Migration).
+> Werkzeug: [`tools/ref-sweep.py`](../../tools/ref-sweep.py). Stand: 2026-06-04.
+
+## Analyse
+
+Sorge des Konzepts: verstreute, eigentümer-gebundene `uses: achimdehnert/...@ref`-Referenzen brechen beim Org-/Account-Wechsel (~14 geschätzt). **Reliable-Discovery** (Workflow-Inhalte direkt gelesen — `gh search code` lieferte falsch **0**, indiziert private Repos unzuverlässig):
+
+**Befund: keine verstreute Kopplung, sondern EINE Quelle.** Alle Refs zeigen auf **`achimdehnert/platform`** — 4 geteilte Bausteine:
+`_ci-python.yml`, `_deploy-unified.yml`, `_build-docker.yml` (reusable workflows) + `actions/gitleaks-scan` (composite action), dazu diverse `publish-*`/`_ci-pypi`.
+
+**Umfang (2026-06-04, vollständig): 52 Refs in 30 Repos** — alle `-hub`-Apps (privat+public), die 5 bereits migrierten iilgmbh-Repos, **und `platform` selbst** (Self-Refs in seinen eigenen Workflows).
+
+## Werkzeug `tools/ref-sweep.py`
+
+- **Dry-Run (default, read-only):** findet alle `uses: <old>/...@ref` und listet Repo/Datei/Anzahl.
+- **`--apply`:** öffnet **eine PR pro Consumer**, ersetzt `<old>/…` → `<new>/…` (Pfad+`@ref` bleiben). Idempotent.
+- Args: `--old achimdehnert/platform --new iilgmbh/platform --owners achimdehnert,iilgmbh`.
+- **Bug-Lehre (gefangen):** eigene **private** Repos via `user/repos?affiliation=owner` listen — `users/<name>/repos` liefert nur public (führte zu Unterzählung 10 statt 30). Code-Search ebenfalls unzuverlässig → Contents-API ist die Wahrheit.
+
+## Strategie (löst OOTB-5 ohne generischen Alias)
+
+1. **Reihenfolge:** Consumer **zuerst** migrieren (ihre Refs auf `achimdehnert/platform` bleiben gültig, solange platform dort liegt). **`platform` als LETZTES.**
+2. **Beim platform-Move:** `ref-sweep.py --apply` über alle Consumer **und** platform-Self-Refs → `iilgmbh/platform`. Ein koordinierter Pass.
+3. **Transfer-Redirect = Brücke:** GitHub leitet `achimdehnert/platform` → `iilgmbh/platform` um; deckt das Sweep-Fenster ab. **Vor Verlass darauf verifizieren, dass `uses:` dem Redirect folgt** (sonst Sweep unmittelbar nach Move, kurzer roter Fenster-Moment einplanen).
+4. Danach: alles unter `iilgmbh` → Bruchstelle existiert dauerhaft nicht mehr.
+
+## Reihenfolge im Gesamt-Rollout
+- S3 Welle 1/2 (isoliert + publiziert): ✅ erledigt — deren Self-Workflows referenzieren weiter `achimdehnert/platform` (gültig).
+- **S3 Welle 3 (Prod-Hubs):** kann jetzt laufen — Refs bleiben gültig bis zum platform-Move.
+- **Letzter Schritt:** `platform` migrieren + `ref-sweep.py --apply`.
+
+## Gates / Leitplanken
+- `--apply` = **scharf** (öffnet ~30 PRs, berührt platform + alle Consumer = max. Blast-Radius) → **separater, ausdrücklich freigegebener** Schritt, gekoppelt an den platform-Move.
+- Dry-Run + Review der PR-Liste **vor** `--apply`.
+- Redirect-Annahme **verifizieren**, nicht annehmen.
+
+## Changelog
+- 2026-06-04: Initial — Single-Source-Befund (52 Refs/30 Repos → `platform`), Tool `ref-sweep.py` (dry-run + --apply), Sweep-Strategie + Reihenfolge.

--- a/tools/ref-sweep.py
+++ b/tools/ref-sweep.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""ref-sweep — repoint hardcoded GitHub Actions refs across consumer repos.
+
+KONZ-platform-002 OOTB-5. The discovery (2026-06-04) showed the org's shared-CI
+coupling is NOT scattered: every `uses:` ref points at ONE source repo
+(`achimdehnert/platform/...`). When that source moves (S3 platform migration),
+each consumer's `uses: <old>/...@ref` must be repointed to `<new>/...`.
+
+This tool finds those refs across consumer repos and, with --apply, opens ONE PR
+per consumer that rewrites them. **Read-only by default (dry-run).** Idempotent:
+a repo already on `<new>` produces no change.
+
+It deliberately rewrites only `uses:` references whose path starts with the
+`--old` `owner/repo` prefix (e.g. `achimdehnert/platform/`), preserving the rest
+of the path and the `@ref`. Nothing else is touched.
+
+Usage:
+  GH_TOKEN=... tools/ref-sweep.py \
+      [--old achimdehnert/platform] [--new iilgmbh/platform] \
+      [--owners achimdehnert,iilgmbh] [--apply]
+
+Needs the `gh` CLI authenticated (GH_TOKEN env or `gh auth login`).
+Dry-run needs read access; --apply needs `repo` scope on the consumers.
+"""
+from __future__ import annotations
+import argparse
+import base64
+import json
+import subprocess
+import sys
+
+
+def gh(*args: str):
+    """Run gh; return (stdout, stderr). Never raises."""
+    r = subprocess.run(["gh", *args], capture_output=True, text=True)
+    return (r.stdout, None) if r.returncode == 0 else (None, r.stderr or "error")
+
+
+def gh_json(path: str, method: str = "GET", fields: dict | None = None):
+    args = ["api", "-X", method, path]
+    for k, v in (fields or {}).items():
+        args += ["-f", f"{k}={v}"]
+    out, err = gh(*args)
+    if out is None:
+        return None, err
+    try:
+        return json.loads(out), None
+    except Exception:
+        return out, None  # raw (e.g. file content via raw accept handled separately)
+
+
+def raw_file(full: str, path: str) -> str | None:
+    out, _ = gh("api", f"repos/{full}/contents/{path}",
+                "-H", "Accept: application/vnd.github.raw")
+    return out
+
+
+def whoami() -> str | None:
+    out, _ = gh("api", "user", "--jq", ".login")
+    return out.strip() if out else None
+
+
+def list_repos(owner: str, me: str | None) -> list[str]:
+    """All repos for an owner (paginated). For the AUTHENTICATED user, use
+    `user/repos` so PRIVATE own-repos are included — `users/<name>/repos`
+    returns only PUBLIC ones (the bug that undercounted consumers)."""
+    if me and owner == me:
+        ep = "user/repos?affiliation=owner&per_page=100"
+    else:
+        ep = f"orgs/{owner}/repos?per_page=100"
+    out, _ = gh("api", "--paginate", ep, "--jq", ".[].full_name")
+    if out is None:
+        return []
+    return [ln.strip() for ln in out.splitlines() if ln.strip()]
+
+
+def find_refs(text: str, old_prefix: str) -> bool:
+    return f"{old_prefix}/" in text
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="OOTB-5 ref-sweep (KONZ-002).")
+    ap.add_argument("--old", default="achimdehnert/platform",
+                    help="old owner/repo prefix of the shared source")
+    ap.add_argument("--new", default="iilgmbh/platform",
+                    help="new owner/repo prefix to repoint to")
+    ap.add_argument("--owners", default="achimdehnert,iilgmbh",
+                    help="comma-separated owners whose repos to scan (consumers)")
+    ap.add_argument("--apply", action="store_true",
+                    help="open one PR per consumer with the rewrite (default: dry-run)")
+    args = ap.parse_args()
+
+    old, new = args.old, args.new
+    if old == new:
+        print("::error:: --old and --new are identical", file=sys.stderr)
+        return 2
+
+    owners = [o.strip() for o in args.owners.split(",") if o.strip()]
+    me = whoami()
+    repos = sorted({r for o in owners for r in list_repos(o, me)})
+    if not repos:
+        print("::error:: no repos readable (token/scope?) — refusing to report 'clean'", file=sys.stderr)
+        return 1
+
+    print(f"# ref-sweep (OOTB-5): `{old}/…` → `{new}/…`")
+    print(f"# scanning {len(repos)} repos across owners: {', '.join(owners)}")
+    print(f"# mode: {'APPLY (opens PRs)' if args.apply else 'DRY-RUN (read-only)'}\n")
+
+    plan: list[tuple[str, str, int]] = []  # (repo, file, hit_count)
+    gaps: list[str] = []
+
+    for full in repos:
+        wf, _ = gh_json(f"repos/{full}/contents/.github/workflows")
+        if not isinstance(wf, list):
+            continue  # no workflows dir
+        for f in wf:
+            path = f.get("path")
+            if not path or not path.endswith((".yml", ".yaml")):
+                continue
+            body = raw_file(full, path)
+            if body is None:
+                gaps.append(f"{full}:{path} unreadable")
+                continue
+            if find_refs(body, old):
+                hits = body.count(f"{old}/")
+                plan.append((full, path, hits))
+                print(f"- {full} :: {path} ({hits} ref{'s' if hits != 1 else ''})")
+
+    print(f"\n# {len(plan)} file(s) in {len({p[0] for p in plan})} repo(s) reference `{old}/`")
+    if gaps:
+        print(f"# ⚠️ {len(gaps)} unreadable file(s) — NOT 'clean': {', '.join(gaps[:5])}"
+              + (" …" if len(gaps) > 5 else ""))
+
+    if not args.apply:
+        print("\n# dry-run only — re-run with --apply to open PRs.")
+        return 0
+
+    # ---- APPLY: one PR per repo ----
+    branch = "chore/ootb5-ref-sweep"
+    changed_repos = sorted({p[0] for p in plan})
+    for full in changed_repos:
+        files = [p[1] for p in plan if p[0] == full]
+        base, _ = gh_json(f"repos/{full}")
+        default_branch = (base or {}).get("default_branch", "main")
+        head, _ = gh_json(f"repos/{full}/git/ref/heads/{default_branch}")
+        sha = (head or {}).get("object", {}).get("sha")
+        if not sha:
+            print(f"  ⚠️ {full}: cannot resolve {default_branch} head — skipped")
+            continue
+        gh("api", "-X", "POST", f"repos/{full}/git/refs",
+           "-f", f"ref=refs/heads/{branch}", "-f", f"sha={sha}")
+        for path in files:
+            body = raw_file(full, path)
+            if body is None or f"{old}/" not in body:
+                continue
+            new_body = body.replace(f"{old}/", f"{new}/")
+            meta, _ = gh_json(f"repos/{full}/contents/{path}?ref={branch}")
+            fsha = (meta or {}).get("sha")
+            b64 = base64.b64encode(new_body.encode()).decode()
+            gh("api", "-X", "PUT", f"repos/{full}/contents/{path}",
+               "-f", f"message=chore(ci): OOTB-5 repoint {old} -> {new}",
+               "-f", f"content={b64}", "-f", f"sha={fsha or ''}", "-f", f"branch={branch}")
+        out, err = gh("api", "-X", "POST", f"repos/{full}/pulls",
+                      "-f", f"title=chore(ci): OOTB-5 repoint {old} → {new}",
+                      "-f", f"head={branch}", "-f", f"base={default_branch}",
+                      "-f", f"body=Automated OOTB-5 ref-sweep (KONZ-002): repoint shared-CI refs from `{old}/` to `{new}/` after the source repo moved. See docs/runbooks/KONZ-002-ootb5-ref-sweep.md.")
+        print(f"  {'PR opened' if out else 'PR FAILED: ' + (err or '')[:80]} — {full}")
+
+    print(f"\n# applied to {len(changed_repos)} repo(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Was (P4-„jetzt", nichts wird bewegt)
Baustein **OOTB-5** zu KONZ-002 — entsperrt S3 Welle 3 (Prod-Hub-Migration).

### Discovery (grounded)
`gh search code` log **falsch 0** (private-Index unzuverlässig) → Workflow-Inhalte direkt gelesen. Befund: die Kopplung ist **keine verstreute Indirektion, sondern EINE Quelle** = `achimdehnert/platform`. Vollständig: **52 Refs in 30 Repos** (alle `-hub`-Apps privat+public, 5 migrierte iilgmbh-Repos, **+ platform-Self-Refs**).

### Werkzeug `tools/ref-sweep.py`
- **Dry-Run (default, read-only):** listet alle `uses: <old>/...@ref`.
- **`--apply`:** 1 PR/Consumer, repoint `<old>/` → `<new>/`. Idempotent.
- **Bug gefangen+gefixt:** eigene private Repos via `user/repos` (nicht `users/<name>/repos` = nur public → unterzählte 10 statt 30).

### Strategie (kein generischer Alias nötig)
Consumer zuerst migrieren, **`platform` zuletzt**; beim platform-Move `ref-sweep --apply` + Transfer-Redirect als Brücke (Redirect-Annahme **verifizieren**, nicht annehmen).

## Gates
`--apply` ist **scharf** (~30 PRs, berührt platform + alle Consumer) → separater, freigegebener Schritt, gekoppelt an den platform-Move. Dieser PR liefert nur Tool (dry-run getestet) + Design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)