### PR TITLE
test(cc-skill-dist): skills-Lane CI-Coverage + Unit-Tests + regenerate-Fix (session-retro F-A/B/D)

### DIFF
--- a/.github/workflows/cc-skill-dist-doctor.yml
+++ b/.github/workflows/cc-skill-dist-doctor.yml
@@ -4,16 +4,24 @@ name: CC-Skill-Dist Round-Trip (ADR-230)
 # aus dem PR-Baum (generate.py) und prüft, dass doctor.py es als Drift 0 liest.
 # Fängt Tooling-Regresse (z.B. generate-Footer ≠ doctor-Vergleich) VOR dem
 # gegateten Live-Rollout. Braucht KEIN ~/.claude/commands — rein selbst-konsistent.
+# Deckt BEIDE Lanes ab (commands + skills) — session-retro 2026-06-05 F-A:
+# vorher lief nur die commands-Lane, die skills-Lane war CI-blind.
 
 on:
   push:
     paths:
       - "tools/cc-skill-dist/**"
+      - "tools/tests/test_generate.py"
+      - "tools/tests/test_doctor.py"
       - ".windsurf/workflows/**"
+      - "skills/**"
   pull_request:
     paths:
       - "tools/cc-skill-dist/**"
+      - "tools/tests/test_generate.py"
+      - "tools/tests/test_doctor.py"
       - ".windsurf/workflows/**"
+      - "skills/**"
 
 jobs:
   round-trip:
@@ -30,8 +38,17 @@ jobs:
 
       # Tools sind stdlib-only — keine pip-Deps. --platform = Checkout (nicht der
       # ~/github/platform-Default, der auf dem CI-Runner nicht existiert).
-      - name: Generate Distributions-Ziel aus PR-Baum
-        run: python3 tools/cc-skill-dist/generate.py --platform "$GITHUB_WORKSPACE" --ref HEAD --target /tmp/cc-roundtrip
+      - name: Round-Trip commands-Lane
+        run: |
+          python3 tools/cc-skill-dist/generate.py --platform "$GITHUB_WORKSPACE" --ref HEAD --target /tmp/cc-roundtrip
+          python3 tools/cc-skill-dist/doctor.py   --platform "$GITHUB_WORKSPACE" --ref HEAD --commands /tmp/cc-roundtrip
 
-      - name: Doctor gegen Erzeugnis — erwartet Drift 0
-        run: python3 tools/cc-skill-dist/doctor.py --platform "$GITHUB_WORKSPACE" --ref HEAD --commands /tmp/cc-roundtrip
+      - name: Round-Trip skills-Lane
+        run: |
+          python3 tools/cc-skill-dist/generate.py --kind skills --platform "$GITHUB_WORKSPACE" --ref HEAD --target /tmp/cc-roundtrip-skills
+          python3 tools/cc-skill-dist/doctor.py   --kind skills --platform "$GITHUB_WORKSPACE" --ref HEAD --skills-dir /tmp/cc-roundtrip-skills
+
+      - name: Unit-Tests (generate + doctor, beide Lanes)
+        run: |
+          pip install pytest --quiet --break-system-packages
+          python3 -m pytest tools/tests/test_generate.py tools/tests/test_doctor.py -q

--- a/tools/cc-skill-dist/generate.py
+++ b/tools/cc-skill-dist/generate.py
@@ -101,11 +101,14 @@ def main():
         manifest["files"].append({"name": name, "source_path": path, "content_hash": "sha256:" + chash})
 
     json.dump(manifest, open(os.path.join(staging, "manifest.json"), "w"), indent=2)
+    # --allow-live in die regenerate-Zeile aufnehmen, wenn das Ziel das Live-Verzeichnis
+    # ist — sonst läuft ein Copy-Paste des Befehls in den Guard (target==live) und bricht ab.
+    regen_live = " --allow-live" if target == live else ""
     open(os.path.join(staging, "MANAGED_BY"), "w").write(
         f"managed_by: platform/tools/cc-skill-dist/generate.py (kind={args.kind})\n"
         f"allowed_writer: cc-skill-dist generator only — KEINE Handänderung\n"
         f"source: achimdehnert/platform @ {commit}\n"
-        f"regenerate: python3 tools/cc-skill-dist/generate.py --kind {args.kind} --target {target}\n")
+        f"regenerate: python3 tools/cc-skill-dist/generate.py --kind {args.kind} --target {target}{regen_live}\n")
 
     # Atomarer Swap
     backup = target + ".bak"

