### PR TITLE
fix(ci): import-smoke gate bypasst App-Entrypoint (--entrypoint sh)

### DIFF
--- a/.github/workflows/_deploy-unified.yml
+++ b/.github/workflows/_deploy-unified.yml
@@ -210,7 +210,12 @@ jobs:
           echo "::group::Import smoke on $IMG"
           echo "cmd: $SMOKE_CMD"
           docker pull "$IMG"
-          docker run --rm "$IMG" sh -c "$SMOKE_CMD"
+          # --entrypoint sh: das App-Entrypoint (z.B. /entrypoint.sh mit
+          # "DJANGO_SETTINGS_MODULE must be set"-Guard) überspringen — die Smoke
+          # testet den IMPORT-Graph, nicht das Entrypoint. Env setzt der Consumer
+          # inline im SMOKE_CMD. Ohne den Bypass false-failt das Gate an
+          # entrypoint-geguardeten Images (cad-hub#21-Deploy, run 26946093189).
+          docker run --rm --entrypoint sh "$IMG" -c "$SMOKE_CMD"
           echo "::endgroup::"
 
   # ── JOB 3a: Deploy to Staging ─────────────────────────────────────────────


### PR DESCRIPTION
## Problem (verifiziert)
Das #451-import-smoke-Gate (`docker run --rm $IMG sh -c $SMOKE_CMD`) lässt das **App-Entrypoint** mitlaufen. Images mit einem Guard-Entrypoint (z.B. `/entrypoint.sh`: `DJANGO_SETTINGS_MODULE must be set`) brechen ab, **bevor** die Smoke läuft — das Gate **false-failt** und blockt den Deploy ohne irgendetwas zu prüfen.

Beleg: cad-hub Deploy run **26946093189**, Step `Import smoke`:
```
/entrypoint.sh: line 9: DJANGO_SETTINGS_MODULE: ERROR: DJANGO_SETTINGS_MODULE must be set
##[error]Process completed with exit code 1.
```
Die Smoke setzt `DJANGO_SETTINGS_MODULE` nur **inline** im Kommando (greift erst nach dem Entrypoint).

## Fix
`docker run --rm --entrypoint sh "$IMG" -c "$SMOKE_CMD"` — überspringt das App-Entrypoint. Die Smoke testet den **Import-Graph**, nicht das Entrypoint; Env setzt der Consumer inline im SMOKE_CMD. Einzeiler, betrifft alle #451-Consumer (cad/trading/learn/mcp).

## Folge
Nach Merge re-run cad-hub Deploy → Build-Smoke läuft durch → Production (jetzt host-gepinnt, #461) deployt sauber.