### PR TITLE
feat(ci): Deploy-Config-Lint — Org-Gate gegen Auto-Prod-Deploy-Drift

### DIFF
--- a/.github/workflows/deploy-config-lint.yml
+++ b/.github/workflows/deploy-config-lint.yml
@@ -1,0 +1,34 @@
+name: "Deploy-Config-Lint"
+
+# Org-Gate gegen den Auto-Prod-Deploy-Drift (risk-hub-Klasse): deploy.yml, das
+# push->main auf 'production' defaultet, deployt unbemerkt direkt auf Prod.
+# Org-Standard (_deploy-unified.yml): push->main = staging; Prod nur Tag/manuell.
+# Hintergrund: session-retro 2026-06-04 (risk-hub ~20 Tage Auto-Prod).
+#
+# Adoption im Repo-CI:
+#   jobs:
+#     deploy-config-lint:
+#       uses: achimdehnert/platform/.github/workflows/deploy-config-lint.yml@main
+
+on:
+  workflow_call: {}
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-config-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout caller repo
+        uses: actions/checkout@v4
+        with:
+          path: caller
+      - name: Checkout platform (Lint-Script)
+        uses: actions/checkout@v4
+        with:
+          repository: achimdehnert/platform
+          ref: main
+          path: platform
+      - name: Lint deploy-Workflows gegen Auto-Prod-Default
+        run: python3 platform/tools/deploy_config_lint.py caller/.github/workflows

