### PR TITLE
feat(skill): session-retro v2 — Schema + Soll-Ablauf + Meta-Self-Review + kollisionsfreier Pfad

### DIFF
--- a/.windsurf/workflows/session-retro.md
+++ b/.windsurf/workflows/session-retro.md
@@ -44,6 +44,22 @@ Survivors strukturell selten → kleiner skalieren (sonst verbrennt die Falsifik
 Kein Multi-Agent unter `lean`. Falsifikation **nie** 1 Agent pro Befund (explodiert linear) —
 gebündelt je Dimension.
 
+## Modell-Routing je Phase (Kosten-Disziplin)
+Die Trennung Richter≠Angeklagter kommt vom **frischen Kontext**, NICHT vom teuren Opus →
+Subagenten laufen auf dem **billigsten Modell, das die Phase trägt** (`agent(..., model: …)`):
+
+| Phase | Wer / Modell | Warum |
+|---|---|---|
+| 0 Right-Sizing | **du** (inline) | trivial |
+| 1 Collect (gh/git) | Subagent **haiku** | reines Sammeln, keine Wertung |
+| 2 Find · 3 Verify · 5 Meta | Subagent **sonnet** | braucht **frischen Kontext** (Richter≠Angeklagter), aber Sonnet trägt Review-Tiefe — ~5× billiger als Opus (s. `session-routing.md`) |
+| 3.5 Soll-Ablauf · 4 Anchor/Report | **du** (Haupt-Session) | nur *Zusammenführen* fremder Befunde + Schreiben = kein Selbst-Urteil → in-context ok |
+| 6 Extern-Handoff | **fremder Anbieter** (Mensch holt ein) | stärkster Falsifikator (fremde Blindflecken) |
+
+**Anti-Pattern:** Find/Verify durch **„du" (Haupt-Session)** erledigen = Self-Review aus eigenem
+Kontext = Bruch von Regel 1. „Billiger" heißt **Sonnet-Subagent**, nicht **kein** Subagent.
+Opus-Subagenten nur, wenn Sonnet nachweislich an Nuance scheitert.
+
 ## Phase 1 — Collect (Ground Truth, frischer Ermittler)
 Ein Subagent sammelt **ausschließlich aus Artefakten** (kein Self-Report):
 - `gh pr list --repo <owner>/<repo> --state all --search "updated:>=<datum>"` (+ `gh issue list`)
@@ -166,6 +182,22 @@ Er sieht nur den Report + diese Skill. Checkliste:
 > aller `~/shared/session-retro-*.md`, trendet `refuted_rate`/Scores und eskaliert jeden
 > `recurring_finding` mit Zähler **≥2 über Retros** automatisch zum Gate-PR-Pflicht-Item.
 
+## Phase 6 — Extern-Handoff (optional, nur `deep`)
+Stärkste Stufe der Selbstverbesserung: eine **anbieter-fremde** Zweitmeinung (nicht nur frischer
+Kontext, sondern fremde Trainings-Blindflecken). Muster wie [`adr-handoff-extern`].
+
+Schreibe ein Briefing nach `~/shared/session-retro-extern-<datum>-<repo>-<sid>.md`:
+1. den fertigen Report (Phase 4),
+2. die 4 Eisernen Regeln + das Output-Schema dieser Skill,
+3. Auftrag: *„**Advocatus Diabolus + Out-of-the-Box:** finde, was dieser Retro übersehen oder
+   falsch bewertet hat. Du hast **KEIN Repo-Zugriff** → kritisiere **Methode/Struktur/Blindflecken/
+   Score-Logik/Soll-Ablauf**, behaupte **keine** Evidenz-Fakten (die prüft Phase 3 mit gh/git)."*
+
+Mensch holt die Zweitmeinung extern, faltet sie zurück. **Harte Grenze:** extern kann **Methode**
+challengen, **nicht Evidenz nachprüfen** (kein gh/git) — Evidenz-Recheck bleibt Phase 3/5.
+**Loop:** wiederkehrende Methoden-Kritik fließt als Verbesserung in **diese Skill** (Changelog) —
+genau wie die Skill ursprünglich aus einem Diabolus-Review entstand.
+
 ## Anti-Patterns
 - ❌ Aus dem eigenen Session-Kontext urteilen (in-context self-review).
 - ❌ Befund ohne harten Artefakt-Beleg.
@@ -181,6 +213,9 @@ Er sieht nur den Report + diese Skill. Checkliste:
 - ❌ **Halbscores** (2.5) — brechen Längsschnitt-Vergleichbarkeit.
 - ❌ **Multi-Agent für `lean`-Footprint** / Skeptiker je Befund statt je Dimension (Spend-Falle).
 - ❌ Meta-Self-Review (Phase 5), der die **Session** statt den **Report** beurteilt (Richter≠Angeklagter auf Meta-Ebene).
+- ❌ Find/Verify durch **„du"/Haupt-Session** „zum Sparen" — das ist Self-Review (Regel-1-Bruch). Kosten-Fix = **Sonnet-Subagent**, nicht **kein** Subagent.
+- ❌ **Opus-Subagenten** als Default — Sonnet trägt Find/Verify/Meta; Opus nur bei nachgewiesenem Nuance-Fail.
+- ❌ Extern-Handoff (Phase 6) **Evidenz-Fakten** behaupten lassen — extern hat kein gh/git, nur Methoden-Kritik.
 
 ## Changelog
 - 2026-06-04: Initial. Aus einem Advocatus-Diabolus-Review des Paste-Prompt-Retros
@@ -197,3 +232,9 @@ Er sieht nur den Report + diese Skill. Checkliste:
   Beleg unabhängig neu (nicht Finder-Befehl wiederholen — sonst überlebt False-Positive); binär
   SURVIVES/REFUTED (kein „weakened"); Belegpflicht auch für Längsschnitt-Behauptungen; Right-Sizing
   nach Befund-Dichte + harte Agenten-Budgets (lean=0 Subagenten, Skeptiker je Dimension).
+- 2026-06-04 (v2.1): **Modell-Routing je Phase** (Kosten) — Subagenten auf billigstem tragenden
+  Modell: Collect=haiku, Find/Verify/Meta=**sonnet** (frischer Kontext ≠ teures Opus → ~5× günstiger),
+  Synthese/Report inline bei der Haupt-Session; „billiger" heißt Sonnet-Subagent, NICHT Self-Review.
+  **Phase 6 Extern-Handoff** (optional, deep) — anbieter-fremde Methoden-Zweitmeinung (Muster
+  `adr-handoff-extern`); harte Grenze: extern kritisiert Methode, prüft KEINE Evidenz (kein gh/git);
+  wiederkehrende Kritik fließt zurück in die Skill (Self-Improvement-Loop mit externem Falsifikator).

--- a/.windsurf/workflows/session-retro.md
+++ b/.windsurf/workflows/session-retro.md
@@ -29,10 +29,20 @@ mode: write
 4. **Geschlossener Loop.** Lessons NICHT als Prosa versanden lassen → als **kopierfertige**
    Memory-/ADR-/CLAUDE.md-Vorschläge ausgeben. Verankerung entscheidet der Mensch.
 
-## Phase 0 — Right-Sizing
-Footprint messen (PRs / Repos / Prod-Schritte / Migrationen / ADRs). **lean** (≤2 PRs,
-1 Repo, kein Prod/Migration/ADR) → 2 Dimensionen, knappe Scorecard. **full** → 3 Dimensionen
-+ volle Scorecard.
+## Phase 0 — Right-Sizing (Footprint **und** erwartete Befund-Dichte)
+Footprint messen (PRs / Repos / Prod-Schritte / Migrationen / ADRs) **und** Befund-Dichte
+schätzen: war die Session **reversibel + transparent + vom-Menschen-freigegeben**, sind harte
+Survivors strukturell selten → kleiner skalieren (sonst verbrennt die Falsifikation Agenten für
+0–1 Survivor). Stufe + **hartes Agenten-Budget**:
+
+| Stufe | Trigger | Agenten-Budget |
+|---|---|---|
+| **lean** | ≤2 PRs, 1 Repo, kein Prod/Migration/ADR | **0 Subagenten** — 1 Inline-Pass, 2 Dimensionen, knappe Scorecard |
+| **full** | Standard | 1 Collector + 3 Finder + Falsifikation **gebündelt** (1 Skeptiker je Dimension, nicht je Befund) — ≤5 Subagenten |
+| **deep** | ≥3 Repos ODER Prod-Schritt ODER Migration ODER Verdacht auf vertuschte Fehler | volle Pipeline + Phase-5 Meta-Reviewer; Skeptiker-Spawns **hart gecappt** (≤ Anzahl Dimensionen) |
+
+Kein Multi-Agent unter `lean`. Falsifikation **nie** 1 Agent pro Befund (explodiert linear) —
+gebündelt je Dimension.
 
 ## Phase 1 — Collect (Ground Truth, frischer Ermittler)
 Ein Subagent sammelt **ausschließlich aus Artefakten** (kein Self-Report):
@@ -62,21 +72,99 @@ Je Befund: Schweregrad (kritisch/hoch/mittel/niedrig) + Root Cause (5-Why) + Kat
 (Wissenslücke / Prozesslücke / Kommunikation / verfrühte Festlegung / fehlende Validierung / Werkzeug).
 
 ## Phase 3 — Verify (Falsifikation)
-Pro Befund ein **Skeptiker-Subagent**: versuche zu WIDERLEGEN, prüfe den Beleg per gh/git nach.
-Default „refuted" bei nicht-tragendem Beleg. Nur überlebende Befunde gehen in den Report.
+Skeptiker-Subagent **je Dimension** (nicht je Befund — Budget, s. Phase 0). **Binär: SURVIVES
+oder REFUTED** — kein „weakened"/„teilweise" (das ist Verhandlung, nicht Falsifikation; mildernde
+Umstände gehören in die Beleg-Spalte, nicht in ein drittes Verdikt).
+
+**Eiserne Verify-Regel (Lehre 2026-06-04):** Der Skeptiker bekommt **nur die Behauptung, NICHT
+den Finder-Befehl** — und muss den Beleg **unabhängig neu ziehen**, breiter/rekursiv (`find -name`,
+nicht `ls <dir>`; `grep -r`, nicht `grep <einzelne Datei>`). Wiederholt er den Finder-Glob, wandert
+dessen False-Positive ungeprüft durch. (Realfall: Finder grepte `tools/`, übersah `tools/tests/`,
+Verify wiederholte es → ein falscher Befund „kein Testfile" überlebte.)
+
+**Belegpflicht gilt AUCH für Längsschnitt-/Wiederholungs-Behauptungen** (Phase 4): „wiederholt
+Drift-Memory X" ist ein Befund → X muss per `ls`/`grep` existieren, sonst REFUTED. (Realfall:
+Verweis auf nicht-existente Memory `claim-confidence-vs-cheapest-check`.)
+
+Nur SURVIVES gehen in den Report.
+
+## Phase 3.5 — Soll-Ablauf (konstruktiv, an Überlebende gekoppelt)
+Diagnose allein lehrt „war schlecht", nicht „so geht's richtig". Pro **überlebendem** Befund
+**genau ein** artefakt-verankerter Alternativschritt, Format **Ist → Soll → eliminiert #**:
+
+| Ist (beobachtet, mit Beleg) | Soll (verbesserter Ablauf) | eliminiert |
+|---|---|---|
+| … was real geschah | … der konkrete bessere Schritt/Checkpoint | #<Befund> |
+
+**Invariante (hart):** `|Soll-Schritte| == |überlebende Befunde|`. Kein Soll-Schritt ohne
+Befund-Referenz (verhindert generische Plattitüden „besser planen/kommunizieren"); kein
+überlebender Befund ohne Soll-Schritt (verhindert reine Anklage). Die Top-3-Maßnahmen (Phase 4)
+werden aus dem Soll-Ablauf **abgeleitet**, nicht frei erfunden.
 
 ## Phase 4 — Anchor (schließen + Längsschnitt)
-- **Executive Summary** (max 5 Bullets).
-- **Scorecard 1–5** je Dimension **mit Anker-Begründung** (Zahl aus den Befunden ableiten,
-  nicht aus dem Bauch): Zielerreichung · Architektur/Design · Code & Konventionstreue ·
-  Risiko-/Debt-Management · Prozess-Effizienz · Entscheidungsqualität.
-- **Kopierfertige** `memory_candidates` + `adr_candidates` (du schreibst sie NICHT selbst).
-- **Längsschnitt — der eigentliche Hebel:** gegen die bestehende Memory abgleichen
-  (`<auto-memory>/MEMORY.md`). Ist ein Befund eine **Wiederholung** (gleiche Kategorie mehrfach
-  in dieser Session ODER schon als Drift-Memory dokumentiert) → Kandidat für ein **HARTES GATE**
-  (Hook / CI), nicht für den N-ten Notizzettel. Die Memory-Schicht hält offensichtlich nicht.
-- **Top-3-Maßnahmen** für die nächste Sitzung (priorisiert, konkret, umsetzbar).
-- Report schreiben nach `~/shared/session-retro-<datum>.md`.
+**Pflicht-Report-Skelett** (erzwungen — feste Reihenfolge + feste Tabellenspalten, damit
+Längsschnitt maschinell auswertbar ist). Beginnt mit maschinenlesbarem YAML-Frontmatter:
+
+```yaml
+---
+retro_schema: 1
+date: <YYYY-MM-DD>
+repo_scope: [<repo>, …]
+session_id: <kurz>
+footprint: lean|full|deep
+findings_total: <n>
+findings_survived: <n>
+refuted_rate: <(refuted)/total, 0–1>     # Skill-KPI, s. Phase 5
+scores:                                   # ganzzahlig 1–5, KEINE Halbwerte
+  zielerreichung: <1-5>
+  architektur_design: <1-5>
+  code_konventionstreue: <1-5>
+  risiko_debt: <1-5>
+  prozess_effizienz: <1-5>
+  entscheidungsqualitaet: <1-5>
+gate_candidates: [<slug>, …]
+recurring_findings: [<slug>, …]
+---
+```
+Danach in fester Reihenfolge:
+- **1. Executive Summary** (max 5 Bullets).
+- **2. Befund-Tabelle** mit **eingefrorenen Spalten:** `# | Befund | Kategorie | Severity | Verdikt | Beleg | Recurrence`.
+- **3. Scorecard** — 6 feste Dimensionen (`zielerreichung · architektur_design · code_konventionstreue ·
+  risiko_debt · prozess_effizienz · entscheidungsqualitaet`), **ganzzahlig 1–5, KEINE Halbwerte**,
+  je **Anker aus Befunden** (nicht Bauch). Rubrik: `1`=Kernziel verfehlt/hoher Schaden · `2`=verfehlt
+  mit Rework · `3`=teilweise erreicht, signifikante Abweichung begründet · `4`=erreicht, kleine Mängel ·
+  `5`=erreicht, vorbildlich.
+- **4. Soll-Ablauf** (aus Phase 3.5, Ist→Soll→eliminiert-#).
+- **5. Längsschnitt — der eigentliche Hebel:** gegen `<auto-memory>/MEMORY.md` abgleichen.
+  Wiederholung (gleiche Kategorie mehrfach in dieser Session ODER schon als Drift-Memory **belegt
+  vorhanden** — Existenz per `grep` prüfen, Phase 3) → **HARTES GATE** (Hook/CI), nicht der N-te Notizzettel.
+- **6. Verankerung:** kopierfertige `memory_candidates` + `adr_candidates` (du schreibst sie NICHT selbst).
+- **7. Maßnahmen als Action-Board** (Org-Standard: Buckets 🟢 dein Zug / 🔵 ich sofort / 🟡-⛔ wip / ✅ done;
+  Lean-Spalten `# | Item | Repo | PR/Issue/ADR | Status | Next Step`), **abgeleitet aus dem Soll-Ablauf**.
+- **8. Nicht verifiziert (Restlücken)** — Pflicht-Sektion: was offen blieb + billigster Check.
+
+**Report-Pfad — kollisionsfrei bei Parallel-Sessions (Pflicht):**
+`~/shared/session-retro-<datum>-<repo>-<session-id-kurz>.md`. **Jede Session schreibt ihre eigene Datei.**
+`<repo>` = primäres Scope-Repo, `<session-id-kurz>` = die letzten ~6 Zeichen der Session-ID (oder ein
+eindeutiger Suffix). **Existiert der Pfad bereits → NICHT überschreiben**, zusätzlichen Suffix anhängen.
+Der bloße `…-<datum>.md`-Default ist verboten (Realfall 2026-06-04: 2 Parallel-Sessions kollidierten am
+selben Pfad → Überschreib-Gefahr).
+
+## Phase 5 — Self-Review (Meta-Agent, nur OUTPUT-Qualität) — `full`/`deep`
+Selbstverbesserung der Skill **ohne Richter≠Angeklagter zu brechen:** ein **separater Meta-Agent**
+prüft AUSSCHLIESSLICH den **Report-Entwurf gegen die Skill-Regeln** — NIE die Session-Erzählung.
+Er sieht nur den Report + diese Skill. Checkliste:
+- Hat **jeder** Befund (inkl. Längsschnitt-Behauptung) einen per `gh/git` **unabhängig nachgeprüften** Beleg?
+- Scores ganzzahlig 1–5, je an Befund verankert? (fängt erfundene Halbwerte wie `2.5`)
+- **Invariante** `|Soll-Schritte| == |überlebende Befunde|` erfüllt?
+- Frontmatter schema-valide (alle Pflichtfelder)? Report-Pfad kollisionsfrei (repo+session-id)?
+- `refuted_rate` plausibel? **Interpretation als Skill-KPI** (kein Session-Urteil): dauerhaft
+  **>0,8** über mehrere Retros → Finder zu lasch (produzieren widerlegbares Stroh); **<0,2** →
+  Falsifikation ist Theater (widerlegt nie). Auffälligkeit als `## Self-Review`-Block im Report notieren.
+
+> **Längsschnitt der Skill selbst (optional):** `retro-kpis.py` (falls vorhanden) liest die Frontmatter
+> aller `~/shared/session-retro-*.md`, trendet `refuted_rate`/Scores und eskaliert jeden
+> `recurring_finding` mit Zähler **≥2 über Retros** automatisch zum Gate-PR-Pflicht-Item.
 
 ## Anti-Patterns
 - ❌ Aus dem eigenen Session-Kontext urteilen (in-context self-review).
@@ -85,8 +173,27 @@ Default „refuted" bei nicht-tragendem Beleg. Nur überlebende Befunde gehen in
 - ❌ Memory/ADR/CLAUDE.md selbst schreiben statt nur vorschlagen.
 - ❌ Ein wiederkehrendes Muster als „noch ein Memo" abtun statt als Gate-Kandidat zu eskalieren.
 - ❌ Vom Menschen genannte Repos als „separaten Workstream" aus dem Scope kippen.
+- ❌ **Verify wiederholt den Finder-Befehl** statt den Beleg unabhängig/breiter neu zu ziehen → False-Positive überlebt.
+- ❌ **Drittes Verdikt „weakened/teilweise"** — Falsifikation ist binär (SURVIVES/REFUTED).
+- ❌ **Längsschnitt-Behauptung („wiederholt Memory X") ohne Existenz-Check** von X (Phantom-Referenz).
+- ❌ **Soll-Schritt ohne Befund-Referenz** (= Plattitüde) ODER überlebender Befund ohne Soll-Schritt.
+- ❌ **Default-Dateiname `…-<datum>.md`** → Kollision/Overwrite bei Parallel-Sessions; repo+session-id ist Pflicht.
+- ❌ **Halbscores** (2.5) — brechen Längsschnitt-Vergleichbarkeit.
+- ❌ **Multi-Agent für `lean`-Footprint** / Skeptiker je Befund statt je Dimension (Spend-Falle).
+- ❌ Meta-Self-Review (Phase 5), der die **Session** statt den **Report** beurteilt (Richter≠Angeklagter auf Meta-Ebene).
 
 ## Changelog
 - 2026-06-04: Initial. Aus einem Advocatus-Diabolus-Review des Paste-Prompt-Retros
   (`iil-prompts-retrospective`) hervorgegangen; die 4 Fixes + der Längsschnitt-Hebel sind die
   Lehren daraus. Deterministische Engine: `~/shared/session-retro.workflow.js`.
+- 2026-06-04 (v2): Adversarialer Selbst-Review der Skill (Richter≠Angeklagter, geerdet am realen
+  Output `session-retro-2026-06-04-platform.md`). **Fixes:** (1) **erzwungenes Report-Skelett** +
+  YAML-Frontmatter + feste Spalten + Score-Rubrik (ganzzahlig, keine Halbwerte) + Action-Board →
+  Längsschnitt maschinell auswertbar. (2) **Phase 3.5 Soll-Ablauf** (Ist→Soll→eliminiert-#, Invariante
+  |Soll|==|Survivors|) → konstruktiv statt nur Anklage, plattitüdenfrei by construction. (3) **Phase 5
+  Meta-Self-Review** (separater Agent, nur Output-Qualität) + `refuted_rate`-KPI → Selbstverbesserung
+  ohne Meta-Richter≠Angeklagter-Bruch. (4) **kollisionsfreier Report-Pfad** `…-<datum>-<repo>-<session-id>.md`
+  (Parallel-Sessions schreiben eigene Dateien; Default-Pfad verboten). **Methodenfixe:** Verify zieht
+  Beleg unabhängig neu (nicht Finder-Befehl wiederholen — sonst überlebt False-Positive); binär
+  SURVIVES/REFUTED (kein „weakened"); Belegpflicht auch für Längsschnitt-Behauptungen; Right-Sizing
+  nach Befund-Dichte + harte Agenten-Budgets (lean=0 Subagenten, Skeptiker je Dimension).


### PR DESCRIPTION
Weiterentwicklung der `/session-retro`-Skill aus einem **adversarialen Selbst-Review** (Richter≠Angeklagter — frische Agenten, geerdet an Quelle **und** realem Output `session-retro-2026-06-04-platform.md`).

## 4 Erweiterungen (wie gewünscht)
1. **Strukturiertere Darstellung** — erzwungenes Report-Skelett: YAML-Frontmatter (`retro_schema`, `refuted_rate`, `scores`), feste Tabellenspalten, **Score-Rubrik (ganzzahlig 1–5, keine Halbwerte)**, Action-Board → Längsschnitt maschinell auswertbar.
2. **Soll-Ablauf (robust)** — neue **Phase 3.5**: pro überlebendem Befund genau ein `Ist → Soll → eliminiert #`; **Invariante `|Soll| == |Survivors|`** → konstruktiv statt nur Diagnose, **plattitüdenfrei by construction** (kein Soll-Schritt ohne Befund-Referenz).
3. **Selbstreflexion** — neue **Phase 5 Meta-Self-Review** (separater Agent, **nur Output-Qualität, nie die Session** → kein Meta-Richter≠Angeklagter-Bruch) + `refuted_rate`-KPI.
4. **Parallel-Session-Naming** — kollisionsfreier Pfad `…-<datum>-<repo>-<session-id>.md`; jede Session **eigene Datei**; Default-Pfad verboten (Realfall: 2 Sessions kollidierten heute).

## Methodenfixe (aus echtem Bug im realen Lauf)
- **Verify zieht Beleg unabhängig neu** statt den Finder-Befehl zu wiederholen — sonst überlebt ein False-Positive (real: „kein Testfile" trotz `tools/tests/test_ref_sweep.py`).
- **Binär SURVIVES/REFUTED** (kein „weakened" = Verhandlung).
- **Belegpflicht auch für Längsschnitt-Claims** (real: Verweis auf Phantom-Memory).
- **Right-Sizing nach Befund-Dichte** + harte Agenten-Budgets (lean=0 Subagenten; Skeptiker je Dimension, nicht je Befund).

## Nicht in diesem PR
Distribution nach `~/.claude/commands/` via `cc-skill-dist generate.py` (separater Schritt nach Merge). Optionales `retro-kpis.py` (Längsschnitt-Sweep) als Folge-Iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)