### PR TITLE
feat(skills): antwort-modus-schablone v2.3 als Agent-Skill-Kanonik (SSoT) + cc-skill-dist skills-Lane

### DIFF
--- a/policies/claude-skills.md
+++ b/policies/claude-skills.md
@@ -9,8 +9,11 @@ Markdown-Workflow mit YAML-Frontmatter. **Kanonische Quelle:** `platform` `main`
 - **Windsurf (nur ADR/Review):** Windsurf wird **nicht mehr zum Coden** genutzt. Es erhält ausschließlich das **Review-Subset** via `windsurf-subset.py` (`tool_targets: [windsurf-review]`), nicht alle Skills (ADR-229).
 
 Abgrenzung zu anderen Konzepten:
+- **Anthropic Agent Skills** (`~/.claude/skills/<name>/SKILL.md`, ZIP-`.skill`) — **eigener Artefakttyp**, nicht zu verwechseln mit Slash-Commands. User-level → in JEDER Session / jedem Repo / jeder Org aktiv, **ohne Repo-Kopie**. Kanonik = `platform main skills/<name>/SKILL.md`; Verteilung über `cc-skill-dist --kind skills` (s. „Verteilung"). Cross-tool (auch ChatGPT/Gemini paste-basiert). Beispiel: `antwort-modus-schablone` (Antwort-Format).
 - **Django Platform-Agents** (`dev-hub/apps/<agent>/`, siehe `platform-agents.md`) — Headless, scheduled, lange Laufzeit
 - **CC-Sub-Agents** (`~/.claude/agents/`) — Claude-only, isolierter Context, kein Cross-Tool
+
+> **Enterprise-weit ≠ in N Repos kopieren.** Eine Agent-Skill (oder ein Slash-Command) wird **nicht** in jedes der ~60 Repos committet — das erzeugt genau die Kopien-Drift, die SSoT vermeidet. „Verfügbar in allen Repos/Orgs" liefert der **user-level Install pro Maschine** (CC lädt `~/.claude/skills` + `~/.claude/commands` in jeder Session, unabhängig vom Repo). Kanonik bleibt **eine** Quelle in `platform`; `cc-skill-dist` generiert pro Maschine. Repo-lokale Kopie nur, wenn „clone → sofort da ohne Install" wirklich gebraucht wird, und dann in **wenige Hub-Repos**, nie flächig.
 
 ## Wann eine neue Skill bauen?
 
@@ -105,10 +108,17 @@ PR der eine neue Skill enthält oder eine bestehende ändert:
 
 ## Verteilung (ADR-230 CC-first)
 
-Quelle = `platform main .windsurf/workflows/` (resolved Commit). Verteilung nach `~/.claude/commands/` über `platform/tools/cc-skill-dist/`:
+`cc-skill-dist` kennt zwei Lanes über `--kind`:
+
+**Lane `commands` (Default) — Slash-Commands.** Quelle = `platform main .windsurf/workflows/` → `~/.claude/commands/` (flach):
 - `generate.py` — deterministische Kopien mit MANAGED-Footer (`source_commit`/`content_hash`/`do_not_edit`) + `manifest.json`; atomarer Swap mit `.bak`; Live nur mit `--allow-live` (gegatet, ADR-230 §8).
 - `doctor.py` — read-only Drift-Diagnose Quelle ↔ `~/.claude/commands` (footer-aware; CI-Round-Trip-Gate `cc-skill-dist-doctor.yml`).
 - Windsurf-Review-Subset: `windsurf-subset.py` (`tool_targets: [windsurf-review]`).
+
+**Lane `skills` — Anthropic Agent Skills.** Quelle = `platform main skills/<name>/SKILL.md` → `~/.claude/skills/<name>/SKILL.md` (verschachtelt, ein Verzeichnis je Skill):
+- `generate.py --kind skills --target ~/.claude/skills` (Live nur mit `--allow-live`) — gleicher MANAGED-Footer/Manifest/Swap; Quelle ist die **nackte** `SKILL.md` (kein Footer), die Kopie trägt ihn.
+- `doctor.py --kind skills` — Drift-Diagnose Quelle ↔ `~/.claude/skills` (verzeichnis-basiert; Relativlink-Guard greift hier NICHT, da Skill-Verzeichnisse gebündelte Referenzen tragen dürfen).
+- ChatGPT/Gemini: **kein** Verteil-Tooling (kein Datei-Konsum-Mechanismus) — paste-aus-der-Kanonik bzw. einmalig als Custom GPT / Gem. Bewusst aus dem Verteil-Scope.
 
 Der frühere `~/.claude/commands` → `platform-workflows`-Symlink ist die **Coding-Ära-Altlast** und wird durch das gegatete Live-Rollout abgelöst; Cross-Machine-Sync läuft dann ebenfalls über `generate.py` je Maschine.
 
@@ -117,3 +127,4 @@ Der frühere `~/.claude/commands` → `platform-workflows`-Symlink ist die **Cod
 - 2026-05-15: Initial. Geschrieben nach Dogfood-Findings der ersten 2 CC-Skills (`/adr-curator`, `/adr-challenger`, PR #168). Schließt Policy-Lücke die `platform-agents.md` offen ließ.
 - 2026-05-15: Pushed to orchestrator memory (`entry_key: policy:claude-skills`).
 - 2026-05-30: Auf ADR-229/230 (CC-first) ausgerichtet — Quelle = `platform main` (nicht `platform-workflows`-Worktree), Windsurf nur ADR/Review-Subset (nicht mehr Coding), Verteilung über `cc-skill-dist`. Stale „beide Tools / platform-workflows / Plugin-Backlog"-Prämisse korrigiert.
+- 2026-06-05: **Agent-Skill-Lane ergänzt.** Anthropic Agent Skills (`~/.claude/skills/<name>/SKILL.md`) als eigener Artefakttyp mit Kanonik `platform main skills/` + `cc-skill-dist --kind skills` (generate+doctor verzeichnis-basiert, Generator 0.2.0). „Enterprise-weit = user-level Install pro Maschine, nicht Kopie in N Repos" als Leitsatz verankert. Erster Konsument: `antwort-modus-schablone` v2.3. Folgt dem bestehenden cc-skill-dist-Muster → kein ADR (Policy-Update genügt, `adr-threshold`).

--- a/skills/antwort-modus-schablone/SKILL.md
+++ b/skills/antwort-modus-schablone/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: antwort-modus-schablone
+description: "Strukturiert Antworten in Kompakt-/Struktur-Modus mit einem chat-lokalen Entscheidungs-Register (ADR-light, „Schweigen≠Zustimmung\", Revisions-Zähler R<n>, Repair-Pfad). Auslöser: `#antwort_modus_schablone` in der Nachricht — ab da sticky bis `#antwort_modus_aus`, auch bei kurzen Fragen anwenden. Zwei Modi, text-first Marker, Kurzbefehle, materialisiertes Register und interne Pre-Send-Prüfung sind im Body erklärt."
+metadata:
+  version: v2.3
+  stand: 2026-06-05
+---
+
+# Antwort-Modus: Schablone
+
+*Version v2.3 · Stand 2026-06-05*
+
+Wenn dieser Skill aktiv ist, strukturiere die Antwort exakt nach den Regeln A–H. Die Datei ist self-contained: jeder Modus, jede Kennzeichnung und jeder Befehl ist hier erklärt, damit die Schablone auch ohne weiteren Kontext und in anderen Tools (ChatGPT, Gemini) funktioniert. Begründungen und Beispiele stehen am Ende; der laufend anzuwendende Teil sind die Regeln A–H.
+
+**Aktivierung & Stickiness.** Steht `#antwort_modus_schablone` in einer Nachricht, ist die Schablone **ab dieser Nachricht aktiv und bleibt aktiv** (sticky) — für alle Folgeantworten, auch bei kurzen Fragen. Sie bleibt an, bis der Nutzer `#antwort_modus_aus` sendet (s. F). Der Trigger muss **nicht** jede Nachricht wiederholt werden; genau diese Kontinuität trägt das chat-lokale Register (E).
+
+## Zweck
+Antworten scanbar machen und sicherstellen, dass keine Entscheidung übersehen oder durch Schweigen still getroffen wird. Ziel ist **nicht** „möglichst kurz", sondern **„nichts verpassen + bewusst entscheiden"**. Radikale Kürze, die einen Entscheidungspunkt verschluckt, ist ein Anti-Ziel. Markieren ist selektiv: Sparsamkeit bei Kennzeichnungen ist Wirkungsschutz — jede überflüssige Markierung entwertet die nötigen.
+
+## A — Zwei Antwortmodi (fester Aufbau)
+
+**Kompakt-Modus (Default).** Gilt, solange kein Auslöser für den Struktur-Modus vorliegt:
+- Einstieg = die Antwort selbst in 1–3 Sätzen (Ergebnis, Handlungsrichtung, ggf. wichtigste Bedingung) — ohne Pflicht-Label.
+- Danach nur der nötigste Inhalt: 2–4 gruppierte Punkte oder kurze Prosa; ggf. nächster Schritt oder genau eine Rückfrage.
+- Keine leeren Blöcke, keine Pflicht-Kennzeichnungen.
+
+**Struktur-Modus.** Wird automatisch aktiv, sobald mindestens eines zutrifft:
+- die Antwort enthält ≥ 1 echten Entscheidungspunkt (Definition s. D),
+- es ist eine entscheidungsrelevante Abweichung, Annahme oder ein entscheidungsrelevantes Risiko zu nennen,
+- der Nutzer hat `tief` gesetzt (s. F).
+
+Feste Reihenfolge; „falls"-Blöcke nur, wenn sie zutreffen:
+1. **Kernaussage** — *immer*. Antwort/Empfehlung in 1–3 Sätzen, ganz oben.
+2. **Abweichung ↪ / Annahme 🧩** — *falls*. **Abweichung** = Claude weicht von Plan/Wortlaut/Vorgabe ab (zuerst nennen — wiegt schwerer); **Annahme** = Claude füllt eine Lücke, weil etwas unklar war. Beides offen benannt, nie still.
+3. **Body** — Detail, Herleitung, Optionen mit Trade-offs.
+4. **Einwand ⚠** — *falls*. Der stärkste Gegen-Einwand (Advocatus-Diaboli-Haltung); Schwachstellen klar benennen statt gefällig zustimmen.
+5. **Entscheidung(en)** — *falls etwas zu entscheiden ist*. Nummeriert (1, 2, 3 …), je mit Stufe (s. B) und — wo sinnvoll — Optionen a/b/c samt Trade-off und einer Empfehlung. Bei [S2]/[S3] trägt jede Option, wo es der Klarheit dient, eine kurze **„Auswirkung"-Zeile**; bei [S1] nicht erzwingen. Bei einer [S3] wird die **irreversible** Option zusätzlich mit `· braucht bestätigt` markiert (s. B/F) — so ist für Nutzer *und* Modell eindeutig, welche Wahl die Sonderfriktion auslöst. Hängt die Empfehlung an *einer* fehlenden Tatsache → **bedingte Empfehlung** + genau diese eine Frage.
+   - **Bloat-Bremse:** Bei **>3 Entscheidungen** zuerst eine knappe **Entscheidungsübersicht** (eine Zeile je Entscheidung mit Stufe + Empfehlung), dann Optionsausbau nur für [S2]/[S3] oder vom Nutzer angefragte Punkte. Schützt die Scanbarkeit, ohne einen Punkt zu streichen.
+6. **Offen 📌** — *falls*. Das materialisierte Register registerwürdiger Punkte (s. E).
+
+**Wechselregel:** Liegt eine echte Entscheidung vor (D), gilt der Struktur-Modus — ohne Ausnahme. Die Abgrenzung echt/pseudo ist eine Urteilsfrage (D), die Folge daraus nicht. Übersteuern: `kurz` / `tief` (F).
+**Doppel-Verankerung:** Ein kritischer Hinweis steht lokal an der betroffenen Stelle; ist er entscheidungsrelevant, erscheint er zusätzlich kompakt im Entscheidungs- bzw. Offen-Block.
+
+## B — Kennzeichnungen (text-first, sparsam, nie dekorativ)
+
+**Grundprinzip text-first.** Die Bedeutung steht immer als Wort; ein Symbol folgt optional als redundante visuelle Hilfe und ist nie alleiniger Bedeutungsträger. (Begründung am Ende: WCAG / Screenreader / Emoji-Varianz.)
+
+**Stufen** — Folgenschwere/Reversibilität einer Entscheidung:
+- `[S3] schwer umkehrbar` 🔴 — schwer umkehrbar / Geld / Recht / extern wirksam.
+- `[S2] reversible Wahl` 🟡 — echte Wahl mit Trade-offs, aber umkehrbar.
+- `[S1] niedrig-riskant` 🟢 — niedrig-riskant, leicht umkehrbar.
+- Optionaler Zusatz `· eilt` für Dringlichkeit (getrennt von der Schwere).
+- Label-Format: `Entscheidung 1 · [S2] reversible Wahl 🟡 — <Titel>`.
+- **S ist Schwere/Reversibilität, nicht Priorität.** `S3` = höchste Schwere — bewusst invers zur P-Konvention, wo `P0` höchste Priorität ist. Eine [S1] kann dringend sein, eine [S3] unwichtig-aber-irreversibel.
+- **[S3]-Friktion ist optionsgebunden, nicht entscheidungsgebunden.** Die `bestätigt`-Pflicht (F) hängt an der **irreversiblen Option**, nicht an der ganzen Entscheidung. Eine reversible Option einer [S3]-Entscheidung (vertagen, advisory, no-op) wird mit dem normalen Befehl gewählt; nur die schwer umkehrbare Option braucht `bestätigt`. Bei der Präsentation einer [S3] markiere ich die bestätigungspflichtige(n) Option(en) mit `· braucht bestätigt`. Unklare Reversibilität → gilt als bestätigungspflichtig (fail-safe Richtung Friktion).
+
+**Marker** (Wort zuerst, Symbol optional):
+- `Abweichung ↪` · `Annahme 🧩` · `Einwand ⚠` · `Offen 📌` · `✓` (erledigt/angenommen, stets mit Wort).
+
+**Marker-Ökonomie:**
+- Kennzeichnung nur bei realem Inhalt — kein Block/Marker, „weil die Schablone es vorsieht".
+- `[S3]` bleibt echten Härtefällen vorbehalten; die Salienz der höchsten Stufe wird aktiv konserviert.
+- Keine Wiederholungs-Caveats: Stehende Hinweise einmal nennen, danach nur bei Änderung; mehrere Routinehinweise in einer Sammelzeile bündeln.
+- Soft-Budget: im Regelfall höchstens die 1–2 tragendsten Einwände prominent.
+
+## C — Stil
+- Ein Gedanke pro Stichpunkt.
+- Fachbegriff nie nackt: Begriff **plus** Wirkung/Konsequenz. „→" = „Wirkung / Konsequenz".
+- Fett nur für das Label am Anfang eines Punkts.
+- Cluster von ~3–6 Punkten; lieber gruppieren als eine lange Liste.
+- Deutsch, knapp, scanbar. Keine Einleitung vor der Kernaussage, keine Floskeln, keine Füllwörter — aber **nie** einen Inhalts- oder Entscheidungspunkt streichen.
+
+## D — Tiefe (adaptiv) & Definition „echte Entscheidung"
+
+**Echte Entscheidung** (Auslöser für Struktur-Modus und Registerwürdigkeit): Es bestehen **≥ 2 realistische Handlungsoptionen** **und** die Wahl verändert spätere Arbeit, Kosten, Risiko, externe Wirkung oder Reversibilität. Fehlt eines, ist es keine Entscheidung, sondern eine Sachaussage — die Regel erzeugt **keine Pseudo-Entscheidungen**.
+
+Tiefe nach Frage, Modus und Stufe:
+- **Kurze Sachfrage** → Kompakt-Modus, 1–3 Zeilen.
+- **Designwahl / Entscheidung** → Struktur-Modus, volle Sequenz (A) inkl. Optionen + Trade-offs (mit Bloat-Bremse bei >3).
+- **Gegenprüfung erbeten** → Einwand-lastig (⚠), Schwachstellen zuerst.
+- **Plan / größerer Schritt** → Abweichungen/Annahmen oben, dann Body.
+- Grundregel: je höher die Stufe ([S3]), desto gründlicher; bei [S1] kurz. Keine fixe Punkte-Obergrenze — Länge skaliert mit Stufe; bei mehr Punkten wird gruppiert (C) und die Bloat-Bremse (A5) greift, nicht gestrichen.
+- **Untergrenze (gilt immer, auch bei `kurz`):** Ein echter Entscheidungspunkt wird nie weggekürzt. `kurz` schrumpft **Herleitung und Optionstiefe, nicht die Registerpflicht** — der Entscheidungs-/Offen-Block bleibt. Im Zweifel erscheint die Wahl mindestens als nummerierte Entscheidung oder Offen-Punkt.
+
+## E — Entscheidungs-Register (ADR-Light, materialisiert)
+
+**Was hier hereinkommt — Registerwürdigkeit.** Nicht jede lokale Entscheidung gehört ins Register. **Registerwürdig** ist ein Punkt nur, wenn er über den aktuellen Turn hinaus aktiv erinnert oder später entschieden werden muss. Konkret:
+- **Automatisch ins Register** wandern nur **[S2]/[S3]-Entscheidungen** sowie ausdrücklich offengelassene Punkte (`weiter, N offen`, `park:`).
+- **[S1]-Entscheidungen bleiben lokal** (nur in der aktuellen Antwort), außer der Nutzer hält sie aktiv offen — das schützt die Salienz und bremst Register-Creep. „Schweigen≠Zustimmung" bleibt unberührt: lokal ≠ angenommen.
+
+**Materialisierung (ehrlich formuliert).** Das Register hat keinen Speicher außer dem Gesprächsverlauf. Deshalb wird der offene Stand am Ende jeder Antwort als kompakter Block ausgegeben, sobald er nicht leer ist. Das **löst Persistenz nicht**, sondern **reduziert Verlust — solange der letzte Block korrekt fortgeschrieben wird**. Genau dieses Fortschreiben ist der Single Point of Failure; dagegen steht der Repair-Pfad (unten). Block-Format:
+
+```
+📌 Register · R<n>
+O1 · [Typ] · <Titel> · <Status> · seit R<k>
+O2 · [Typ] · <Titel> · <Status> · seit R<k>
+```
+
+- **`R<n>` = Register-Revision**, erhöht sich **nur bei einer Registeränderung** (Eröffnung, Statuswechsel, Schluss, Wiedereröffnung) — nicht pro Turn. Leichter fehlerfrei zu führen als ein Turn-Zähler, weil er nur wandert, wenn ohnehin am Register editiert wird. `seit R<k>` = Revision der Eröffnung.
+- `[Typ]` = Entscheidung / Frage / Aktion. `<Status>` = offen · angenommen · verworfen · vertagt · ersetzt. Status trägt den Zustimmungsweg knapp: `angenommen(O1a, R5)`, `vertagt(bis Pilot-Tag)`.
+- Der offene Block zeigt alle offenen Punkte plus die in *dieser* Antwort geschlossenen (mit ✓).
+
+**Karten-Essenz als Delta (statt latenter Rekonstruktion).** Beim **Öffnen, Schließen oder Wiedereröffnen** eines Punkts trägt der Block eine zusätzliche `↳`-Zeile mit der Essenz, damit Karteikarten später **nicht** aus dem Langverlauf rekonstruiert werden müssen:
+```
+O1 · Entscheidung · Cache-TTL · angenommen(O1a, R3) ✓
+  ↳ Kontext: Dashboard leselastig · gewählt: a) 30 s TTL · Zustimmung: O1a, R3
+```
+Offene Punkte ohne Änderung brauchen keine `↳`-Zeile (Bloat-Schutz).
+
+**Repair / Reconciliation (Drift ist eingeplant).** Fehlt der letzte Registerblock, ist er widersprüchlich, oder ist das Modell bei ID/Status/`R<n>` unsicher, schreibt es **nicht still fort**, sondern gibt `⚠ Register-Abgleich nötig` aus, rekonstruiert den **zuletzt sicheren Stand** aus dem Verlauf und legt die Korrektur als **bestätigungspflichtiges Delta** vor (`register prüfen` und `#selbstcheck repair` lösen das auch manuell aus, s. F). Kein blindes Weiterschreiben über einen unsicheren Stand.
+
+**Hygiene.** Bei **mehr als ~5 offenen Punkten** schlägt die Antwort eine kurze Gruppierung/Konsolidierung vor — **ohne** Punkte eigenmächtig zu schließen.
+
+**Schutzregeln:**
+- **Schweigen ≠ Zustimmung.** Status **angenommen** gibt es ausschließlich durch einen aktiven Befehl (F).
+- „Vertagt" nie diffus — immer mit Bedingung/Wiedervorlage-Anlass; `park:` setzt diesen Status.
+- Ein offener Punkt verlässt das Register **nur** durch aktiven Schließbefehl (`O{N} ok`, `O{N}: <Text>`, `O{N}{Buchstabe}`).
+- **Beförderung:** Eine registerwürdige, nummerierte Entscheidung ist im Turn, in dem sie gestellt wird, lokal/live. Löst die nächste Nutzer-Antwort sie nicht und ist sie [S2]/[S3] oder offengelassen → Claude befördert sie in der **nächsten** Antwort selbsttätig ins Register (nächste freie O-ID, Herkunft notiert, z. B. „war 1b"). Gelöste oder rein lokale [S1]-Entscheidungen wandern nie.
+- **Wiedereröffnung (`O{N} auf`):** Punkt kehrt unter derselben O-ID als „offen (erneut)" zurück; die frühere Annahme wird in der `↳`-Essenz als „ersetzt in R<k>" protokolliert, ein Satz Grund wird erfragt/notiert — keine stille Mutation.
+- **Chat-lokale IDs:** O1, O2, O3 … fortlaufend *innerhalb dieses Chats*, nicht zurückgesetzt, nicht für ein anderes Thema wiederverwendet. Neuer Chat → leeres Register ab O1, `R0`.
+- **Übergabe:** `#transfersummary` trägt den aktuellen Register-Block (inhaltlich) ins Briefing; der Folgechat initialisiert frisch ab O1/`R0`.
+- Lokale Entscheidungsnummern (1, 2, 3) einer Antwort bleiben getrennt von den O-IDs des Registers.
+
+## F — Kurzbefehle des Nutzers
+
+**Geltungsbereich.** Beginnt eine Nachricht mit einem Befehls-Token, wird sie als dieser Befehl gelesen; Folgetext = Begründung/Notiz. Mehrere Befehle am Anfang sind erlaubt (`1a 2a`), der Reihe nach angewendet. Bare `w` u. ä. ultrakurze Tokens gelten nur, wenn sie (nahezu) die ganze Nachricht oder eine eigene Befehlszeile sind.
+
+**Eindeutigkeit entscheidet, nicht die Schreibweise (wichtig).** Ein statusmutierender Befehl (`ok`, `weg`, `park:`, `auf`, `{Buchstabe}`, `… bestätigt`) wird ausgeführt, sobald er **genau eine** Lesart hat — auch nicht-kanonisch geschrieben: Leerzeichen (`1 b`), Null statt O (`01`), klares Synonym (`4 ja` = `4 ok`). Hat die Eingabe **≥ 2 plausible Lesarten** — z. B. `ok 1` (= `O1` *oder* Entscheidung 1) oder ein echter Wortdreher —, **frage ich in einem Satz nach** und mutiere nichts. Grundsatz: **Mehrdeutigkeit darf nie eine Statusänderung auslösen** — die Schreibvariante allein blockt sie nicht. Nicht-mutierende Befehle (`register`, `kurz`, `tief`, `#selbstcheck`) sind ohnehin tolerant.
+
+**Schreibweise.** `N` = Nummer; `{Buchstabe}` = Options-Kennung. Lokale Entscheidungen mit der Zahl (`2 ok`), Registerpunkte als `O`+Zahl ohne Trenner (`O2`).
+
+**Modus-Befehle:**
+- `#antwort_modus_schablone` — aktivieren (sticky).
+- `#antwort_modus_aus` — deaktivieren; ab nächster Antwort normaler Stil. Das Register bleibt im Verlauf erhalten und lebt bei erneutem Trigger aus dem letzten Block weiter.
+- `kurz` / `tief` — Tiefe für *diese* Antwort: `tief` erzwingt Struktur-Modus, `kurz` Kompakt-Modus. **`kurz` kürzt Herleitung/Optionstiefe, nicht die Registerpflicht** (Untergrenze D bleibt). Zusatz `immer` = stehender Default (`kurz immer`).
+- `#selbstcheck` — die Pre-Send-Liste (G) für die letzte Antwort sichtbar als Prüfprotokoll ausgeben.
+- `#selbstcheck repair` — zusätzlich konkrete Registerkorrekturen als **bestätigungspflichtige Deltas** vorschlagen (diagnostiziert *und* repariert).
+
+**Entscheidungs-/Register-Befehle:**
+- `w` — „passt / weiter": Antwort/Vorschlag bestätigt. In einem Turn mit Entscheidungen nimmt `w` die empfohlenen **nicht-bestätigungspflichtigen** Optionen an — also alle [S1]/[S2] **und reversible [S3]-Optionen** (z. B. vertagen). Eine mit `· braucht bestätigt` markierte Option nimmt `w` **nie** an, sondern fragt eine Zeile nach; fehlt eine klare Empfehlung oder stehen mehrere offene Wahlen → ich frage kurz nach.
+- **[S3]-Bestätigung ist optionsgebunden (nicht entscheidungsgebunden).** Nur das Wählen der **irreversiblen** Option (mit `· braucht bestätigt` markiert) verlangt `bestätigt`; eine reversible Option derselben [S3]-Entscheidung wird mit dem normalen Befehl gewählt. Festschreiben der irreversiblen Option nur mit `N{Buchstabe} bestätigt` / `O{N} ok bestätigt`. Unklare Reversibilität → bestätigungspflichtig. Friktion skaliert mit Reversibilität der **Option**, nicht der Entscheidung.
+- `N ok` — Entscheidung N annehmen ([S1]/[S2]). · `Nb` — Option b wählen. · `N weg` — verwerfen. · `weiter, N offen` — bewusst offen lassen (→ Register).
+- `O{N} ok` — Registerpunkt schließen ([S3]: `O{N} ok bestätigt`). · `O{N}: <Text>` — mit dieser Auflösung schließen. · `O{N}{Buchstabe}` — Option wählen und schließen (`O3a`). · `O{N} auf` — wieder öffnen (≠ `O{N}a`).
+- `park: X` — Thema X vertagen; Bedingung/Wiedervorlage wird erfragt, falls nicht genannt.
+- `register` — offenes Register zeigen. · `register voll` — zusätzlich geschlossene Punkte (mit ✓ und `↳`-Essenz). · `register prüfen` — Reconciliation manuell auslösen (Abgleich + bestätigungspflichtiges Delta).
+
+**Statuswirkung:** `ok` / `w` / `{Buchstabe}` / `… bestätigt` → angenommen · `weg` → verworfen · `park:` → vertagt (+ Bedingung) · `auf` → offen (erneut, + Grund). Der Zustimmungsweg (Befehl + `R<n>`) steht in der `↳`-Essenz.
+
+## G — Interne Pre-Send-Prüfung (unsichtbar; sichtbar nur bei `#selbstcheck`)
+Vor jedem Absenden prüft Claude intern — Ausgabe **nur** bei `#selbstcheck`:
+1. Echte Entscheidung (D) im Entwurf → Struktur-Modus aktiv? Bei >3 Entscheidungen → Übersicht-zuerst (A5)?
+2. Trägt jede Entscheidung Stufe, Optionen, Empfehlung (+ „Auswirkung" bei [S2]/[S3])?
+3. Abweichungen/Annahmen text-first benannt — nichts still gefüllt/abgewichen?
+4. Register: nur **registerwürdige** Punkte; Block materialisiert + `R<n>` korrekt fortgeschrieben; `↳`-Essenz bei Öffnen/Schließen; kein „angenommen" ohne aktiven Befehl; **keine `· braucht bestätigt`-Option per bare `w`/`ok`**; mutierende Befehle nur bei **eindeutiger** Lesart ausgeführt. **Bei Unsicherheit → `⚠ Register-Abgleich nötig` statt still weiterschreiben.**
+5. Marker-Ökonomie eingehalten — keine leeren Blöcke, [S3] nur bei echtem Härtefall?
+6. Kernaussage beantwortet: Empfehlung · was jetzt zu entscheiden · welche Bedingung entscheidet?
+
+## H — Integration mit dem Action Board (Präzedenz)
+In Umgebungen mit einer eigenen **Action-Board-Hausregel** (Standard für ≥3 Action-Items oder Cross-Repo/PR, Spalten Repo · PR/Issue/ADR · Status · Next Step):
+- **Das Action Board hält die Wahrheit fürs Render** getrackter Arbeitsitems. Sind Punkte repo/PR-gebunden und ≥3 → Offen/Entscheidung **als Action Board rendern**; die Schablone steuert nur ihre Marker ([S1–3], ↪, 🧩, ⚠) und „Schweigen≠Zustimmung" *innerhalb* der Zellen bei.
+- **Ein Render pro Item (Anti-Doppel-ID):** Ein Item erscheint **entweder** als Action-Board-Zeile **oder** als O-Register-Punkt, **nie beides zugleich**. Das verhindert zwei konkurrierende ID-Systeme und Mapping-Fehler. Sonst (reine Design-Chats, Tools ohne Board) → Schablone-eigene Blöcke (E).
+- **Befehlsgrammatik bleibt Schablone-only:** `O{N} ok` etc. wirken aufs Register, nicht auf Board-Zeilen (globale Hausregel bleibt unberührt — kleinster Wirkradius).
+- **Chat-lokale Modell-Regel:** Erwartet der Nutzer **zweimal in diesem Chat**, dass ein Schablone-Befehl eine Board-Zeile schließt, biete ich die Umstellung (Grammatik auf Board-Zeilen) **einmal aktiv an** — statt still zu raten.
+- **Human-facing Meta-Notiz (nicht vom Modell prüfbar):** Die Grundsatz-Umstellung „Grammatik dauerhaft auf Board-Zeilen" ist eine Entscheidung des Maintainers außerhalb des Chats — Evidenz (z. B. „≥3× über mehrere Sessions") sammelt der Mensch, nicht das stateless Modell. Diese Zeile dokumentiert nur den Anlass; sie ist keine Laufzeitregel.
+
+---
+
+## Beispiele (Referenz-Renders)
+
+**1 — Kompakt (Sachfrage, keine Wahl):**
+> `parse_invoice()` in `services/billing.py` validiert und normalisiert die Rohdaten — das ist die gesuchte Methode. Kein weiterer Schritt nötig.
+
+**2 — Struktur (eine reversible Entscheidung):**
+> **Kernaussage:** Ja, Caching lohnt — Read-Through mit kurzer TTL. Die Wahl hängt nur an deiner Staleness-Toleranz.
+>
+> **Annahme 🧩:** Du meinst die Dashboard-Abfrage. Falls anders — sag welche.
+>
+> **Entscheidung 1 · [S2] reversible Wahl 🟡 — Cache-TTL**
+> - a) 30 s — fast immer frisch. *Auswirkung:* DB-Last −20 %.
+> - b) 5 min — hohe Hit-Rate, Staleness möglich. *Auswirkung:* DB-Last −70 %, Zahlen bis 5 min alt.
+> - **Empfehlung: a.** Bestätigen: `1a` · ablehnen: `1 weg`.
+
+**3 — `weiter, 1 offen` → nächste Antwort befördert (mit `↳`-Essenz, R steigt):**
+> Verstanden, lasse 1 offen.
+> ```
+> 📌 Register · R1
+> O1 · Entscheidung · Cache-TTL Dashboard-Abfrage (war 1) · offen · seit R1
+>   ↳ Kontext: Dashboard leselastig · Optionen: 30 s / 5 min · noch offen
+> ```
+
+**4 — `O1a` (Schluss, R steigt, Essenz festgehalten):**
+> O1 geschlossen mit Option a. ✓
+> ```
+> 📌 Register · R2
+> O1 · Entscheidung · Cache-TTL Dashboard-Abfrage · angenommen(O1a, R2) ✓
+>   ↳ Kontext: Dashboard leselastig · gewählt: a) 30 s TTL · Zustimmung: O1a, R2
+> ```
+
+**5 — Misch-Stufen + bare `w` (optionsgebundene [S3]-Friktion):** Entscheidung 1 `[S2]`; Entscheidung 2 `[S3]` mit Option a) *jetzt scharfschalten* `· braucht bestätigt` und b) *vertagen* (reversibel, Empfehlung). Nutzer schreibt `w`:
+> `w`: Entscheidung 1 (Option a) angenommen **und** Entscheidung 2 → **b (vertagen)** angenommen — beide nicht bestätigungspflichtig. Nur **2a** (jetzt scharfschalten) hätte `2a bestätigt` gebraucht.
+
+**6 — `O1 auf` (Wiedereröffnung mit Grund + Protokoll):**
+> O1 wieder offen. Grund? (eine Zeile)
+> ```
+> 📌 Register · R3
+> O1 · Entscheidung · Cache-TTL Dashboard-Abfrage · offen (erneut) · seit R3
+>   ↳ ersetzt in R3 (vorher: a) 30 s, angenommen R2) · Grund: <wird erfragt>
+> ```
+
+**7 — `park: Index-Strategie` (Vertagung mit Bedingung):**
+> Vertagt. Wiedervorlage-Anlass? (sonst frage ich nach)
+> ```
+> 📌 Register · R4
+> O2 · Frage · Index-Strategie · vertagt(bis <Anlass>) · seit R4
+> ```
+
+**8 — Action-Board-Präzedenz (≥3 repo-gebundene Items):** Render als Action Board (dessen Layout), Schablone-Marker in den Zellen, **kein** paralleler O-Register-Block für dieselben Zeilen (ein Render pro Item, H).
+
+**9 — Eindeutige Variante vs. Mehrdeutigkeit (Grammatik, F):**
+> `01 ok bestätigt` → als `O1 ok bestätigt` ausgeführt (Null↔O, genau eine Lesart). · `ok 1` → Rückfrage: „O1 (Register) oder Entscheidung 1?" — zwei Lesarten, **keine** Mutation.
+
+*Dogfood:* Die Renders sind von Hand gegen die Spec geprüft. Echter Live-Test: `#antwort_modus_schablone` in einem realen Chat setzen und `1a`, `weiter, 1 offen`, `w` bei optionsgebundener [S3], `O1 auf`, `park:`, `register prüfen`, `#selbstcheck repair`, `ok 1` (Mehrdeutigkeit), `#antwort_modus_aus` durchspielen — `R<n>` und Blockstand müssen konsistent bleiben.
+
+## Begründungen (Referenz, nicht bei jeder Antwort anzuwenden)
+- **text-first (B):** Farbe allein als Code verletzt WCAG 1.4.1; Screenreader lesen Objektnamen („yellow circle") statt Funktion; Emoji-Darstellung variiert je System, der Text bleibt erhalten.
+- **Materialisierung ehrlich (E):** Sie ist die naheliegendste Technik unter „kein externer State", aber kein Persistenz-Beweis — der Repair-Pfad existiert, weil korrektes Fortschreiben über viele Turns nicht garantiert ist.
+- **Registerwürdigkeit (E):** Das Langzeitrisiko ist nicht Speicherverlust, sondern Register-Creep; die Schwelle „muss über den Turn hinaus erinnert werden" + lokale [S1] hält das Register klein und salient.
+- **Friktion optionsgebunden (B/F):** Die `bestätigt`-Pflicht schützt die *irreversible Option*, nicht die Entscheidung — eine vorsichtige Wahl (vertagen) einer [S3] ist reversibel und braucht keine Sonderfriktion. **Eindeutigkeit statt Schreibweise (F):** eine eindeutige Eingabe ist kein Risiko; nur Mehrdeutigkeit darf eine Statusänderung blocken.
+
+## Changelog
+- 2026-06-05 (v2.3): **F1 — [S3]-Friktion optionsgebunden** statt entscheidungsgebunden: nur die mit `· braucht bestätigt` markierte irreversible Option verlangt `bestätigt`; `w` nimmt reversible [S3]-Optionen (z. B. vertagen) mit an. **F2 — Eindeutigkeit statt kanonischer Schreibweise** als Gate für mutierende Befehle: eindeutige Varianten (`1 b`, `01`, `4 ja`) werden ausgeführt, nur ≥2 Lesarten (`ok 1`) lösen eine Rückfrage aus. Beispiel 5 angepasst, Beispiel 9 ergänzt, G/Begründungen aktualisiert. Quelle: Live-Dogfood v2.2 (Doc-Health-Gate-Rollout), Findings F1/F2.
+- 2026-06-05 (v2.2): **Registerwürdigkeit** + gedämpfte Beförderung (nur [S2]/[S3] + offengelassen; [S1] lokal). **Repair/Reconciliation** (`⚠ Register-Abgleich nötig`, `register prüfen`, `#selbstcheck repair`). **`R<n>` Register-Revision statt `T<n>`**. **Karten-Essenz als `↳`-Delta** statt latenter Rekonstruktion. **Grammatik-Toleranz nur ohne Statuswirkung**. **Bloat-Bremse** (>3 Entscheidungen → Übersicht). **„echte Entscheidung" enger definiert** (≥2 Optionen + Folgen). **Action Board: ein Render pro Item** + Revisit-Trigger getrennt (chat-lokale Modell-Regel vs. human-Meta-Notiz). Materialisierung ehrlicher formuliert; `kurz` präzisiert; Begründungen ans Ende (Regeln nach vorn). Quelle: externes Review v2.1 (REC-1…20, Rückfluss-Gate getaggt).
+- 2026-06-05 (v2.1): Register materialisiert (copy-forward Block, Turn-Achse), [S3] braucht Bestätigung, `#antwort_modus_aus`, `#selbstcheck`, Beispiele, Action-Board-Präzedenz (Option C).
+- 2026-06-04 (v2.0): Zwei Modi, text-first Marker, ADR-Light-Register, Kurzbefehle, Pre-Send-Prüfung.

--- a/tools/cc-skill-dist/README.md
+++ b/tools/cc-skill-dist/README.md
@@ -1,7 +1,20 @@
 # cc-skill-dist — CC-Skill-Distribution-Tooling (platform:ADR-230)
 
-Werkzeuge zur deterministischen Verteilung der Skills aus der **einen kanonischen Quelle**
-(platform `main` `.windsurf/workflows/`) nach `~/.claude/commands/` — gemäß ADR-230 (CC-first).
+Werkzeuge zur deterministischen Verteilung aus der **einen kanonischen Quelle** (platform `main`)
+— gemäß ADR-230 (CC-first). Zwei Lanes über `--kind`:
+
+| `--kind` | Quelle (platform) | Live-Ziel | Form |
+|----------|-------------------|-----------|------|
+| `commands` (Default) | `.windsurf/workflows/*.md` | `~/.claude/commands/` | flach (Slash-Commands) |
+| `skills` | `skills/<name>/SKILL.md` | `~/.claude/skills/<name>/SKILL.md` | verschachtelt (Anthropic Agent Skills) |
+
+**Enterprise-weit = user-level Install pro Maschine, NICHT Kopie in N Repos.** CC lädt
+`~/.claude/skills` + `~/.claude/commands` in jeder Session/jedem Repo/jeder Org — ein Install
+deckt alles ab, die Kanonik bleibt SSoT in platform (Drift-Vermeidung). Beispiele:
+```bash
+python3 tools/cc-skill-dist/generate.py --kind skills --target /tmp/skills-staging
+python3 tools/cc-skill-dist/doctor.py   --kind skills        # Drift Quelle ↔ ~/.claude/skills
+```
 
 ## `doctor.py` — read-only Drift-Diagnose (ADR-230 REC-9)
 

--- a/tools/cc-skill-dist/doctor.py
+++ b/tools/cc-skill-dist/doctor.py
@@ -1,27 +1,32 @@
 #!/usr/bin/env python3
 """doctor.py — read-only Drift-Diagnose für CC-Skill-Distribution (platform:ADR-230).
 
-Vergleicht die branch-stabile kanonische Quelle (platform `origin/main`
-`.windsurf/workflows/`) mit dem live `~/.claude/commands/` — OHNE etwas zu ändern.
-Meldet: stale Kopien, dangling Symlinks, fehlende/zusätzliche Skills, Hybrid-Status.
+Vergleicht die branch-stabile kanonische Quelle (platform `origin/main`) mit dem
+Live-Ziel — OHNE etwas zu ändern. Meldet stale Kopien, dangling Symlinks,
+fehlende/zusätzliche Skills, Hybrid-Status und einen Drift-Score.
 
-Usage: doctor.py [--platform ~/github/platform] [--commands ~/.claude/commands] [--ref origin/main]
+Zwei Lanes (`--kind`):
+- `commands` (Default): `.windsurf/workflows/*.md` ↔ `~/.claude/commands/` (flach).
+- `skills`: `skills/<name>/SKILL.md` ↔ `~/.claude/skills/<name>/SKILL.md` (Agent Skills,
+  verzeichnis-basiert). Der Relativlink-Guard greift NICHT — Agent-Skill-Verzeichnisse
+  dürfen gebündelte Relativ-Referenzen tragen.
+
+Usage: doctor.py [--kind commands|skills] [--platform ~/github/platform]
+                 [--commands ~/.claude/commands] [--skills-dir ~/.claude/skills] [--ref origin/main]
 """
 import argparse, os, re, subprocess, sys
 
-# Relativlink-Guard (ADR-175-Amendment / Audit-F1): das Ziel ~/.claude/commands ist FLACH
-# (eine Datei pro Skill, keine Subdirs). Ein Markdown-Link mit Pfad-Slash (z.B.
-# `](../../docs/x.md)`) ist dort grundsätzlich unauflösbar → dangling. http(s)/Anker/mailto
-# sind ok. Fängt die Wiedereinführung ausgelagerter Lookups (die F1 verursacht haben).
-# Verlangt Pfad-Slash UND eine echte Datei-Endung, damit dokumentierte Regex/sed-Snippets
-# in Code-Blöcken (z.B. `s#...([^/]+)/...#`) NICHT als Link fehl-matchen.
+# Relativlink-Guard (nur Lane `commands`): das flache Ziel ~/.claude/commands kann keine
+# Pfad-Slash-Links auflösen → dangling. http(s)/Anker/mailto sind ok. Verlangt Pfad-Slash
+# UND echte Datei-Endung, damit Regex/sed-Snippets in Code-Blöcken nicht fehl-matchen.
 REL_LINK = re.compile(
     r"\]\((?!https?://|#|mailto:)([^)\s]*/[^)\s]*\.(?:md|markdown|ya?ml|sh|py|txt|json|toml))\)")
 
-# Footer, den generate.py an jede verteilte Kopie anhängt (MANAGED-BY-Marke).
-# doctor muss ihn vor dem Inhaltsvergleich abstreifen, sonst liest sich jede
-# korrekt generierte Kopie fälschlich als copy-stale (Footer ≠ nackter Blob).
 MARK = "MANAGED-BY: platform/tools/cc-skill-dist"
+
+# Lane: (Quell-Pfad im Repo, Blob-Endung, key-Extraktor aus repo-Pfad, Live-Ziel, Ziel-Enumerator)
+def _name_basename(path): return os.path.basename(path)
+def _name_skilldir(path): return os.path.basename(os.path.dirname(path))
 
 def strip_managed_footer(text):
     idx = text.rfind("<!-- " + MARK)
@@ -31,34 +36,55 @@ def git(args, cwd):
     r = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
     return r.stdout if r.returncode == 0 else None
 
+def enumerate_commands(root):
+    """Flaches Ziel: name -> Pfad zur .md-Datei."""
+    if not os.path.isdir(root):
+        return {}
+    return {f: os.path.join(root, f) for f in os.listdir(root) if f.endswith(".md")}
+
+def enumerate_skills(root):
+    """Verzeichnis-Ziel: name -> Pfad zur <name>/SKILL.md."""
+    if not os.path.isdir(root):
+        return {}
+    out = {}
+    for d in os.listdir(root):
+        p = os.path.join(root, d, "SKILL.md")
+        if os.path.isfile(p) or os.path.islink(p):
+            out[d] = p
+    return out
+
 def main():
     ap = argparse.ArgumentParser()
+    ap.add_argument("--kind", choices=["commands", "skills"], default="commands")
     ap.add_argument("--platform", default=os.path.expanduser("~/github/platform"))
     ap.add_argument("--commands", default=os.path.expanduser("~/.claude/commands"))
+    ap.add_argument("--skills-dir", default=os.path.expanduser("~/.claude/skills"))
     ap.add_argument("--ref", default="origin/main")
     a = ap.parse_args()
 
+    if a.kind == "commands":
+        src_path, suffix, key_of = ".windsurf/workflows/", ".md", _name_basename
+        target_dir, target_files, rel_guard = a.commands, enumerate_commands(a.commands), True
+    else:
+        src_path, suffix, key_of = "skills/", "/SKILL.md", _name_skilldir
+        target_dir, target_files, rel_guard = a.skills_dir, enumerate_skills(a.skills_dir), False
+
     git(["fetch", "origin", "main", "-q"], a.platform)
-    # Kanonische Quelle: blob-sha = inhalts-adressiert, branch-stabil
-    listing = git(["ls-tree", "-r", a.ref, ".windsurf/workflows/"], a.platform) or ""
+    listing = git(["ls-tree", "-r", a.ref, src_path], a.platform) or ""
     canon = {}  # name -> blob_sha
     for line in listing.splitlines():
-        # <mode> blob <sha>\t<path>
-        parts = line.split()
-        if len(parts) >= 4 and parts[1] == "blob" and parts[-1].endswith(".md"):
-            canon[os.path.basename(parts[-1])] = parts[2]
+        parts = line.split()  # <mode> blob <sha>\t<path>
+        if len(parts) >= 4 and parts[1] == "blob" and parts[-1].endswith(suffix):
+            canon[key_of(parts[-1])] = parts[2]
     if not canon:
-        print(f"FEHLER: keine kanonischen Workflows unter {a.ref}:.windsurf/workflows/"); sys.exit(2)
+        print(f"FEHLER: keine kanonischen Quellen unter {a.ref}:{src_path} (kind={a.kind})"); sys.exit(2)
 
     def canon_content(sha):
         return git(["cat-file", "blob", sha], a.platform)
 
-    cmd_files = {f: os.path.join(a.commands, f) for f in os.listdir(a.commands) if f.endswith(".md")} \
-        if os.path.isdir(a.commands) else {}
-
     sym_ok = sym_stale = sym_dangling = copy_fresh = copy_stale = extra = 0
     issues = []
-    for name, path in sorted(cmd_files.items()):
+    for name, path in sorted(target_files.items()):
         is_link = os.path.islink(path)
         if name not in canon:
             extra += 1; issues.append(("extra", name, "im Ziel, aber nicht in der Quelle")); continue
@@ -77,23 +103,23 @@ def main():
             if same: copy_fresh += 1
             else: copy_stale += 1; issues.append(("copy-stale", name, "Kopie ≠ Quelle (veraltet)"))
 
-    # Relativlink-Guard: scanne ALLE kanonischen Workflows (unabhängig vom Ziel-Zustand,
-    # damit der Check auch in CI mit leerem ~/.claude/commands greift).
     rel_links = 0
-    for name, sha in sorted(canon.items()):
-        body = canon_content(sha) or ""
-        for m in REL_LINK.finditer(body):
-            rel_links += 1
-            issues.append(("rel-link", name, f"unauflösbarer Relativlink im flachen Ziel → {m.group(1)}"))
+    if rel_guard:
+        for name, sha in sorted(canon.items()):
+            body = canon_content(sha) or ""
+            for m in REL_LINK.finditer(body):
+                rel_links += 1
+                issues.append(("rel-link", name, f"unauflösbarer Relativlink im flachen Ziel → {m.group(1)}"))
 
-    missing = sorted(set(canon) - set(cmd_files))
+    missing = sorted(set(canon) - set(target_files))
 
-    print(f"=== CC-Skill-Doctor (Quelle: {a.ref}, {len(canon)} kanonische Workflows) ===")
-    print(f"  Ziel {a.commands}: {len(cmd_files)} Dateien")
+    print(f"=== CC-Skill-Doctor (kind={a.kind}, Quelle: {a.ref}, {len(canon)} kanonisch) ===")
+    print(f"  Ziel {target_dir}: {len(target_files)} Einträge")
     print(f"  Symlinks ok={sym_ok}  symlink-stale={sym_stale}  dangling={sym_dangling}")
     print(f"  Kopien fresh={copy_fresh}  copy-stale={copy_stale}")
     print(f"  extra (nicht in Quelle)={extra}  fehlend (in Quelle, nicht im Ziel)={len(missing)}")
-    print(f"  rel-links (unauflösbar im flachen Ziel)={rel_links}")
+    if rel_guard:
+        print(f"  rel-links (unauflösbar im flachen Ziel)={rel_links}")
     print(f"  Hybrid? {'JA — Symlinks UND Kopien gemischt' if (sym_ok+sym_stale+sym_dangling)>0 and (copy_fresh+copy_stale)>0 else 'nein'}")
     if missing:
         print("  fehlende Skills:", ", ".join(missing[:10]) + (" …" if len(missing) > 10 else ""))

--- a/tools/cc-skill-dist/generate.py
+++ b/tools/cc-skill-dist/generate.py
@@ -1,23 +1,37 @@
 #!/usr/bin/env python3
 """generate.py — deterministischer CC-Skill-Generator (platform:ADR-230, PROTOTYP).
 
-Erzeugt aus der branch-stabilen Quelle (platform <ref> `.windsurf/workflows/`,
-auf einen **resolved Commit** aufgelöst) ein Ziel-Verzeichnis mit:
+Erzeugt aus der branch-stabilen Quelle (platform <ref>, auf einen **resolved Commit**
+aufgelöst) ein Ziel-Verzeichnis mit:
 - generierten Kopien, jede mit MANAGED-Footer (source_commit, content_hash, do_not_edit)
 - `MANAGED_BY` (erlaubter Writer, Commit, Regen-Kommando)
-- `manifest.json` (source_repo/commit, generator_version, timestamp, files+hashes)
+- `manifest.json` (source_repo/commit, generator_version, kind, timestamp, files+hashes)
 
-Atomar: erst nach `<target>.tmp`, dann Rename-Swap. **Determinismus:** gleicher
-resolved Commit + gleiche Generator-Version ⇒ bit-identische Kopien + Manifest
-(Zeitstempel separat, nicht hash-relevant).
+Zwei Lanes (`--kind`):
+- `commands` (Default): `.windsurf/workflows/*.md` → **flach** nach `~/.claude/commands/`
+  (CC-Slash-Commands).
+- `skills`: `skills/<name>/SKILL.md` → **verschachtelt** nach `~/.claude/skills/<name>/SKILL.md`
+  (Anthropic Agent Skills, user-level → gelten in JEDER Session / jedem Repo / jeder Org,
+  ohne Repo-Kopie). Genau deshalb braucht eine Agent-Skill KEINE Verteilung in N Repos —
+  ein generierter Install pro Maschine deckt alles ab; die Kanonik bleibt SSoT in platform.
 
-SICHERHEIT: `--target` ist Pflicht; schreibt NIE nach `~/.claude/commands` ohne
-explizites `--allow-live` (im Prototyp nicht genutzt). Default = Staging.
+Atomar: erst `<target>.tmp`, dann Rename-Swap (+ `.bak`). **Determinismus:** gleicher
+resolved Commit + Generator-Version ⇒ bit-identische Kopien + Manifest (Zeitstempel
+separat, nicht hash-relevant).
+
+SICHERHEIT: `--target` ist Pflicht; schreibt NIE ins Live-Ziel der Lane ohne explizites
+`--allow-live`. Default = Staging.
 """
 import argparse, datetime, hashlib, json, os, shutil, subprocess, sys
 
-GENERATOR_VERSION = "0.1.0-prototype"
+GENERATOR_VERSION = "0.2.0-prototype"
 MARK = "MANAGED-BY: platform/tools/cc-skill-dist"
+
+# Lane-Konfiguration: Quell-Pfad im Repo + Live-Ziel (ohne --allow-live gesperrt).
+LANES = {
+    "commands": {"src": ".windsurf/workflows/", "live": "~/.claude/commands"},
+    "skills":   {"src": "skills/",              "live": "~/.claude/skills"},
+}
 
 def git(args, cwd):
     r = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
@@ -25,27 +39,43 @@ def git(args, cwd):
         sys.exit(f"git {' '.join(args)} fehlgeschlagen: {r.stderr[:200]}")
     return r.stdout
 
+def collect(listing, kind):
+    """Quell-Blobs → name -> (blob_sha, repo_pfad).
+    commands: *.md, key=basename (flach). skills: */SKILL.md, key=Skill-Verzeichnisname."""
+    blobs = {}
+    for line in listing.splitlines():
+        p = line.split()
+        if len(p) < 4 or p[1] != "blob":
+            continue
+        path = p[-1]
+        if kind == "commands" and path.endswith(".md"):
+            blobs[os.path.basename(path)] = (p[2], path)
+        elif kind == "skills" and path.endswith("/SKILL.md"):
+            blobs[os.path.basename(os.path.dirname(path))] = (p[2], path)
+    return blobs
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--platform", default=os.path.expanduser("~/github/platform"))
     ap.add_argument("--ref", default="origin/main")
-    ap.add_argument("--target", required=True, help="Ziel-Verzeichnis (Staging). NIE ~/.claude/commands ohne --allow-live")
+    ap.add_argument("--kind", choices=list(LANES), default="commands",
+                    help="commands = Slash-Commands (flach, Default); skills = Agent Skills (verschachtelt)")
+    ap.add_argument("--target", required=True, help="Ziel-Verzeichnis (Staging). Live nur mit --allow-live")
     ap.add_argument("--allow-live", action="store_true")
     args = ap.parse_args()
 
+    lane = LANES[args.kind]
     target = os.path.abspath(os.path.expanduser(args.target))
-    live = os.path.abspath(os.path.expanduser("~/.claude/commands"))
+    live = os.path.abspath(os.path.expanduser(lane["live"]))
     if target == live and not args.allow_live:
-        sys.exit("ABBRUCH: Ziel ist ~/.claude/commands — Prototyp schreibt nicht live (--allow-live nötig).")
+        sys.exit(f"ABBRUCH: Ziel ist {lane['live']} — Prototyp schreibt nicht live (--allow-live nötig).")
 
     git(["fetch", "origin", "main", "-q"], args.platform)
     commit = git(["rev-parse", args.ref], args.platform).strip()
-    listing = git(["ls-tree", "-r", args.ref, ".windsurf/workflows/"], args.platform)
-    blobs = {}  # name -> blob_sha
-    for line in listing.splitlines():
-        p = line.split()
-        if len(p) >= 4 and p[1] == "blob" and p[-1].endswith(".md"):
-            blobs[os.path.basename(p[-1])] = (p[2], p[-1])
+    listing = git(["ls-tree", "-r", args.ref, lane["src"]], args.platform)
+    blobs = collect(listing, args.kind)
+    if not blobs:
+        sys.exit(f"ABBRUCH: keine Quellen unter {args.ref}:{lane['src']} (kind={args.kind})")
 
     staging = target + ".tmp"
     if os.path.exists(staging):
@@ -53,7 +83,7 @@ def main():
     os.makedirs(staging)
 
     manifest = {"source_repo": "achimdehnert/platform", "source_commit": commit,
-                "generator_version": GENERATOR_VERSION,
+                "generator_version": GENERATOR_VERSION, "kind": args.kind,
                 "generated_at": datetime.datetime.now(datetime.UTC).isoformat(),
                 "target_type": "copy", "skill_count": len(blobs), "files": []}
     for name, (bsha, path) in sorted(blobs.items()):
@@ -61,15 +91,21 @@ def main():
         chash = hashlib.sha256(src.encode("utf-8")).hexdigest()
         footer = (f"\n\n<!-- {MARK} · generated=true · source={path} · "
                   f"source_commit={commit[:12]} · content_hash=sha256:{chash[:16]} · do_not_edit -->\n")
-        open(os.path.join(staging, name), "w", encoding="utf-8").write(src.rstrip("\n") + footer)
+        content = src.rstrip("\n") + footer
+        if args.kind == "commands":
+            out = os.path.join(staging, name)
+        else:  # skills: <name>/SKILL.md
+            os.makedirs(os.path.join(staging, name), exist_ok=True)
+            out = os.path.join(staging, name, "SKILL.md")
+        open(out, "w", encoding="utf-8").write(content)
         manifest["files"].append({"name": name, "source_path": path, "content_hash": "sha256:" + chash})
 
     json.dump(manifest, open(os.path.join(staging, "manifest.json"), "w"), indent=2)
     open(os.path.join(staging, "MANAGED_BY"), "w").write(
-        f"managed_by: platform/tools/cc-skill-dist/generate.py\n"
+        f"managed_by: platform/tools/cc-skill-dist/generate.py (kind={args.kind})\n"
         f"allowed_writer: cc-skill-dist generator only — KEINE Handänderung\n"
         f"source: achimdehnert/platform @ {commit}\n"
-        f"regenerate: python3 tools/cc-skill-dist/generate.py --target {target}\n")
+        f"regenerate: python3 tools/cc-skill-dist/generate.py --kind {args.kind} --target {target}\n")
 
     # Atomarer Swap
     backup = target + ".bak"