--- a/tools/tests/test_doctor.py
+++ b/tools/tests/test_doctor.py
@@ -1,0 +1,97 @@
+"""Unit-/E2E-Tests für cc-skill-dist/doctor.py (session-retro 2026-06-05, F-A/F-B).
+
+Deckt die reinen Helfer (`strip_managed_footer`, `enumerate_commands`,
+`enumerate_skills`) und den e2e-Round-Trip der skills-Lane: generate → doctor == Drift 0,
+plus Drift-Erkennung bei manipulierter Kopie. Schließt F-A (skills-Lane war CI-blind).
+
+Run: `python3 -m pytest tools/tests/test_doctor.py -q`
+"""
+import importlib.util
+import pathlib
+import subprocess
+import sys
+
+_DOC = pathlib.Path(__file__).resolve().parents[1] / "cc-skill-dist" / "doctor.py"
+_GEN = pathlib.Path(__file__).resolve().parents[1] / "cc-skill-dist" / "generate.py"
+_spec = importlib.util.spec_from_file_location("doctor", _DOC)
+doc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(doc)
+
+MARK_FOOTER = ("\n\n<!-- MANAGED-BY: platform/tools/cc-skill-dist · generated=true · "
+               "source=skills/bar/SKILL.md · source_commit=abc123def456 · "
+               "content_hash=sha256:0123456789abcdef · do_not_edit -->\n")
+
+
+# ---------------------------------------------------------------- reine Helfer
+def test_should_strip_managed_footer():
+    assert doc.strip_managed_footer("content\n" + MARK_FOOTER).rstrip("\n") == "content"
+
+
+def test_should_not_strip_when_no_footer():
+    t = "plain content\nno footer\n"
+    assert doc.strip_managed_footer(t) == t
+
+
+def test_should_enumerate_only_dirs_with_skill_md(tmp_path):
+    (tmp_path / "alpha").mkdir()
+    (tmp_path / "alpha" / "SKILL.md").write_text("x")
+    (tmp_path / "beta").mkdir()
+    (tmp_path / "beta" / "SKILL.md").write_text("y")
+    (tmp_path / "nope").mkdir()                              # kein SKILL.md
+    assert set(doc.enumerate_skills(str(tmp_path))) == {"alpha", "beta"}
+
+
+def test_should_enumerate_flat_md_only(tmp_path):
+    (tmp_path / "a.md").write_text("x")
+    (tmp_path / "b.txt").write_text("y")
+    assert set(doc.enumerate_commands(str(tmp_path))) == {"a.md"}
+
+
+def test_should_return_empty_for_missing_dir():
+    assert doc.enumerate_skills(str(pathlib.Path("/nonexistent/xyz/123"))) == {}
+
+
+# ---------------------------------------------------------------- e2e round-trip
+def _git(root, *args):
+    subprocess.run(["git", *args], cwd=root, check=True, capture_output=True, text=True)
+
+
+def _make_repo(root):
+    root.mkdir(parents=True)
+    _git(root, "init", "-b", "main")
+    _git(root, "config", "user.email", "t@t.t")
+    _git(root, "config", "user.name", "t")
+    (root / "skills" / "bar").mkdir(parents=True)
+    (root / "skills" / "bar" / "SKILL.md").write_text("---\nname: bar\n---\n# bar\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-m", "init")
+    _git(root, "remote", "add", "origin", str(root))
+    _git(root, "fetch", "origin", "main", "-q")
+    return root
+
+
+def _doctor_skills(repo, skills_dir):
+    return subprocess.run(
+        [sys.executable, str(_DOC), "--kind", "skills", "--platform", str(repo),
+         "--ref", "HEAD", "--skills-dir", str(skills_dir)],
+        capture_output=True, text=True)
+
+
+def test_should_report_drift_zero_then_detect_tamper(tmp_path):
+    repo = _make_repo(tmp_path / "repo")
+    dist = tmp_path / "dist"
+    subprocess.run(
+        [sys.executable, str(_GEN), "--kind", "skills", "--platform", str(repo),
+         "--ref", "HEAD", "--target", str(dist)],
+        check=True, capture_output=True, text=True)
+
+    # frisch generiert → Drift 0
+    r = _doctor_skills(repo, dist)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "DRIFT-SCORE: 0" in r.stdout
+
+    # manipulierte Kopie → Drift erkannt (exit 1, score > 0)
+    (dist / "bar" / "SKILL.md").write_text("TAMPERED\n")
+    r2 = _doctor_skills(repo, dist)
+    assert r2.returncode == 1
+    assert "DRIFT-SCORE: 0" not in r2.stdout

