### PR TITLE
feat(tools): OOTB-A — ref-sweep gehärtet + Shared-CI-Extraktions-Runbook

### DIFF
--- a/docs/runbooks/KONZ-002-ootb-a-shared-ci.md
+++ b/docs/runbooks/KONZ-002-ootb-a-shared-ci.md
@@ -1,0 +1,44 @@
+# Runbook — OOTB-A: Shared-CI aus `platform` herauslösen (Tag-gepinnt)
+
+> Optimierung aus dem adversarialen Review (2026-06-04). Löst den `platform`-SPOF
+> **und** das OOTB-5-Cutover-Problem **by construction**. Werkzeug: [`tools/ref-sweep.py`](../../tools/ref-sweep.py) (gehärtet).
+
+## Problem (Review-Befund)
+
+Die gesamte CI von ~30 Repos hängt an **einem** Repo `achimdehnert/platform`, referenziert per **`uses: …@main`**. Zwei reale Risiken:
+1. **Supply-Chain / SPOF:** ein Push auf `platform/main` deployt sofort, ungereviewt, in alle 30 Consumer-CIs (inkl. Deploy-/Publish-Workflows mit Secrets/OIDC). `@main` = keine stabile Version, kein Review-Gate.
+2. **Harter Cutover:** `uses:` folgt dem Transfer-Redirect **nicht** ([ootb5-Runbook](./KONZ-002-ootb5-ref-sweep.md)) → ein `platform`-Move bräche alle 30 Consumer gleichzeitig.
+
+## Lösung
+
+Die geteilten Bausteine in ein **eigenes, langlebiges, NIE migriertes** Repo `iilgmbh/shared-ci` ziehen, Consumer auf **Tag** statt `@main` pinnen, Dependabot hält sie aktuell.
+
+- 6 reusable Workflows: `_ci-python`, `_ci-pypi`, `_deploy-unified`, `_deploy-hetzner`, `_build-docker`, `_ci-odoo`
+- 3 composite actions: `gitleaks-scan`, `install-iil-packages`, `resolve-install-extra`
+
+**Warum besser:** Tag-Pinning = stabile Version + Supply-Chain-Schutz (Updates = reviewbare Dependabot-PRs). `shared-ci` wird nie transferiert → `platform` (und jedes andere Repo) kann frei umziehen, **kein** `uses:`-Bruch mehr. Eigene CODEOWNERS/Recovery-Owner → entkoppelt vom Bus-Faktor des Mono-`platform`.
+
+## Schritte
+
+| # | Schritt | Reversibel? | Gate |
+|---|---|---|---|
+| **B1** | Repo `iilgmbh/shared-ci` anlegen (in Enterprise → erbt Posture) | additiv (archivierbar) | — |
+| **B2** | Die 6 Workflows + 3 Actions hineinkopieren; **interne Self-Refs** (`achimdehnert/platform/...` *innerhalb* der Bausteine) auf `iilgmbh/shared-ci/...` setzen | additiv | B1 |
+| **B3** | `v1.0.0` taggen | additiv | B2; Smoke: 1 Demo-Repo gegen `@v1.0.0` grün |
+| **B4** | **Consumer sweepen:** `ref-sweep.py --old achimdehnert/platform --new iilgmbh/shared-ci --pin v1.0.0` — **erst `--apply --limit 1` (Canary)** → grün → dann voll | PRs reversibel | **scharf** |
+| **B5** | Dependabot `github-actions` in Consumern (hält `@v1`-Pins aktuell) | additiv | nach B4 |
+| **B6** | reusable Workflows aus `platform` entfernen/archivieren (erst wenn ALLE Consumer auf `shared-ci` + grün) | reversibel (re-add) | B4 vollständig grün |
+
+## Werkzeug-Härtung (ref-sweep.py, Review-Fixes)
+- Ersetzt nur echte **`uses:`-Zeilen** (Kommentare/Banner werden übersprungen).
+- **Wortgrenze**: `achimdehnert/platform` matcht nicht `…/platform-tools`.
+- **`--pin v1.0.0`**: repinnt `@main` → `@v1.0.0` (killt das `@main`-Antipattern).
+- **`--limit N`** (Canary) + **Branch-/PR-Idempotenz** (Re-Run dupliziert nicht).
+
+## Gates / Leitplanken
+- **B4 ist der einzige scharfe Schritt** → **Canary (`--limit 1`) zuerst**, verifizieren (Consumer-CI grün gegen `@v1.0.0`), dann voll. Kein Auto-Merge ohne Sicht auf ≥1 grüne Canary-PR.
+- B1–B3 sind additiv (nichts zeigt auf `shared-ci`, bis B4) → null Bruch-Risiko.
+- `platform`-Move ist nach OOTB-A **kein Sonderfall** mehr (siehe ootb5-Runbook: Cutover-Problem entfällt).
+
+## Changelog
+- 2026-06-04: Initial — OOTB-A-Design (shared-ci-Extraktion + Tag-Pinning); ref-sweep.py gehärtet (uses:-Anker, --pin, --limit, Idempotenz).

