### PR TITLE
feat(guard): main-tree-guard pre-commit-Backstop (ADR-233, Retro F2) [DRAFT]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,14 @@ repos:
 
   - repo: local
     hooks:
+      - id: main-tree-protect
+        name: Main-Tree-Guard (ADR-233 — kein Commit im heiligen Haupt-Tree)
+        language: system
+        entry: tools/main-tree-guard.sh precommit-check
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
+
       - id: adr-number-guard
         name: ADR Number Guard (no duplicate numbers)
         language: python

--- a/docs/adr/ADR-233-parallel-session-worktree-convention.md
+++ b/docs/adr/ADR-233-parallel-session-worktree-convention.md
@@ -1,6 +1,6 @@
 ---
 status: proposed
-implementation_status: none
+implementation_status: partial  # 2026-06-04: pre-commit-Backstop (main-tree-protect) verdrahtet; Snap-back-Hook-Aktivierung via 'tools/main-tree-guard.sh install .' je Checkout
 date: 2026-06-01
 decision-makers: Achim Dehnert
 domains: [dx, git-workflow, drift-prevention, governance]

--- a/tools/main-tree-guard.sh
+++ b/tools/main-tree-guard.sh
@@ -74,9 +74,23 @@ cmd_report() {
   [ "${n:-0}" = "0" ] || { echo "  → Kill-Gate (ADR-233 §8): Konvention nicht erzwingbar (>0)."; tail -3 "$log"; }
 }
 
+# Backstop für pre-commit (ADR-233 §2.1): im sentinel-geschützten Haupt-Tree wird NICHT
+# committet — editierende Arbeit gehört in einen per-session Worktree. In Worktrees ist
+# ".git" eine Datei (kein Verzeichnis), der relative Sentinel-Pfad existiert dort nicht
+# → der Hook greift NUR im Haupt-Tree. Fängt den HEAD-Flip-Commit-auf-main (Retro 2026-06-04 F2),
+# der vom post-checkout-Snap-back allein nicht verhindert wird.
+cmd_precommit_check() {
+  [ -e "$SENTINEL" ] || exit 0   # kein geschützter Haupt-Tree (oder Worktree) → erlauben
+  echo "BLOCK: main-tree-guard (ADR-233): Commit im heiligen Haupt-Tree unterbunden." >&2
+  echo "    Editierende Arbeit gehört in einen per-session Worktree:" >&2
+  echo "    git worktree add /tmp/<slug> -b <branch> origin/main   (oder 'repo-session start')." >&2
+  exit 1
+}
+
 case "${1:-}" in
-  install) shift; cmd_install "$@";;
-  hook)    shift; cmd_hook "$@";;
-  report)  shift; cmd_report "$@";;
-  *) echo "usage: main-tree-guard.sh {install <repo> | report [repo] | hook <prev> <new> <flag>}" >&2; exit 2;;
+  install)         shift; cmd_install "$@";;
+  hook)            shift; cmd_hook "$@";;
+  report)          shift; cmd_report "$@";;
+  precommit-check) shift; cmd_precommit_check "$@";;
+  *) echo "usage: main-tree-guard.sh {install <repo> | report [repo] | precommit-check | hook <prev> <new> <flag>}" >&2; exit 2;;
 esac


### PR DESCRIPTION
> **DRAFT — kein Merge ohne Decider-OK.** Aggressivitäts-Entscheid (s.u.) ist deiner.

## Warum
`/session-retro` (2026-06-04) Befund F2: Branch-Drift **2× in 3 Tagen** — ein Commit landete im *Haupt-Tree* auf `main` statt im Feature-Branch (HEAD durch parallele Session geflippt). ADR-233 mandatiert den `main-tree-guard` bereits, steht aber auf `implementation_status: none` — **gebaut, nie eingehängt**. Vier Notizen (2 Memory, CLAUDE.md, der ADR selbst) haben das Muster nicht gebrochen → harter Gate statt 5. Notiz.

## Was (versioniert, idiomatisch)
- **`main-tree-guard.sh precommit-check`** (neuer Modus): blockt Commit, wenn der Sentinel `.git/iil-main-tree-protected` präsent ist (= geschützter Haupt-Tree). **Worktrees:** `.git` ist dort eine Datei → Sentinel-Pfad existiert nicht → Commits erlaubt. Beide Pfade getestet (exit 0 / exit 1).
- **`.pre-commit-config.yaml`**: lokaler `main-tree-protect`-Hook (pre-commit-Stage) — nutzt das schon aktive pre-commit-Framework, kein neuer Mechanismus.
- **ADR-233** `implementation_status: none → partial`.

## Aktivierung (je Checkout, einmalig — git-Hooks/Sentinel sind nicht versionierbar)
```
tools/main-tree-guard.sh install .   # Sentinel + post-checkout-Snap-back
pre-commit install                   # (bereits aktiv, da gitleaks/adr-hooks laufen)
```

## Dein Entscheid vor Merge
Der Backstop blockt **ALLE** Commits im sentinel-geschützten Haupt-Tree (Konvention: editieren nur in Worktrees). Das ist bewusst aggressiv — es ist die einzige Variante, die *genau* den Retro-F2-Vorfall verhindert (post-checkout-Snap-back allein verhindert den Commit-auf-main nicht). Bestätige die Aggressivität, oder wir lockern auf „nur blocken wenn HEAD≠main".

🤖 Generated with [Claude Code](https://claude.com/claude-code)