### PR TITLE
fix(deploy): host-pin staging/production runner (deploy_runs_on) — fixes silent wrong-host deploys

### DIFF
--- a/.github/workflows/_deploy-unified.yml
+++ b/.github/workflows/_deploy-unified.yml
@@ -66,6 +66,17 @@ on:
         required: false
         type: string
         default: "self-hosted"
+      deploy_runs_on:
+        description: >-
+          Runner label for the HOST-BOUND deploy jobs (staging/production). These do
+          atomic-sync to /opt/<app> on the target host, so they MUST run on that host —
+          a generic 'self-hosted' label can land the job on the WRONG runner (e.g. a dev
+          box without /opt/<app> writable) -> 'cp: ... Permission denied' and no deploy.
+          Set to the deploy host's UNIQUE label (e.g. 'prod-server'). Empty (default) =
+          fall back to runs_on, behaviour unchanged.
+        required: false
+        type: string
+        default: ""
     secrets:
       DEPLOY_SSH_KEY:
         description: "SSH Key für Production (vorhandener Secret-Name)"
@@ -205,7 +216,7 @@ jobs:
   # ── JOB 3a: Deploy to Staging ─────────────────────────────────────────────
   deploy-staging:
     name: "🧪 Staging"
-    runs-on: ${{ inputs.runs_on }}
+    runs-on: ${{ inputs.deploy_runs_on || inputs.runs_on }}
     needs: [resolve, build]
     if: |
       always() &&
@@ -261,7 +272,7 @@ jobs:
   # Falls back to SSH if runs_on != self-hosted (e.g. ubuntu-latest).
   deploy-production:
     name: "🚀 Production"
-    runs-on: ${{ inputs.runs_on }}
+    runs-on: ${{ inputs.deploy_runs_on || inputs.runs_on }}
     needs: [resolve, build]
     if: |
       always() &&


### PR DESCRIPTION
## Problem (verifiziert, cad-hub#21)
`_deploy-unified.yml` lässt **alle** Jobs auf `runs-on: ${{ inputs.runs_on }}` laufen (Default `self-hosted`). Bei **mehreren** self-hosted Runnern mit gemeinsamem `self-hosted`-Label landen die **host-gebundenen** deploy-Jobs nichtdeterministisch auf dem falschen Host:

```
cad-hub deploy-production atomic-sync (ADR-021 §2.20):
cp: cannot create regular file '/opt/cad-hub/docker-compose.prod.yml.tmp<pid>': Permission denied
```

Belegte Runner (cad-hub): `prod-server` (labels: self-hosted,Linux,X64,**prod-server**) und `dev-hetzner` (labels: self-hosted,Linux,X64,hetzner,**dev**) — **beide** tragen `self-hosted`. Der Production-Job kann auf `dev-hetzner` landen, wo `/opt/cad-hub` nicht existiert/beschreibbar ist → `cp` scheitert, **kein** Deploy. Letzter grüner cad-Deploy war 2026-05-30; seither jeder Lauf rot (passt zum Hinzukommen des 2. Runners).

## Fix
Neuer optionaler Input **`deploy_runs_on`** (Default `""`). Nur `deploy-staging` + `deploy-production` nutzen `runs-on: ${{ inputs.deploy_runs_on || inputs.runs_on }}`. `resolve`/`build`/`notify` bleiben `runs_on` (host-agnostisch, build pusht nur ins Registry).

**Voll rückwärtskompatibel:** ungesetzt → Verhalten unverändert (`'' || runs_on`). Consumer mit Multi-Runner-Setup setzen z. B. `deploy_runs_on: prod-server`.

## Consumer-Follow-up (separat, 1 Zeile je Repo)
cad-hub/trading-hub/learn-hub/mcp-hub deploy.yml → `with: { deploy_runs_on: "prod-server" }` (bzw. das jeweilige Host-Label).

## Cross-cutting
Betrifft ALLE `_deploy-unified`-Consumer (additiv, opt-in). Review durch Decider sinnvoll.