--- a/tools/deploy_config_lint.py
+++ b/tools/deploy_config_lint.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""deploy_config_lint.py — Org-Gate gegen Auto-Prod-Deploy-Drift.
+
+Prueft die Deploy-Workflows eines Repos darauf, dass push->main NICHT auf
+'production' defaultet. Org-Standard (platform/_deploy-unified.yml):
+push->main = staging; Prod nur via Tag v* oder bewusster workflow_dispatch-Wahl.
+
+Hintergrund: risk-hub deployte ~20 Tage unbemerkt push->main direkt auf Prod,
+weil deploy.yml `target_environment` auf 'production' defaultete (session-retro
+2026-06-04, run wf_313a3b58). Dieses Lint faengt die Drift-Klasse org-weit am
+PR-Gate — statt N-ter Memory-Eintrag.
+
+Usage:
+    python3 deploy_config_lint.py [<workflows-dir>]   # default .github/workflows
+Exit 1 wenn ein Auto-Prod-Default-Anti-Pattern gefunden wird, sonst 0.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+# Anti-Pattern 1 (Haupt-Drift-Ursache): push-Fallback auf production, z.B.
+#   target_environment: ${{ inputs.target_environment || 'production' }}
+_FALLBACK = re.compile(r"""target_environment\s*:.*\|\|\s*['"]production['"]""")
+
+# Anti-Pattern 2: workflow_dispatch-Input-Default 'production' im
+# target_environment-Block (Mehrzeilen-Block bis zum naechsten default:).
+_INPUT_DEFAULT = re.compile(
+    r"""target_environment\s*:\s*\n(?:[ \t]+\S.*\n)*?[ \t]+default\s*:\s*['"]production['"]""",
+)
+
+
+def lint_text(name: str, text: str) -> list[str]:
+    """Findet Auto-Prod-Default-Anti-Pattern in einem Workflow-Text."""
+    out: list[str] = []
+    for m in _FALLBACK.finditer(text):
+        out.append(
+            f"{name}: push->branch faellt auf production zurueck (Default sollte 'staging'): {m.group(0).strip()}"
+        )
+    if _INPUT_DEFAULT.search(text):
+        out.append(
+            f"{name}: workflow_dispatch target_environment-Default = 'production' (sollte 'staging')"
+        )
+    return out
+
+
+def lint_dir(d: pathlib.Path) -> list[str]:
+    out: list[str] = []
+    for f in sorted([*d.glob("*.yml"), *d.glob("*.yaml")]):
+        out.extend(lint_text(str(f), f.read_text(encoding="utf-8", errors="ignore")))
+    return out
+
+
+def main(argv: list[str]) -> int:
+    d = pathlib.Path(argv[1] if len(argv) > 1 else ".github/workflows")
+    if not d.is_dir():
+        print(f"✅ Deploy-Config-Lint: kein Verzeichnis {d} — nichts zu pruefen.")
+        return 0
+    offenders = lint_dir(d)
+    if offenders:
+        print("❌ Deploy-Config-Lint: Auto-Prod-Default-Anti-Pattern gefunden:")
+        for o in offenders:
+            print("  -", o)
+        print(
+            "\nFix: target_environment-Default auf 'staging'. Prod nur via Tag v* "
+            "oder bewusster workflow_dispatch-Wahl (Org-Standard _deploy-unified.yml)."
+        )
+        return 1
+    print("✅ Deploy-Config-Lint: kein Auto-Prod-Default.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/tests/test_deploy_config_lint.py
+++ b/tools/tests/test_deploy_config_lint.py
@@ -1,0 +1,75 @@
+"""Tests fuer tools/deploy_config_lint.py — Org-Gate gegen Auto-Prod-Deploy-Drift."""
+
+import importlib.util
+import pathlib
+
+_SPEC = importlib.util.spec_from_file_location(
+    "deploy_config_lint",
+    pathlib.Path(__file__).resolve().parents[1] / "deploy_config_lint.py",
+)
+dcl = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(dcl)
+
+
+# ---- Anti-Pattern 1: push-Fallback auf production ---------------------------
+_BAD_FALLBACK = """
+jobs:
+  deploy:
+    uses: achimdehnert/platform/.github/workflows/_deploy-unified.yml@main
+    with:
+      target_environment: ${{ inputs.target_environment || 'production' }}
+"""
+
+# ---- Anti-Pattern 2: workflow_dispatch input default production -------------
+_BAD_INPUT_DEFAULT = """
+on:
+  workflow_dispatch:
+    inputs:
+      target_environment:
+        description: "Ziel"
+        required: false
+        default: "production"
+        type: choice
+"""
+
+# ---- Konform (risk-hub nach #165/#166) --------------------------------------
+_GOOD = """
+on:
+  workflow_dispatch:
+    inputs:
+      target_environment:
+        default: "staging"
+jobs:
+  deploy:
+    with:
+      target_environment: ${{ inputs.target_environment || 'staging' }}
+"""
+
+
+def test_should_flag_push_fallback_to_production():
+    out = dcl.lint_text("deploy.yml", _BAD_FALLBACK)
+    assert out, "push->branch-Fallback auf production muss erkannt werden"
+    assert "production" in out[0]
+
+
+def test_should_flag_workflow_dispatch_default_production():
+    out = dcl.lint_text("deploy.yml", _BAD_INPUT_DEFAULT)
+    assert out, "workflow_dispatch-Default 'production' muss erkannt werden"
+
+
+def test_should_pass_staging_default():
+    assert dcl.lint_text("deploy.yml", _GOOD) == [], "staging-Default ist konform"
+
+
+def test_should_lint_dir_clean_when_no_offenders(tmp_path):
+    wf = tmp_path / ".github" / "workflows"
+    wf.mkdir(parents=True)
+    (wf / "deploy.yml").write_text(_GOOD, encoding="utf-8")
+    assert dcl.lint_dir(wf) == []
+
+
+def test_should_lint_dir_flags_offender(tmp_path):
+    wf = tmp_path / ".github" / "workflows"
+    wf.mkdir(parents=True)
+    (wf / "deploy.yml").write_text(_BAD_FALLBACK, encoding="utf-8")
+    assert dcl.lint_dir(wf)


### PR DESCRIPTION
## Warum
Der **session-retro** (2026-06-04, run `wf_313a3b58`) fand den schärfsten Befund der Session: **risk-hub deployte ~20 Tage unbemerkt `push→main` direkt auf Prod** (schutztat.de), weil seine `deploy.yml` `target_environment` auf `production` defaultete — als einziger Ausreißer gegen den Org-Standard (`_deploy-unified.yml`: push→main = staging).

Zwei Drift-Memories existierten bereits, verhinderten den Ausreißer aber nicht → **recurring_pattern → hartes Gate** statt N-ter Notizzettel (genau der Längsschnitt-Hebel der session-retro-Skill).

## Was
- **`tools/deploy_config_lint.py`** — flaggt `deploy.yml`, das push→branch auf `production` defaultet (Fallback `|| 'production'` **oder** `workflow_dispatch`-Input-Default `production`). Exit 1 bei Fund.
- **`tools/tests/test_deploy_config_lint.py`** — 5 Tests (beide Anti-Pattern + Clean-Cases). *(Committed — nicht „unit-getestet ohne Testdatei", die der Retro andernorts rügte.)*
- **`.github/workflows/deploy-config-lint.yml`** — reusable Workflow. Adoption im Repo-CI:
  `uses: achimdehnert/platform/.github/workflows/deploy-config-lint.yml@main` (Muster wie `registry-lint` / `import-smoke`).

## Verifikation
- pytest 5/5; `ruff format` clean.
- Lint **grün** gegen risk-hub (nach #165/#166) + platform.
- **Fängt den alten pre-#165-Stand** → hätte die 20-Tage-Drift am PR-Gate erwischt.

## Scope / Rollout
Keine ADR (folgt dem vorhandenen Shared-Gate-Muster registry-lint/import-smoke). Rollout = Repos adoptieren den reusable Workflow (wie bei import-smoke); risk-hub als erster Adopter sinnvoll. Die 3 Custom-Auto-Prod-Repos (iil-relaunch×2, odoo-hub) brauchen zusätzlich Staging+Environment — separater Schritt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)