--- a/tools/ref-sweep.py
+++ b/tools/ref-sweep.py
@@ -1,31 +1,34 @@
 #!/usr/bin/env python3
-"""ref-sweep — repoint hardcoded GitHub Actions refs across consumer repos.
+"""ref-sweep — repoint hardcoded GitHub Actions `uses:` refs across consumer repos.
 
-KONZ-platform-002 OOTB-5. The discovery (2026-06-04) showed the org's shared-CI
-coupling is NOT scattered: every `uses:` ref points at ONE source repo
-(`achimdehnert/platform/...`). When that source moves (S3 platform migration),
-each consumer's `uses: <old>/...@ref` must be repointed to `<new>/...`.
+KONZ-platform-002 OOTB-5 / OOTB-A. The shared-CI coupling points at ONE source
+(`achimdehnert/platform`). To move that source — or extract it into a dedicated
+`iilgmbh/shared-ci` repo (OOTB-A) — every consumer's `uses: <old>/...@ref` must be
+repointed to `<new>/...` (and ideally repinned from `@main` to a tag).
 
-This tool finds those refs across consumer repos and, with --apply, opens ONE PR
-per consumer that rewrites them. **Read-only by default (dry-run).** Idempotent:
-a repo already on `<new>` produces no change.
+Read-only by default (dry-run). `--apply` opens ONE PR per consumer. Idempotent:
+a repo already on `<new>` produces no change; an existing sweep branch/PR is reused
+or skipped, not duplicated.
 
-It deliberately rewrites only `uses:` references whose path starts with the
-`--old` `owner/repo` prefix (e.g. `achimdehnert/platform/`), preserving the rest
-of the path and the `@ref`. Nothing else is touched.
+HARDENED (Review 2026-06-04):
+- Rewrites only real `uses:` references (YAML key), NEVER comments/banners.
+- Word-bounded prefix match (`<old>` only when followed by `/`, `@`, space, quote)
+  → no collision with `<old>-tools` etc.
+- `--pin <tag>` repins the `@ref` (kill the `@main` supply-chain antipattern).
+- `--limit N` = canary (process only the first N affected repos on --apply).
+- Branch-/PR-lifecycle idempotent; per-step errors are surfaced, not swallowed.
 
 Usage:
   GH_TOKEN=... tools/ref-sweep.py \
