### PR TITLE
feat(guard): main-tree-guard fängt Commit-auf-main framework-unabhängig (Retro #5)

### DIFF
--- a/tools/main-tree-guard.sh
+++ b/tools/main-tree-guard.sh
@@ -40,8 +40,23 @@ cmd_install() {
 exec "$self" hook "\$@"
 HOOK
   chmod +x "$hook"
-  echo "✓ Guard installiert: Sentinel $repo/$SENTINEL + post-checkout-Hook."
-  echo "  Hinweis: harte Blockade nur via repo-session-Wrapper; dieser Hook = Snap-back + Metrik."
+  # Nativer pre-commit-Hook (Retro 2026-06-05 #5): aktiviert den precommit-check OHNE das
+  # Python-pre-commit-Framework (das oft nicht installiert ist → Guard war dormant, #5 rutschte durch).
+  local pchook="$hookdir/pre-commit"
+  if [ -e "$pchook" ] && ! grep -q 'main-tree-guard' "$pchook" 2>/dev/null; then
+    echo "  ⚠️  pre-commit-Hook existiert bereits und ist fremd: $pchook — NICHT überschrieben." >&2
+    echo "      (Nutzt du das pre-commit-Framework, ist der Check via .pre-commit-config.yaml aktiv.)" >&2
+  else
+    cat > "$pchook" <<HOOK
+#!/usr/bin/env bash
+# installed by main-tree-guard (ADR-233) — nativer Backstop, kein Framework nötig
+exec "$self" precommit-check
+HOOK
+    chmod +x "$pchook"
+    echo "✓ nativer pre-commit-Hook gesetzt."
+  fi
+  echo "✓ Guard installiert: Sentinel $repo/$SENTINEL + post-checkout- + pre-commit-Hook."
+  echo "  Hinweis: harte Commit-Blockade jetzt auch ohne pre-commit-Framework (nativer Hook)."
 }
 
 # git post-checkout args: <prev-HEAD> <new-HEAD> <branch-checkout-flag(1=branch,0=file)>
@@ -80,7 +95,21 @@ cmd_report() {
 # → der Hook greift NUR im Haupt-Tree. Fängt den HEAD-Flip-Commit-auf-main (Retro 2026-06-04 F2),
 # der vom post-checkout-Snap-back allein nicht verhindert wird.
 cmd_precommit_check() {
-  [ -e "$SENTINEL" ] || exit 0   # kein geschützter Haupt-Tree (oder Worktree) → erlauben
+  local head; head="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || echo DETACHED)"
+  # (1) Branch-Fallback (SENTINEL-UNABHÄNGIG): nie direkt auf main/master committen.
+  #     Fängt den Commit-auf-main (Retro 2026-06-05 #5) AUCH in Klons, in denen
+  #     'install' nie lief — der Hauptgrund des Rückfalls (Guard war dormant).
+  case "$head" in
+    main|master)
+      echo "BLOCK: main-tree-guard (ADR-233): Commit direkt auf '$head' unterbunden." >&2
+      echo "    Editierende Arbeit gehört in einen Feature-Branch / per-session Worktree:" >&2
+      echo "    git switch -c <branch>   |   git worktree add /tmp/<slug> -b <branch> origin/main" >&2
+      echo "    (Bewusster Override: git commit --no-verify)" >&2
+      exit 1 ;;
+  esac
+  # (2) Tree-Schutz (Sentinel): im heiligen Haupt-Tree wird gar nicht committet (auch nicht
+  #     auf einem Feature-Branch — editierende Arbeit gehört in einen per-session Worktree).
+  [ -e "$SENTINEL" ] || exit 0   # Worktree/ungeschützt + nicht-main → erlauben
   echo "BLOCK: main-tree-guard (ADR-233): Commit im heiligen Haupt-Tree unterbunden." >&2
   echo "    Editierende Arbeit gehört in einen per-session Worktree:" >&2
   echo "    git worktree add /tmp/<slug> -b <branch> origin/main   (oder 'repo-session start')." >&2


### PR DESCRIPTION
## Session-Retro 2026-06-05 Befund #5 (Wiederholung) → hartes Gate

**Diagnose:** Commit `7018909` landete erneut lokal auf `main` trotz `main-tree-guard` (8b9ac8c, ADR-233). Ursache: der Guard war **dormant** — in der Arbeitskopie war weder das Python-`pre-commit`-Framework installiert (Binary fehlte) noch der Sentinel (`install` nie gelaufen). Beides → `precommit-check` no-op + Hook feuert nie.

**Fix (2 Lücken):**
1. `precommit-check` bekommt einen **Branch-Fallback** (`main`/`master`), der **sentinel-unabhängig** blockt → fängt Commit-auf-main auch in frischen Klons ohne `install`.
2. `install` wirt zusätzlich einen **nativen `.git/hooks/pre-commit`** → der Check funktioniert **ohne** das oft-fehlende pre-commit-Framework (Fremd-Hook-Schutz inklusive).

**Getestet (lokal, 4 Pfade):** main/kein-Sentinel→block · feat/kein-Sentinel→allow · install→3 Hooks+Sentinel · feat/Sentinel→block (Worktree-Konvention bleibt).

ADR-Threshold: reine Ergänzung nach ADR-233-Muster → kein neuer ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)