### PR TITLE
feat(admin): Profil-B GitHub-App Lifecycle-Artefakt + Mint-Script

### DIFF
--- a/docs/PROFILE_B.md
+++ b/docs/PROFILE_B.md
@@ -47,11 +47,12 @@ Org-Installations · People · Org-Management · SSO · Custom properties
 Nach dem Anlegen, in `~/.bashrc`:
 
 ```bash
-export GH_APP_ID=<app-id>
+export GH_APP_ID=3971306
 export GH_APP_KEY="$HOME/.secrets/github_app_iilgmbh_admin.pem"
-export GH_APP_INSTALL_ID=<install-id-iilgmbh>   # je Org eine; passende setzen
-# Break-Glass-Session: Enterprise-/Org-Admin-Token nur in DIESEM Terminal
-alias claude-ent='GH_TOKEN="$(~/github/platform/tools/gh-app-token.sh)" claude'
+export GH_APP_DEFAULT_ACCOUNT=achimdehnert   # Default-Konto ohne Argument
+# Break-Glass-Session: Org-/Repo-Admin-Token nur in DIESEM Terminal.
+# claude-ent [account] — gh-app-token.sh löst die Install-ID live per JWT auf.
+claude-ent() { GH_TOKEN="$(~/github/platform/tools/gh-app-token.sh "${1:-$GH_APP_DEFAULT_ACCOUNT}")" claude "${@:2}"; }
 ```
 
 `claude-ent` startet eine Session, in der `gh` über den kurzlebigen App-Token
@@ -74,7 +75,11 @@ Profil B ist breit, **weil** gerade Umbau läuft. Die Verengung ist eine
 
 ## Verifiziert / nicht verifiziert
 
+- **Ist-Stand (2026-06-05):** App **angelegt** — `iilgmbh-admin`, **App ID `3971306`**,
+  Owner `achimdehnert` (privat); Key in `~/.secrets/github_app_iilgmbh_admin.pem` (600).
+  Installiert auf `achimdehnert` (Install `138206871`); **Token-Smoke grün** (50 Repos).
+  `gh-app-token.sh <account>` löst die Install-ID live per JWT auf.
 - **Verifiziert (2026-06-05):** GitHub Apps können org/repo-Admin voll (GA) +
   Enterprise-Member/Org/SSO (Public Preview); Billing/-Policy **nicht** → PAT-Rest.
-- **Nicht verifiziert:** die App existiert noch nicht (UI-Schritt offen);
-  App-ID/Install-IDs sind nach dem Anlegen einzutragen.
+- **Offen (M6):** App auf „Any account" stellen + Install auf `iilgmbh`/`bahn-sqf`
+  (Org-Admin); `~/.bashrc`-Block setzen; PR #476 mergen.