-      [--old achimdehnert/platform] [--new iilgmbh/platform] \
-      [--owners achimdehnert,iilgmbh] [--apply]
-
-Needs the `gh` CLI authenticated (GH_TOKEN env or `gh auth login`).
-Dry-run needs read access; --apply needs `repo` scope on the consumers.
+      [--old achimdehnert/platform] [--new iilgmbh/shared-ci] [--pin v1.0.0] \
+      [--owners achimdehnert,iilgmbh] [--apply] [--limit N]
+Needs `gh` authenticated. Dry-run needs read; --apply needs `repo` on consumers.
 """
 from __future__ import annotations
 import argparse
 import base64
 import json
+import re
 import subprocess
 import sys
 
@@ -36,22 +39,19 @@ def gh(*args: str):
     return (r.stdout, None) if r.returncode == 0 else (None, r.stderr or "error")
 
 
-def gh_json(path: str, method: str = "GET", fields: dict | None = None):
-    args = ["api", "-X", method, path]
-    for k, v in (fields or {}).items():
-        args += ["-f", f"{k}={v}"]
-    out, err = gh(*args)
+def gh_json(path: str):
+    out, err = gh("api", path)
     if out is None:
         return None, err
     try:
         return json.loads(out), None
     except Exception:
-        return out, None  # raw (e.g. file content via raw accept handled separately)
+        return out, None
 
 
-def raw_file(full: str, path: str) -> str | None:
-    out, _ = gh("api", f"repos/{full}/contents/{path}",
-                "-H", "Accept: application/vnd.github.raw")
+def raw_file(full: str, path: str, ref: str | None = None) -> str | None:
+    p = f"repos/{full}/contents/{path}" + (f"?ref={ref}" if ref else "")
+    out, _ = gh("api", p, "-H", "Accept: application/vnd.github.raw")
     return out
 
 
@@ -61,112 +61,147 @@ def whoami() -> str | None:
 
 
 def list_repos(owner: str, me: str | None) -> list[str]:
-    """All repos for an owner (paginated). For the AUTHENTICATED user, use
-    `user/repos` so PRIVATE own-repos are included — `users/<name>/repos`
-    returns only PUBLIC ones (the bug that undercounted consumers)."""
-    if me and owner == me:
-        ep = "user/repos?affiliation=owner&per_page=100"
-    else:
-        ep = f"orgs/{owner}/repos?per_page=100"
+    """For the AUTHENTICATED user use `user/repos` (includes PRIVATE own-repos);
+    `users/<name>/repos` returns only public (the bug that undercounted)."""
+    ep = ("user/repos?affiliation=owner&per_page=100" if me and owner == me
+          else f"orgs/{owner}/repos?per_page=100")
     out, _ = gh("api", "--paginate", ep, "--jq", ".[].full_name")
-    if out is None:
-        return []
-    return [ln.strip() for ln in out.splitlines() if ln.strip()]
+    return [ln.strip() for ln in out.splitlines() if ln.strip()] if out else []
 
 
-def find_refs(text: str, old_prefix: str) -> bool:
-    return f"{old_prefix}/" in text
+def rewrite_uses(text: str, old: str, new: str, pin: str | None):
+    """Return (new_text, count). Rewrites ONLY real `uses:` lines whose value is
+    `<old>` (word-bounded); skips comment lines/banners. Optionally repins @ref."""
+    out_lines, count = [], 0
+    # value must be <old> followed by a boundary (path '/', '@ref', whitespace, quote, EOL)
+    pat = re.compile(r'(uses:\s*["\']?)(' + re.escape(old) + r')(?=[/@\s"\']|$)(\S*)')
+    for line in text.split("\n"):
+        if line.lstrip().startswith("#") or "uses:" not in line:
+            out_lines.append(line)
+            continue
+        m = pat.search(line)
+        if not m:
+            out_lines.append(line)
+            continue
+        rest = m.group(3)  # e.g. "/.github/workflows/x.yml@main" or "@main" or ""
+        if pin:
+            rest = re.sub(r'@[^\s"\']+$', "", rest) + f"@{pin}"
+        out_lines.append(line.replace(m.group(0), m.group(1) + new + rest, 1))
+        count += 1
+    return "\n".join(out_lines), count
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description="OOTB-5 ref-sweep (KONZ-002).")
-    ap.add_argument("--old", default="achimdehnert/platform",
-                    help="old owner/repo prefix of the shared source")
-    ap.add_argument("--new", default="iilgmbh/platform",
-                    help="new owner/repo prefix to repoint to")
-    ap.add_argument("--owners", default="achimdehnert,iilgmbh",
-                    help="comma-separated owners whose repos to scan (consumers)")
-    ap.add_argument("--apply", action="store_true",
-                    help="open one PR per consumer with the rewrite (default: dry-run)")
+    ap = argparse.ArgumentParser(description="OOTB-5/A ref-sweep (KONZ-002).")
+    ap.add_argument("--old", default="achimdehnert/platform")
+    ap.add_argument("--new", default="iilgmbh/shared-ci")
+    ap.add_argument("--pin", default=None, help="repin @ref to this tag (e.g. v1.0.0); kills @main")
+    ap.add_argument("--owners", default="achimdehnert,iilgmbh")
+    ap.add_argument("--apply", action="store_true", help="open one PR per consumer (default: dry-run)")
+    ap.add_argument("--limit", type=int, default=0, help="canary: only first N affected repos on --apply")
     args = ap.parse_args()
 
-    old, new = args.old, args.new
-    if old == new:
-        print("::error:: --old and --new are identical", file=sys.stderr)
+    old, new, pin = args.old, args.new, args.pin
+    if old == new and not pin:
+        print("::error:: --old == --new and no --pin → nothing to do", file=sys.stderr)
         return 2
 
-    owners = [o.strip() for o in args.owners.split(",") if o.strip()]
     me = whoami()
-    repos = sorted({r for o in owners for r in list_repos(o, me)})
+    repos = sorted({r for o in args.owners.split(",") if o.strip()
+                    for r in list_repos(o.strip(), me)})
     if not repos:
         print("::error:: no repos readable (token/scope?) — refusing to report 'clean'", file=sys.stderr)
         return 1
 
-    print(f"# ref-sweep (OOTB-5): `{old}/…` → `{new}/…`")
-    print(f"# scanning {len(repos)} repos across owners: {', '.join(owners)}")
-    print(f"# mode: {'APPLY (opens PRs)' if args.apply else 'DRY-RUN (read-only)'}\n")
+    print(f"# ref-sweep: `{old}/…` → `{new}/…`" + (f" @{pin}" if pin else ""))
+    print(f"# {len(repos)} repos · owners {args.owners} · "
+          f"{'APPLY' + (f' (canary limit {args.limit})' if args.limit else '') if args.apply else 'DRY-RUN'}\n")
 
-    plan: list[tuple[str, str, int]] = []  # (repo, file, hit_count)
-    gaps: list[str] = []
-
+    plan, gaps = [], []
     for full in repos:
         wf, _ = gh_json(f"repos/{full}/contents/.github/workflows")
         if not isinstance(wf, list):
-            continue  # no workflows dir
+            continue
+        repo_hits = 0
         for f in wf:
-            path = f.get("path")
-            if not path or not path.endswith((".yml", ".yaml")):
+            path = f.get("path", "")
+            if not path.endswith((".yml", ".yaml")):
                 continue
             body = raw_file(full, path)
             if body is None:
-                gaps.append(f"{full}:{path} unreadable")
+                gaps.append(f"{full}:{path}")
                 continue
-            if find_refs(body, old):
-                hits = body.count(f"{old}/")
-                plan.append((full, path, hits))
-                print(f"- {full} :: {path} ({hits} ref{'s' if hits != 1 else ''})")
+            _, hits = rewrite_uses(body, old, new, pin)
+            if hits:
+                repo_hits += hits
+                print(f"- {full} :: {path.split('/')[-1]} ({hits})")
+        if repo_hits:
+            plan.append(full)
 
-    print(f"\n# {len(plan)} file(s) in {len({p[0] for p in plan})} repo(s) reference `{old}/`")
+    print(f"\n# {len(plan)} repo(s) to sweep")
     if gaps:
-        print(f"# ⚠️ {len(gaps)} unreadable file(s) — NOT 'clean': {', '.join(gaps[:5])}"
-              + (" …" if len(gaps) > 5 else ""))
-
+        print(f"# ⚠️ {len(gaps)} unreadable file(s) — NOT 'clean': {', '.join(gaps[:5])}")
     if not args.apply:
         print("\n# dry-run only — re-run with --apply to open PRs.")
         return 0
 
-    # ---- APPLY: one PR per repo ----
-    branch = "chore/ootb5-ref-sweep"
-    changed_repos = sorted({p[0] for p in plan})
-    for full in changed_repos:
-        files = [p[1] for p in plan if p[0] == full]
+    targets = plan[:args.limit] if args.limit else plan
+    if args.limit:
+        print(f"\n# canary: applying to {len(targets)} of {len(plan)} (--limit {args.limit})")
+    branch = "chore/ref-sweep-ootb"
+    for full in targets:
+        # idempotency: skip if a PR for this branch already exists
+        prs, _ = gh_json(f"repos/{full}/pulls?head={full.split('/')[0]}:{branch}&state=open")
+        if isinstance(prs, list) and prs:
+            print(f"  skip (PR exists): {full}")
+            continue
         base, _ = gh_json(f"repos/{full}")
-        default_branch = (base or {}).get("default_branch", "main")
-        head, _ = gh_json(f"repos/{full}/git/ref/heads/{default_branch}")
+        db = (base or {}).get("default_branch", "main")
+        head, _ = gh_json(f"repos/{full}/git/ref/heads/{db}")
         sha = (head or {}).get("object", {}).get("sha")
         if not sha:
-            print(f"  ⚠️ {full}: cannot resolve {default_branch} head — skipped")
+            print(f"  ⚠️ {full}: no head sha — skipped")
             continue
-        gh("api", "-X", "POST", f"repos/{full}/git/refs",
-           "-f", f"ref=refs/heads/{branch}", "-f", f"sha={sha}")
-        for path in files:
-            body = raw_file(full, path)
-            if body is None or f"{old}/" not in body:
+        existing, _ = gh_json(f"repos/{full}/git/ref/heads/{branch}")
+        if not (isinstance(existing, dict) and existing.get("ref")):
+            _, err = gh("api", "-X", "POST", f"repos/{full}/git/refs",
+                        "-f", f"ref=refs/heads/{branch}", "-f", f"sha={sha}")
+            if err:
+                print(f"  ⚠️ {full}: branch create failed ({err[:60]}) — skipped")
                 continue
-            new_body = body.replace(f"{old}/", f"{new}/")
+        wf, _ = gh_json(f"repos/{full}/contents/.github/workflows")
+        changed = 0
+        for f in (wf if isinstance(wf, list) else []):
+            path = f.get("path", "")
+            if not path.endswith((".yml", ".yaml")):
+                continue
+            body = raw_file(full, path, ref=branch)
+            if body is None:
+                continue
+            new_body, hits = rewrite_uses(body, old, new, pin)
+            if not hits:
+                continue
             meta, _ = gh_json(f"repos/{full}/contents/{path}?ref={branch}")
-            fsha = (meta or {}).get("sha")
+            fsha = (meta or {}).get("sha", "")
             b64 = base64.b64encode(new_body.encode()).decode()
-            gh("api", "-X", "PUT", f"repos/{full}/contents/{path}",
-               "-f", f"message=chore(ci): OOTB-5 repoint {old} -> {new}",
-               "-f", f"content={b64}", "-f", f"sha={fsha or ''}", "-f", f"branch={branch}")
+            _, err = gh("api", "-X", "PUT", f"repos/{full}/contents/{path}",
+                        "-f", f"message=chore(ci): ref-sweep {old} → {new}" + (f" @{pin}" if pin else ""),
+                        "-f", f"content={b64}", "-f", f"sha={fsha}", "-f", f"branch={branch}")
+            if err:
+                print(f"  ⚠️ {full}:{path} update failed ({err[:60]})")
+            else:
+                changed += 1
+        if not changed:
+            print(f"  ⚠️ {full}: branch created but 0 files changed — check manually")
+            continue
         out, err = gh("api", "-X", "POST", f"repos/{full}/pulls",
-                      "-f", f"title=chore(ci): OOTB-5 repoint {old} → {new}",
-                      "-f", f"head={branch}", "-f", f"base={default_branch}",
-                      "-f", f"body=Automated OOTB-5 ref-sweep (KONZ-002): repoint shared-CI refs from `{old}/` to `{new}/` after the source repo moved. See docs/runbooks/KONZ-002-ootb5-ref-sweep.md.")
-        print(f"  {'PR opened' if out else 'PR FAILED: ' + (err or '')[:80]} — {full}")
+                      "-f", f"title=chore(ci): ref-sweep {old} → {new}",
+                      "-f", f"head={branch}", "-f", f"base={db}",
+                      "-f", "body=Automated OOTB-A ref-sweep (KONZ-002): repoint shared-CI `uses:` refs."
+                            " See docs/runbooks/KONZ-002-ootb5-ref-sweep.md.")
+        print(f"  {'PR opened (' + str(changed) + ' files)' if out else 'PR FAILED: ' + (err or '')[:60]} — {full}")
 
-    print(f"\n# applied to {len(changed_repos)} repo(s).")
+    print(f"\n# applied to {len(targets)} repo(s).")
     return 0
 
 


### PR DESCRIPTION
## OOTB-A Foundation (nichts wird bewegt)

**ref-sweep.py gehärtet** (Review-Fixes):
- ersetzt nur echte `uses:`-Zeilen → **Kommentare/Banner werden übersprungen** (war: blind `replace()`)
- **Wortgrenze**: `achimdehnert/platform` ≠ `…/platform-tools`
- **`--pin v1.0.0`** repinnt `@main`→Tag (killt das Supply-Chain-Antipattern)
- **`--limit N`** (Canary) + Branch-/PR-Idempotenz; Fehler werden gemeldet
- unit-getestet (Kommentar-Skip/Wortgrenze/Pin)

**Runbook OOTB-A:** 6 reusable Workflows + 3 composite actions →  (nie migriert) + Tag-Pinning. Löst **platform-SPOF** (@main-Supply-Chain) **und** den platform-Move-Cutover *by construction*. Schritte B1–B6; nur **B4 (Sweep) scharf** → Canary zuerst.

Reine Tool-/Doku-Foundation. Repo-Anlage (B1) + Sweep (B4) sind separate, gegatete Schritte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)