### PR TITLE
feat(ci): test-claim-check — warn-only Gate gegen Test-Claims ohne Testfile (Retro Gate 1)

### DIFF
--- a/.github/workflows/test-claim-check.yml
+++ b/.github/workflows/test-claim-check.yml
@@ -1,0 +1,121 @@
+name: Test-Claim-Check
+
+# session-retro Gate 1 (Befund 6): warnt, wenn ein PR Test-Behauptungen
+# ("unit-getestet", "tests added", ...) enthält, aber keine Testdatei ändert.
+# Phase SUGGEST — INFORMATIV, NIE BLOCKIEREND (das Verdikt setzt nie setFailed).
+# Der Tool-Selbsttest (Step 1) darf failen — das ist normale Korrektheits-CI.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  test-claim-check:
+    runs-on: ubuntu-latest
+    # Bot-PRs (nur Dep-Bumps) auslassen — analog guardian.yml
+    if: >
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'renovate[bot]' &&
+      !startsWith(github.head_ref, 'dependabot/') &&
+      !startsWith(github.head_ref, 'renovate/')
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      # Step 1 (blocking): die Gate-Logik muss korrekt sein.
+      - name: Tool-Selbsttest
+        run: |
+          pip install pytest --quiet --break-system-packages
+          python -m pytest tools/tests/test_test_claim_check.py -q
+
+      # Step 2: Eingaben aus dem PR ableiten.
+      - name: Eingaben sammeln
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          printf '%s' "$PR_BODY" > /tmp/pr_body.txt
+          git log "origin/${{ github.base_ref }}..HEAD" \
+            --format='%s%n%b' > /tmp/pr_commits.txt || true
+          git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+            > /tmp/pr_changed.txt || true
+
+      - name: Run Test-Claim-Check
+        id: check
+        run: |
+          python tools/test_claim_check.py \
+            --body-file /tmp/pr_body.txt \
+            --commits-file /tmp/pr_commits.txt \
+            --changed-files-file /tmp/pr_changed.txt \
+            --format json > /tmp/result.json
+          python tools/test_claim_check.py \
+            --body-file /tmp/pr_body.txt \
+            --commits-file /tmp/pr_commits.txt \
+            --changed-files-file /tmp/pr_changed.txt \
+            --format markdown > /tmp/comment.md
+          cat /tmp/result.json
+
+      - name: Post/Update PR Comment (warn-only)
+        if: always()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            let result = { should_comment: false };
+            let comment = '';
+            try {
+              result = JSON.parse(fs.readFileSync('/tmp/result.json', 'utf8'));
+              comment = fs.readFileSync('/tmp/comment.md', 'utf8');
+            } catch (e) {
+              console.log('No check output:', e.message);
+              return;
+            }
+
+            const MARKER = 'Test-Claim-Check';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes(MARKER)
+            );
+
+            // Kein Claim-ohne-Test -> still: vorhandenen Kommentar aufräumen, sonst nichts.
+            if (!result.should_comment) {
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body: '### 🧪 Test-Claim-Check\n\n✅ Kein offener Test-Claim ohne Testdatei.',
+                });
+              }
+              console.log('verdict ok — no warn.');
+              return;
+            }
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: comment,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: comment,
+              });
+            }

