### PR TITLE
feat(tools): ref-sweep --exclude (Default bfagent)

### DIFF
--- a/tools/ref-sweep.py
+++ b/tools/ref-sweep.py
@@ -99,6 +99,8 @@ def main() -> int:
     ap.add_argument("--owners", default="achimdehnert,iilgmbh")
     ap.add_argument("--apply", action="store_true", help="open one PR per consumer (default: dry-run)")
     ap.add_argument("--limit", type=int, default=0, help="canary: only first N affected repos on --apply")
+    ap.add_argument("--exclude", default="bfagent",
+                    help="comma-separated repo names to skip (frozen/special). Default: bfagent (#44 frozen, import-only).")
     args = ap.parse_args()
 
     old, new, pin = args.old, args.new, args.pin
@@ -112,6 +114,11 @@ def main() -> int:
     if not repos:
         print("::error:: no repos readable (token/scope?) — refusing to report 'clean'", file=sys.stderr)
         return 1
+    excl = {e.strip() for e in args.exclude.split(",") if e.strip()}
+    skipped = [r for r in repos if r.split("/")[-1] in excl]
+    if skipped:
+        repos = [r for r in repos if r.split("/")[-1] not in excl]
+        print(f"# excluded ({len(skipped)}, NOT swept): {', '.join(skipped)}")
 
     print(f"# ref-sweep: `{old}/…` → `{new}/…`" + (f" @{pin}" if pin else ""))
     print(f"# {len(repos)} repos · owners {args.owners} · "


### PR DESCRIPTION
Frozen-/Spezial-Repos aus dem Sweep ausklammern. `--exclude` komma-separiert, Default `bfagent` (#44 frozen, import-only). Ausgeschlossene werden geloggt (kein Silent-Cap). Verifiziert per dry-run: `excluded (1, NOT swept): achimdehnert/bfagent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)