### PR TITLE
feat(ci): opt-in import-smoke gate — block deploy of non-startable images

### DIFF
--- a/.github/workflows/_deploy-unified.yml
+++ b/.github/workflows/_deploy-unified.yml
@@ -44,6 +44,18 @@ on:
         required: false
         type: string
         default: "Dockerfile"
+      import_smoke:
+        description: >-
+          Shell-Kommando, das NACH dem Build IM frisch gebauten Image läuft, BEVOR
+          deployt wird. Non-zero exit lässt den build-Job scheitern → alle Deploys
+          (needs: build) werden geskippt → ein nicht-startbares Image erreicht Prod
+          nie. Fängt Import-Contract-Drift (ModuleNotFoundError/ImportError), die
+          erst zur Laufzeit zuschlägt (z.B. nach Paket-Restructure).
+          Leer (default) = Gate aus, Verhalten unverändert.
+          Django-Beispiel: "SECRET_KEY=ci-smoke DJANGO_SETTINGS_MODULE=config.settings.test python manage.py check"
+        required: false
+        type: string
+        default: ""
       notify_discord:
         description: "Discord Deploy-Notification senden"
         required: false
@@ -172,6 +184,23 @@ jobs:
             APP_VERSION=${{ needs.resolve.outputs.image_tag }}
           secrets: |
             PROJECT_PAT=${{ secrets.PROJECT_PAT }}
+
+      # Gate: ein nicht-startbares Image darf nicht deployt werden. Läuft das
+      # consumer-definierte import_smoke-Kommando IM frisch gebauten Image; bei
+      # non-zero exit fällt dieser build-Job → deploy-* (needs: build) skippen.
+      # Fängt Import-Contract-Drift (ModuleNotFoundError/ImportError), die sonst
+      # erst Wochen später als Prod-Crash-Loop sichtbar wird. Opt-in (leer = aus).
+      - name: Import smoke (gate deploy on a runnable image)
+        if: ${{ inputs.import_smoke != '' }}
+        env:
+          SMOKE_CMD: ${{ inputs.import_smoke }}
+        run: |
+          IMG="ghcr.io/${{ env.IMAGE_NAME }}:${{ needs.resolve.outputs.image_tag }}"
+          echo "::group::Import smoke on $IMG"
+          echo "cmd: $SMOKE_CMD"
+          docker pull "$IMG"
+          docker run --rm "$IMG" sh -c "$SMOKE_CMD"
+          echo "::endgroup::"
 
   # ── JOB 3a: Deploy to Staging ─────────────────────────────────────────────
   deploy-staging:


### PR DESCRIPTION
## Problem (Klasse, nicht Einzelfall)
Vier Prod-Crash-Loops dieser Session hatten *eine* Wurzel — **Import-Contract-Drift**: Consumer-Code importiert Symbole/Pfade, die ein (neueres) geteiltes Paket zur Laufzeit nicht mehr liefert:
- `platform_context.HealthBypassMiddleware` (entfernt) → trading_hub_web
- `mcp_core` (archiviert) → llm_gateway
- `nl2cad_core` → restrukturiert zu `nl2cad.core` → cad_hub_worker
- iil-learnfw-Routen (Consumer-Test war voraus) → learn-hub

Jedes Mal: **grüner Build, kaputtes Image gepusht+deployed, Crash-Loop Wochen später** — weil der Import erst zur *Laufzeit* bricht, nicht beim `docker build`.

## Fix (OOTB: Fehler vom Prod nach Build-Zeit verschieben)
Neuer opt-in-Input `import_smoke`: ein Kommando, das **im frisch gebauten Image, vor dem Deploy** läuft (im `build`-Job, nach Push). Non-zero exit → build-Job fällt → `deploy-staging`/`deploy-prod` (`needs: build`) **skippen** → ein nicht-startbares Image erreicht Prod nie.

```yaml
# Consumer (z.B. cad-hub deploy.yml):
uses: achimdehnert/platform/.github/workflows/_deploy-unified.yml@main
with:
  import_smoke: "SECRET_KEY=ci-smoke DJANGO_SETTINGS_MODULE=config.settings.test python manage.py check"
```

- **Default `''` = aus** → null Verhaltensänderung für Nicht-Adopter (sicherer Rollout).
- Fängt die *ganze Klasse* (alle 4 obigen Fälle hätte `manage.py check` im Image gefangen).

Validiert: YAML-Parse, Input-default `''`, Step guarded by `if: import_smoke != ''`.

**Rollout:** nach Merge Consumer schrittweise opt-in (cad/mcp/trading/learn zuerst — die gerade gebissen haben).

🤖 Generated with [Claude Code](https://claude.com/claude-code)