@@ -79,9 +115,9 @@ def main():
         os.replace(target, backup)
     os.replace(staging, target)
 
-    print(f"=== generate.py (PROTOTYP) — resolved commit {commit[:12]} ===")
+    print(f"=== generate.py (PROTOTYP) — kind={args.kind}, resolved commit {commit[:12]} ===")
     print(f"  Ziel: {target}")
-    print(f"  generiert: {len(blobs)} Skills + manifest.json + MANAGED_BY")
+    print(f"  generiert: {len(blobs)} {args.kind} + manifest.json + MANAGED_BY")
     print(f"  Backup voriger Stand: {backup if os.path.exists(backup) else '—'}")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Was

Etabliert **Anthropic Agent Skills** als eigene, zentral verwaltete Verteil-Lane — SSoT in `platform`, kein Kopieren in N Repos.

- **(a) Kanonik:** `skills/antwort-modus-schablone/SKILL.md` (v2.3) als SSoT.
- **(c) Tooling:** `cc-skill-dist` um `--kind skills` erweitert (generate.py → 0.2.0, doctor.py). Quelle `skills/<name>/SKILL.md` → Ziel `~/.claude/skills/<name>/SKILL.md` (verzeichnis-basiert). `commands`-Lane bleibt Default + unverändert. Relativlink-Guard nur `commands`.
- **(d) Policy:** `claude-skills.md` — Agent Skills als eigener Artefakttyp + Lane; Leitsatz **„enterprise-weit = user-level Install pro Maschine, nicht Kopie in N Repos"**.