--- a/tools/tests/test_generate.py
+++ b/tools/tests/test_generate.py
@@ -1,0 +1,132 @@
+"""Unit-/E2E-Tests für cc-skill-dist/generate.py (session-retro 2026-06-05, F-B).
+
+Schließt die Test-Lücke: +121 LOC Verteil-Tooling (commands + skills Lane) waren
+ungetestet. Deckt `collect()` (beide Lanes + Edge-Cases), den e2e-Generate (flach vs.
+verschachtelt), den `--allow-live`-Guard und die F-D-Regression (regenerate-Zeile trägt
+`--allow-live` bei Live-Ziel).
+
+Run: `python3 -m pytest tools/tests/test_generate.py -q`
+(generate.py über importlib geladen — collect() ist rein, der Rest via subprocess.)
+"""
+import importlib.util
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+_SRC = pathlib.Path(__file__).resolve().parents[1] / "cc-skill-dist" / "generate.py"
+_spec = importlib.util.spec_from_file_location("generate", _SRC)
+gen = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gen)
+
+
+# ---------------------------------------------------------------- collect() (rein)
+def test_should_collect_commands_by_basename():
+    listing = ("100644 blob aaa\t.windsurf/workflows/foo.md\n"
+               "100644 blob bbb\t.windsurf/workflows/bar.md\n")
+    out = gen.collect(listing, "commands")
+    assert set(out) == {"foo.md", "bar.md"}
+    assert out["foo.md"] == ("aaa", ".windsurf/workflows/foo.md")
+
+
+def test_should_collect_skills_by_dirname():
+    listing = ("100644 blob c1\tskills/alpha/SKILL.md\n"
+               "100644 blob c2\tskills/beta/SKILL.md\n")
+    out = gen.collect(listing, "skills")
+    assert set(out) == {"alpha", "beta"}
+    assert out["alpha"] == ("c1", "skills/alpha/SKILL.md")
+
+
+def test_should_ignore_non_skill_files_in_skills_lane():
+    listing = ("100644 blob c1\tskills/alpha/SKILL.md\n"
+               "100644 blob c2\tskills/alpha/README.md\n")
+    assert set(gen.collect(listing, "skills")) == {"alpha"}
+
+
+def test_should_ignore_non_md_in_commands_lane():
+    listing = ("100644 blob c1\t.windsurf/workflows/foo.md\n"
+               "100644 blob c2\t.windsurf/workflows/logo.png\n")
+    assert set(gen.collect(listing, "commands")) == {"foo.md"}
+
+
+def test_should_ignore_tree_lines():
+    listing = ("040000 tree ddd\tskills/alpha\n"
+               "100644 blob c1\tskills/alpha/SKILL.md\n")
+    assert set(gen.collect(listing, "skills")) == {"alpha"}
+
+
+# ---------------------------------------------------------------- e2e helpers
+def _git(root, *args):
+    subprocess.run(["git", *args], cwd=root, check=True, capture_output=True, text=True)
+
+
+def _make_repo(root):
+    """Minimal-Repo mit beiden Quellen + self-origin (generate.py fetcht origin main)."""
+    root.mkdir(parents=True)
+    _git(root, "init", "-b", "main")
+    _git(root, "config", "user.email", "t@t.t")
+    _git(root, "config", "user.name", "t")
+    (root / ".windsurf" / "workflows").mkdir(parents=True)
+    (root / ".windsurf" / "workflows" / "foo.md").write_text("# foo\nbody\n")
+    (root / "skills" / "bar").mkdir(parents=True)
+    (root / "skills" / "bar" / "SKILL.md").write_text("---\nname: bar\n---\n# bar\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-m", "init")
+    _git(root, "remote", "add", "origin", str(root))
+    _git(root, "fetch", "origin", "main", "-q")
+    return root
+
+
+def _run(args, env=None):
+    return subprocess.run([sys.executable, str(_SRC), *args],
+                          capture_output=True, text=True, env=env)
+
+
+def test_should_generate_commands_flat(tmp_path):
+    repo = _make_repo(tmp_path / "repo")
+    out = tmp_path / "out"
+    r = _run(["--platform", str(repo), "--ref", "HEAD", "--target", str(out)])
+    assert r.returncode == 0, r.stderr
+    assert (out / "foo.md").is_file()                       # flach
+    assert "MANAGED-BY" in (out / "foo.md").read_text()
+    m = json.loads((out / "manifest.json").read_text())
+    assert m["kind"] == "commands" and m["skill_count"] == 1
+
+
+def test_should_generate_skills_nested(tmp_path):
+    repo = _make_repo(tmp_path / "repo")
+    out = tmp_path / "out"
+    r = _run(["--kind", "skills", "--platform", str(repo), "--ref", "HEAD", "--target", str(out)])
+    assert r.returncode == 0, r.stderr
+    assert (out / "bar" / "SKILL.md").is_file()             # verschachtelt <name>/SKILL.md
+    assert "MANAGED-BY" in (out / "bar" / "SKILL.md").read_text()
+    assert json.loads((out / "manifest.json").read_text())["kind"] == "skills"
+
+
+def test_should_block_live_target_without_allow_live(tmp_path):
+    repo = _make_repo(tmp_path / "repo")
+    home = tmp_path / "home"
+    env = dict(os.environ, HOME=str(home))
+    live = home / ".claude" / "commands"                    # == lane["live"] unter HOME-Override
+    r = _run(["--platform", str(repo), "--ref", "HEAD", "--target", str(live)], env=env)
+    assert r.returncode != 0
+    assert "ABBRUCH" in r.stderr
+    assert not live.exists()                                # nichts geschrieben
+
+
+def test_should_carry_allow_live_in_regenerate_for_live_target(tmp_path):
+    """F-D-Regression: Live-Ziel → regenerate-Zeile MUSS --allow-live tragen, sonst
+    bricht ihr Copy-Paste am Guard ab."""
+    repo = _make_repo(tmp_path / "repo")
+    home = tmp_path / "home"
+    env = dict(os.environ, HOME=str(home))
+    live = home / ".claude" / "skills"
+    r = _run(["--kind", "skills", "--platform", str(repo), "--ref", "HEAD",
+              "--target", str(live), "--allow-live"], env=env)
+    assert r.returncode == 0, r.stderr
+    assert "--allow-live" in (live / "MANAGED_BY").read_text()
+    # Gegenprobe: ein Nicht-Live-Ziel trägt KEIN --allow-live.
+    out = tmp_path / "staging"
+    _run(["--kind", "skills", "--platform", str(repo), "--ref", "HEAD", "--target", str(out)], env=env)
+    assert "--allow-live" not in (out / "MANAGED_BY").read_text()