--- a/docs/PROFILE_B.md
+++ b/docs/PROFILE_B.md
@@ -1,0 +1,80 @@
+# Profil B — GitHub-Admin Break-Glass (iilgmbh)
+
+> **Lifecycle-Artefakt** für das github-admin-Mandat (Sessions 2026-06-05).
+> Profil **A** (Cross-Repo-Dev) braucht keine Sonderrechte — der normale
+> `gho_`-OAuth-Login deckt es. **Dieses Dokument = Profil B** (org/enterprise-
+> Admin) und sein **Re-Narrow-Gate**.
+
+## Entscheidung (festgeschrieben)
+
+- **Mandat:** volle org/repo-Admin via **GitHub App** (nicht persönlicher PAT).
+  Enterprise-Billing/-Policy bleiben Mini-Break-Glass über den Enterprise-PAT.
+- **Auth-Bauform:** kurzlebiger Installation-Token (~1 h) statt langlebigem
+  God-PAT. Token nie persistiert; pro Befehl/Session frisch geprägt.
+- **Install-Scope:** `iilgmbh` + `bahn-sqf` + persönlicher Account `achimdehnert`.
+  **Gov-Orgs (`ttz-lif`/`meiki-lra`) bewusst DRAUSSEN** — bei Bedarf 10-Sekunden-
+  Scope-Erweiterung im UI, nicht per Default (Bürger-/Behörden-Workloads).
+- **Modus:** Break-Glass pro Umbau-Task (`claude-ent`), nicht stehend.
+  Irreversible Aktionen (Member entfernen · Billing · Org-Transfer · Repo-Delete)
+  immer mit explizitem Einzel-OK des Owners, auch wenn der Token sie erlaubt.
+
+## Permission-Manifest (beim App-Anlegen setzen)
+
+**Repository** (Read & Write, außer Metadata=Read):
+Administration · Contents · Actions · Workflows · Environments · Secrets ·
+Variables · Pull requests · Issues · Pages · Webhooks · Deployments · *Metadata (R)*
+
+**Organization** (Read & Write):
+Administration · Members · Org secrets · Org variables · Org webhooks ·
+Custom properties · Self-hosted runners · Teams
+
+**Enterprise** (später, Public-Preview-Sets — nur wenn Enterprise-Ops nötig):
+Org-Installations · People · Org-Management · SSO · Custom properties
+
+## Anlege-Schritte (Owner, UI)
+
+1. `github.com/organizations/iilgmbh/settings/apps` → **New GitHub App**.
+2. Permissions = Manifest oben. Webhooks: keine (oder nach Bedarf).
+   „Where can this be installed" → **Only this account**.
+3. **Generate a private key** → speichern als
+   `~/.secrets/github_app_iilgmbh_admin.pem` (chmod 600).
+4. **App ID** notieren (App-Settings-Seite).
+5. **Install** auf `iilgmbh`, `bahn-sqf`, `achimdehnert` → je **Installation ID**
+   notieren (URL der Install-Settings: `.../installations/<ID>`).
+
+## Token prägen + claude-ent
+
+Nach dem Anlegen, in `~/.bashrc`:
+
+```bash
+export GH_APP_ID=<app-id>
+export GH_APP_KEY="$HOME/.secrets/github_app_iilgmbh_admin.pem"
+export GH_APP_INSTALL_ID=<install-id-iilgmbh>   # je Org eine; passende setzen
+# Break-Glass-Session: Enterprise-/Org-Admin-Token nur in DIESEM Terminal
+alias claude-ent='GH_TOKEN="$(~/github/platform/tools/gh-app-token.sh)" claude'
+```
+
+`claude-ent` startet eine Session, in der `gh` über den kurzlebigen App-Token
+läuft (Profil B). Normaler `claude` = Profil A (dein OAuth-Login). Die
+Terminal-Wahl **ist** der Scope-Checkpoint.
+
+## Re-Narrow-Gate (Kill-Gate gegen den „temporär→permanent"-Ratchet)
+
+Profil B ist breit, **weil** gerade Umbau läuft. Die Verengung ist eine
+**getrackte Pflicht**, kein Vorsatz:
+
+- **Trigger:** Abschluss der KONZ-002-Konsolidierung (S4 erledigt, Repos in
+  Enterprise-Org, User-Account ausgetrocknet) **ODER** spätestens `review_by`.
+- **`review_by`:** 2026-09-05.
+- **Aktion bei Trigger:** Install-Scope auf das tatsächlich noch nötige Minimum
+  zusammenziehen (UI, Sekunden); Permission-Set auf den dann real genutzten
+  Subset reduzieren; Enterprise-PAT-Break-Glass auf Notwendigkeit prüfen.
+- **Verifikation:** App-Install-Liste + Permission-Set gegen dieses Dokument;
+  Abweichung = entweder hier begründen oder verengen.
+
+## Verifiziert / nicht verifiziert
+
+- **Verifiziert (2026-06-05):** GitHub Apps können org/repo-Admin voll (GA) +
+  Enterprise-Member/Org/SSO (Public Preview); Billing/-Policy **nicht** → PAT-Rest.
+- **Nicht verifiziert:** die App existiert noch nicht (UI-Schritt offen);
+  App-ID/Install-IDs sind nach dem Anlegen einzutragen.