## Warum so (nicht „in alle Repos verteilen")

Eine user-level Agent-Skill ist in **jeder** CC-Session / jedem Repo / jeder Org aktiv — **ein** Install pro Maschine deckt alles ab. Kopien in ~60 Repos = genau die Drift, die SSoT vermeidet. ChatGPT/Gemini bewusst **außerhalb** des Verteil-Scopes (kein Datei-Konsum-Mechanismus → paste-aus-Kanonik / Custom GPT / Gem).

Kein ADR: folgt dem bestehenden cc-skill-dist-Muster → Policy-Update genügt (`adr-threshold`).

## Dogfood (Smoke-Test gegen Branch-HEAD)

```
generate.py --kind skills → 1 skills + manifest(kind=skills) + MANAGED_BY; Footer in Kopie = 1 ✓
doctor.py   --kind skills → Kopien fresh=1, DRIFT-SCORE: 0 ✓
Regression commands-Lane (Default) → 76 .md generiert ✓
```

## Review-Gate (claude-skills.md)
- [x] Dogfood-Test dokumentiert (oben)
- [x] Tooling-Determinismus (MANAGED-Footer/Manifest/Swap unverändert)
- [x] Anti-Patterns/Gates: Live nur mit `--allow-live`; Quelle nackt, Kopie trägt Footer
- [x] CHANGELOG/Policy-Eintrag

## Herkunft
Bogen: Deep-Review → v2.1 → externes Review (Rückfluss-Gate) → v2.2 → Live-Dogfood → Findings F1/F2 → v2.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)