### PR DESCRIPTION
## Was
Folge-PR aus dem **session-retro 2026-06-05** (`~/shared/session-retro-2026-06-05-platform-fde7ff.md`) — schließt die 3 operativen Survivors aus dem Review von #477.

- **F-A (hoch):** `cc-skill-dist-doctor.yml` deckte nur die **commands**-Lane ab; die in #477 eingeführte **skills**-Lane war CI-blind (Gate lief mit Default `--kind commands`, `skills/**` fehlte im Trigger). → neuer **skills-Round-Trip-Step** (`generate --kind skills` → `doctor --kind skills` == Drift 0) + `skills/**` + Test-Pfade im Trigger.
- **F-B (mittel):** +121 LOC Verteil-Tooling ohne Unit-Test. → `test_generate.py` + `test_doctor.py` (**15 Tests**): `collect()`/`enumerate_*`/`strip_managed_footer` (beide Lanes + Edge-Cases), e2e-generate (flach vs. verschachtelt), `--allow-live`-Guard, Drift-0 + Tamper-Detection. Als **blocking** Step im Round-Trip-Workflow.
- **F-D (niedrig-mittel):** `generate.py` schrieb die `MANAGED_BY`-`regenerate:`-Zeile ohne `--allow-live` → Copy-Paste lief in den Guard. → bei Live-Ziel wird `--allow-live` ergänzt; Regression-Test deckt es.

## Dogfood
```
python3 -m pytest tools/tests/test_generate.py tools/tests/test_doctor.py -q  → 15 passed
generate --kind skills → doctor --kind skills (gegen HEAD)                    → DRIFT-SCORE: 0
```

## Scope-Bezug
Survivors F-H/F-F (PR-Atomarität, Issue-Tracking) + F-C (prototype-Label) + F-I (stale Ref) sind **nicht** hier — F-C/F-H/F-F sind Konventions-/Label-Entscheidungen (dein Zug), F-I ist eine lokale Git-Op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)