--- a/tools/gh-app-token.sh
+++ b/tools/gh-app-token.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# gh-app-token.sh — präge einen kurzlebigen (~1 h) GitHub-App-Installation-Token
+# für Profil B (iilgmbh org/repo-Admin). Siehe docs/PROFILE_B.md.
+#
+# Gibt NUR den Token auf stdout aus (kein Echo des Private Keys). Gedacht für:
+#   alias claude-ent='GH_TOKEN="$(~/github/platform/tools/gh-app-token.sh)" claude'
+#
+# Env (in ~/.bashrc setzen, nach App-Anlage):
+#   GH_APP_ID          App ID (App-Settings-Seite)
+#   GH_APP_KEY         Pfad zum Private-Key-PEM (Default ~/.secrets/github_app_iilgmbh_admin.pem)
+#   GH_APP_INSTALL_ID  Installation ID der Ziel-Org (iilgmbh/bahn-sqf/achimdehnert)
+set -euo pipefail
+
+APP_ID="${GH_APP_ID:?GH_APP_ID nicht gesetzt — siehe docs/PROFILE_B.md}"
+KEY="${GH_APP_KEY:-$HOME/.secrets/github_app_iilgmbh_admin.pem}"
+INSTALL_ID="${GH_APP_INSTALL_ID:?GH_APP_INSTALL_ID nicht gesetzt — siehe docs/PROFILE_B.md}"
+[ -r "$KEY" ] || { echo "Private Key nicht lesbar: $KEY" >&2; exit 1; }
+
+b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+
+now=$(date +%s)
+header="$(printf '{"alg":"RS256","typ":"JWT"}' | b64url)"
+# iat -60s (Clock-Skew), exp +9 min (GitHub-Max 10 min)
+payload="$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$((now - 60))" "$((now + 540))" "$APP_ID" | b64url)"
+sig="$(printf '%s.%s' "$header" "$payload" | openssl dgst -sha256 -sign "$KEY" -binary | b64url)"
+jwt="${header}.${payload}.${sig}"
+
+# JWT → Installation-Token (läuft nach ~1 h ab, wandert nie in gh-Config)
+gh api --method POST \
+  -H "Authorization: Bearer ${jwt}" \
+  -H "Accept: application/vnd.github+json" \
+  "/app/installations/${INSTALL_ID}/access_tokens" \
+  --jq '.token'

--- a/tools/gh-app-token.sh
+++ b/tools/gh-app-token.sh
@@ -1,33 +1,47 @@
 #!/usr/bin/env bash
-# gh-app-token.sh — präge einen kurzlebigen (~1 h) GitHub-App-Installation-Token
-# für Profil B (iilgmbh org/repo-Admin). Siehe docs/PROFILE_B.md.
+# gh-app-token.sh [account] — kurzlebiger (~1 h) GitHub-App-Installation-Token
+# für Profil B (siehe docs/PROFILE_B.md). Gibt NUR den Token auf stdout aus.
 #
-# Gibt NUR den Token auf stdout aus (kein Echo des Private Keys). Gedacht für:
-#   alias claude-ent='GH_TOKEN="$(~/github/platform/tools/gh-app-token.sh)" claude'
+#   gh-app-token.sh              → Default-Account (GH_APP_DEFAULT_ACCOUNT)
+#   gh-app-token.sh iilgmbh      → Token für die iilgmbh-Installation
+#   gh-app-token.sh bahn-sqf     → Token für die bahn-sqf-Installation
 #