--- a/tools/test_claim_check.py
+++ b/tools/test_claim_check.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Test-Claim-Check — Warn-only CI gate (session-retro Gate 1).
+
+Befund 6 des Session-Retros (2026-06-04): ein PR-Body behauptet "unit-getestet",
+aber der Diff enthält keine geänderte Testdatei — eine prüfbare Behauptung ohne
+committeten Beleg (Wiederholung von House-Rule "Evidenz vor Behauptung" +
+Drift-Memory claim-confidence-vs-cheapest-check). Memo-Ebene hielt nicht → Gate.
+
+Mechanik (rein deterministisch, KEIN LLM — feedback_repo_health_rule_discipline):
+  1. PR-Body + Commit-Messages nach *Test*-Claim-Wörtern scannen.
+  2. Geänderte Dateien nach Testdateien scannen.
+  3. Claim ohne Test-Diff -> WARN (Kommentar). Sonst -> still.
+
+Phase SUGGEST: Das Gate WARNT nur (Exit immer 0 für das Verdikt), bis es gegen
+echte PRs FP-frei validiert ist. Erst danach ggf. auf Fail hochziehen.
+
+CLI:
+  python tools/test_claim_check.py \
+    --body-file pr_body.txt [--commits-file commits.txt] \
+    --changed-files-file changed.txt [--format markdown|json]
+
+Run-Tests: python3 -m pytest tools/tests/test_test_claim_check.py -q
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+# --- Claim-Erkennung -------------------------------------------------------
+# Bewusst auf *starke* Test-Behauptungen zentriert (Precision > Recall — ein
+# warn-only Gate, das Wolf schreit, wird ignoriert). Empirisch getunt gegen die
+# letzten 30 merged platform-PRs (2026-06-04): diese Liste -> 1 WARN (#453, der
+# kanonische Befund-6-Fall), 0 FP. BEWUSST AUSGESCHLOSSEN, weil FP-Magneten:
+#   - das blosse "verifiziert"/"verified" (meist manuelle/inhaltliche Verifikation,
+#     z.B. "Portabilitaet verifiziert");
+#   - das blosse "getestet"/"tested" als Einzelwort (kam in Docs-Prosa wie
+#     '"Rueckgabefaehig" = getestet, nicht behauptet' vor -> #437 war damit FP).
+# Die starken Marker (unit-getestet, unittests, test coverage, "tests added/pass")
+# tragen den Befund-6-Kern ohne das Rauschen.
+_CLAIM_PATTERNS = [
+    r"\bunit[\s-]?(?:getestet|tested|tests?)\b",
+    r"\bunittests?\b",
+    r"\btest[\s-]?coverage\b",
+    r"\btests?\s+(?:added|pass(?:ed|ing)?|hinzugef[uü]gt|erg[aä]nzt|gr[uü]n)\b",
+]
+_CLAIM_RE = re.compile("|".join(f"(?:{p})" for p in _CLAIM_PATTERNS), re.IGNORECASE)
+
+# Negation/Abschwaechung im Fenster VOR dem Treffer -> kein Claim.
+# Faengt "nicht getestet", "noch nicht getestet", "manuell getestet",
+# "kein Unit-Test", "not tested", "without tests".
+_NEG_RE = re.compile(
+    r"(nicht|noch\s+nicht|kein[e]?|ohne|manuell|manual|\bnot\b|\bno\b|without)",
+    re.IGNORECASE,
+)
+_NEG_WINDOW = 30  # Zeichen vor dem Treffer
+
+# --- Testdatei-Erkennung ---------------------------------------------------
+_TEST_FILE_PATTERNS = [
+    r"(^|/)tests?/",
+    r"(^|/)test_[^/]+\.py$",
+    r"_test\.(?:py|js|ts|tsx|jsx|go|rb)$",
+    r"\.test\.(?:js|ts|jsx|tsx)$",
+    r"\.spec\.(?:js|ts|jsx|tsx)$",
+    r"(^|/)conftest\.py$",
+]
+_TEST_FILE_RE = re.compile("|".join(_TEST_FILE_PATTERNS))
+
+
+def find_test_claims(text: str) -> list[str]:
+    """Liefert die gefundenen Claim-Phrasen (Negationen herausgefiltert)."""
+    if not text:
+        return []
+    claims: list[str] = []
+    for m in _CLAIM_RE.finditer(text):
+        window = text[max(0, m.start() - _NEG_WINDOW): m.start()]
+        if _NEG_RE.search(window):
+            continue  # abgeschwaecht/negiert -> kein Test-Claim
+        claims.append(m.group(0).strip())
+    return claims
+
+
+def changed_test_files(paths: list[str]) -> list[str]:
+    """Filtert die Liste geaenderter Pfade auf Testdateien."""
+    return [p for p in paths if p and _TEST_FILE_RE.search(p)]
+
+
+def analyze(body: str, commits: str, changed_files: list[str]) -> dict:
+    """Kern-Verdikt. Pure function — vollstaendig unit-testbar."""
+    claims = find_test_claims(body) + find_test_claims(commits)
+    test_files = changed_test_files(changed_files)
+    verdict = "warn" if claims and not test_files else "ok"
+    return {
+        "verdict": verdict,
+        "should_comment": verdict == "warn",
+        "claims": sorted(set(claims), key=str.lower),
+        "test_files": test_files,
+    }
+
+
+def render_markdown(result: dict) -> str:
+    claims = ", ".join(f"`{c}`" for c in result["claims"])
+    return (
+        "### 🧪 Test-Claim-Check — Hinweis (warn-only)\n\n"
+        f"Dieser PR enthält Test-Behauptung(en) ({claims}), aber der Diff ändert "
+        "**keine Testdatei**.\n\n"
+        "Bitte eines von beidem:\n"
+        "- den behaupteten Test als Datei committen (`tests/`, `test_*.py`, "
+        "`*_test.*`, `*.spec.*`), **oder**\n"
+        "- die Behauptung im PR-Body präzisieren (z. B. „manuell verifiziert“, "
+        "„kein Unit-Test nötig“).\n\n"
+        "> Hintergrund: Session-Retro 2026-06-04, Befund 6 — „Evidenz vor "
+        "Behauptung“. Dieser Check ist **informativ, nie blockierend**."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Test-Claim-Check (warn-only)")
+    ap.add_argument("--body-file")
+    ap.add_argument("--commits-file")
+    ap.add_argument("--changed-files-file")
+    ap.add_argument("--format", choices=["markdown", "json"], default="json")
+    args = ap.parse_args(argv)
+
+    def _read(p: str | None) -> str:
+        if not p:
+            return ""
+        try:
+            with open(p, encoding="utf-8") as fh:
+                return fh.read()
+        except OSError:
+            return ""
+
+    body = _read(args.body_file)
+    commits = _read(args.commits_file)
+    changed = [ln.strip() for ln in _read(args.changed_files_file).splitlines() if ln.strip()]
+
+    result = analyze(body, commits, changed)
+
+    if args.format == "json":
+        print(json.dumps(result, ensure_ascii=False))
+    elif result["should_comment"]:
+        print(render_markdown(result))
+
+    return 0  # warn-only: Verdikt blockiert nie
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_test_claim_check.py
+++ b/tools/tests/test_test_claim_check.py
@@ -1,0 +1,95 @@
+"""Unit tests for tools/test_claim_check.py (session-retro Gate 1).
+
+The gate that demands tests ships with tests — and these run in CI via
+.github/workflows/test-claim-check.yml (step 1, blocking). Naming: test_should_*.
+"""
+import importlib
+
+tcc = importlib.import_module("tools.test_claim_check")
+
+
+# --- claim detection -------------------------------------------------------
+def test_should_detect_unit_getestet_claim():
+    assert tcc.find_test_claims("Tool ist unit-getestet.") == ["unit-getestet"]
+
+
+def test_should_detect_strong_english_claim():
+    assert tcc.find_test_claims("Tests added for the new path.") == ["Tests added"]
+
+
+def test_should_detect_unittests_and_coverage():
+    assert tcc.find_test_claims("Added unittests, test coverage up.")
+
+
+def test_should_ignore_negated_unit_claim():
+    # negation window guard: "nicht unit-getestet" must not count
+    assert tcc.find_test_claims("Noch nicht unit-getestet, kommt später.") == []
+
+
+def test_should_ignore_manual_test_disclaimer():
+    # "manuell ... kein Unit-Test" -> negation window suppresses the unit match
+    assert tcc.find_test_claims("Nur manuell getestet, kein Unit-Test.") == []
+
+
+def test_should_not_match_bare_verifiziert():
+    # "verifiziert" alone is a FP magnet (manual/content verification) -> excluded
+    assert tcc.find_test_claims("Portabilität verifiziert via PR #429.") == []
+
+
+def test_should_not_match_bare_getestet_prose():
+    # empirically a FP source (#437: '"Rückgabefähig" = getestet, nicht behauptet')
+    # -> bare "getestet"/"tested" is intentionally NOT a claim
+    assert tcc.find_test_claims('"Rückgabefähig" = getestet, nicht behauptet.') == []
+    assert tcc.find_test_claims("Behaviour is tested in CI.") == []
+
+
+def test_should_not_match_untested_substring():
+    assert tcc.find_test_claims("Dieser Pfad ist ungetestet.") == []
+    assert tcc.find_test_claims("This path is untested.") == []
+
+
+# --- test-file detection ---------------------------------------------------
+def test_should_recognize_test_paths():
+    paths = [
+        "src/app.py",
+        "tools/tests/test_ref_sweep.py",
+        "frontend/x.spec.ts",
+        "pkg/foo_test.go",
+        "tests/conftest.py",
+        "README.md",
+    ]
+    found = tcc.changed_test_files(paths)
+    assert "src/app.py" not in found
+    assert "README.md" not in found
+    assert "tools/tests/test_ref_sweep.py" in found
+    assert "frontend/x.spec.ts" in found
+    assert "pkg/foo_test.go" in found
+    assert "tests/conftest.py" in found
+
+
+def test_should_not_flag_docs_dir_named_protests():
+    # word-ish boundary: a path like "protests/" must not match the tests/ rule
+    assert tcc.changed_test_files(["docs/protests/notes.md"]) == []
+
+
+# --- end-to-end verdict ----------------------------------------------------
+def test_should_warn_on_claim_without_test_file():
+    r = tcc.analyze("Vollständig unit-getestet.", "", ["tools/foo.py"])
+    assert r["verdict"] == "warn"
+    assert r["should_comment"] is True
+
+
+def test_should_pass_when_test_file_present():
+    r = tcc.analyze("Unit-getestet.", "", ["tools/foo.py", "tools/tests/test_foo.py"])
+    assert r["verdict"] == "ok"
+    assert r["should_comment"] is False
+
+
+def test_should_pass_when_no_claim_at_all():
+    r = tcc.analyze("Reiner Docs-Fix, Tippfehler.", "", ["docs/x.md"])
+    assert r["verdict"] == "ok"
+
+
+def test_should_detect_claim_in_commit_messages():
+    r = tcc.analyze("", "fix(x): behoben, unit-getestet", ["src/x.py"])
+    assert r["verdict"] == "warn"


### PR DESCRIPTION
## Was

Setzt **Gate 1** aus dem Session-Retro (2026-06-04) um: einen **warn-only** CI-Check, der einen PR markiert, wenn Body/Commits eine **Test-Behauptung** enthalten (`unit-getestet`, `tests added`, `test coverage` …), der Diff aber **keine Testdatei** ändert.

Schließt damit das Muster hinter **Befund 6** (PR #453 behauptete „unit-getestet" ohne committeten Test) — eine Wiederholung der House-Rule *„Evidenz vor Behauptung"*. Memo-Ebene hat nicht gehalten → **Gate statt N-ter Notiz** (Längsschnitt-Hebel des Retros).

## Wie

| Datei | Zweck |
|---|---|
| `tools/test_claim_check.py` | pure `analyze()` (deterministisch, **kein LLM**) + CLI |
| `tools/tests/test_test_claim_check.py` | 14 Unit-Tests (`test_should_*`) |
| `.github/workflows/test-claim-check.yml` | warn-only Workflow (Verdikt nie `setFailed`), PR-Kommentar wie `context-reviewer` |

- **Precision > Recall** (ein Gate, das Wolf schreit, wird ignoriert): nur **starke** Test-Claims. Bloßes `getestet`/`verifiziert` ist **bewusst ausgeschlossen** — empirisch FP-Magnet (z. B. `#437`: `"Rückgabefähig" = getestet, nicht behauptet` in Docs-Prosa). Negations-Fenster filtert `nicht/kein/manuell`.
- Das Gate, das Tests verlangt, **liefert Tests mit** und führt sie in CI aus (Step 1, blocking). Nebeneffekt: schließt die Lücke, dass `tools/tests/` bisher in **keiner** PR-CI lief (auch der mit #464 gemergte `test_ref_sweep.py` lief nicht).

## Validierung (0-FP-Disziplin, `feedback_repo_health_rule_discipline`)

Empirisch gegen die **letzten 30 merged platform-PRs** getunt:
- **1 WARN** → `#453` (genau der kanonische Befund-6-Fall) ✅
- **0 False-Positives**
- Unit-Tests: **14 passed**; gesamte `tools/tests/`: **26 passed**

## Scope / Phase

**SUGGEST** — warn-only, **platform-only**. Erst nach FP-freier Praxis ggf. auf Fail hochziehen bzw. via `cc-skill-dist`/shared-CI auf weitere Repos ausrollen. Kein ADR nötig (additive CI nach bestehendem Muster `context-reviewer.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)