-# Env (in ~/.bashrc setzen, nach App-Anlage):
-#   GH_APP_ID          App ID (App-Settings-Seite)
-#   GH_APP_KEY         Pfad zum Private-Key-PEM (Default ~/.secrets/github_app_iilgmbh_admin.pem)
-#   GH_APP_INSTALL_ID  Installation ID der Ziel-Org (iilgmbh/bahn-sqf/achimdehnert)
+# Die Install-ID wird LIVE per App-JWT aufgelöst (kein hartkodiertes Mapping) —
+# sobald die App auf einer weiteren Org installiert ist, greift ihr Name sofort.
+#
+# Env (in ~/.bashrc):
+#   GH_APP_ID                App ID
+#   GH_APP_KEY               PEM-Pfad (Default ~/.secrets/github_app_iilgmbh_admin.pem)
+#   GH_APP_DEFAULT_ACCOUNT   Account ohne Argument (z. B. achimdehnert)
 set -euo pipefail
 
 APP_ID="${GH_APP_ID:?GH_APP_ID nicht gesetzt — siehe docs/PROFILE_B.md}"
 KEY="${GH_APP_KEY:-$HOME/.secrets/github_app_iilgmbh_admin.pem}"
-INSTALL_ID="${GH_APP_INSTALL_ID:?GH_APP_INSTALL_ID nicht gesetzt — siehe docs/PROFILE_B.md}"
+ACCOUNT="${1:-${GH_APP_DEFAULT_ACCOUNT:-}}"
 [ -r "$KEY" ] || { echo "Private Key nicht lesbar: $KEY" >&2; exit 1; }
 
 b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
-
 now=$(date +%s)
 header="$(printf '{"alg":"RS256","typ":"JWT"}' | b64url)"
-# iat -60s (Clock-Skew), exp +9 min (GitHub-Max 10 min)
 payload="$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$((now - 60))" "$((now + 540))" "$APP_ID" | b64url)"
 sig="$(printf '%s.%s' "$header" "$payload" | openssl dgst -sha256 -sign "$KEY" -binary | b64url)"
 jwt="${header}.${payload}.${sig}"
 
-# JWT → Installation-Token (läuft nach ~1 h ab, wandert nie in gh-Config)
-gh api --method POST \
-  -H "Authorization: Bearer ${jwt}" \
-  -H "Accept: application/vnd.github+json" \
-  "/app/installations/${INSTALL_ID}/access_tokens" \
-  --jq '.token'
+api() { curl -sS -H "Authorization: Bearer ${jwt}" -H "Accept: application/vnd.github+json" "$@"; }
+
+# Install-ID des gewünschten Accounts live auflösen
+iid="$(api https://api.github.com/app/installations | ACCOUNT="$ACCOUNT" python3 -c '
+import sys, os, json
+d = json.load(sys.stdin)
+if isinstance(d, dict):
+    sys.exit("API-Fehler: " + str(d.get("message")))
+acc = os.environ.get("ACCOUNT", "")
+hit = [i for i in d if (not acc or i["account"]["login"].lower() == acc.lower())]
+if not hit:
+    sys.exit("Keine Installation fuer %r. Installiert auf: %s"
+             % (acc, ", ".join(i["account"]["login"] for i in d)))
+print(hit[0]["id"])')"
+
+# JWT → kurzlebiger Installation-Token (wandert nie in gh-Config)
+api -X POST "https://api.github.com/app/installations/${iid}/access_tokens" \
+  | python3 -c 'import sys, json; print(json.load(sys.stdin)["token"])'


### PR DESCRIPTION
Prep für das github-admin-Mandat (Profil B = org/repo-Admin via GitHub App). **App-Anlage = dein UI-Schritt**; diese Artefakte machen ihn lückenlos.

- `docs/PROFILE_B.md` — Entscheidung (Scope iilgmbh+bahn-sqf+achimdehnert, Gov draußen), Permission-Manifest, Anlege-Schritte, **Re-Narrow-Gate** (review_by 2026-09-05, gegen den temporär→permanent-Ratchet).
- `tools/gh-app-token.sh` — JWT→kurzlebiger (~1h) Installation-Token für `claude-ent`; Token nie persistiert, Key nie geechot.

Nach App-Anlage trägst du App-ID/Install-IDs in ~/.bashrc ein (Vorlage im Doc), dann ist Profil B scharf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)