### PR TITLE
chore(tools): F1 sweep — drop resolved dev-hub temp-exclude

### DIFF
--- a/tools/f1-windsurf-sweep.sh
+++ b/tools/f1-windsurf-sweep.sh
@@ -22,8 +22,9 @@ APPLY="${F1_APPLY:-0}"; MERGE="${F1_MERGE:-0}"; ONLY="${F1_ONLY:-}"
 BR="chore/untrack-synced-windsurf"
 
 # --- TEMPORÄRE Exclude-Liste — Repos mit AKTIVER Arbeit (nach Abschluss ENTFERNEN!) ---
-#   dev-hub : 2026-06-01 aktiv von anderer Session bearbeitet (unmerged .windsurf). Revisit.
-EXCLUDE_TEMP="dev-hub"
+#   (leer 2026-06-06: dev-hub-Sweep abgeschlossen — die aktive Session von 2026-06-01 ist
+#    aufgelöst, PR #56/Traefik berührt kein .windsurf; F1-Flotte damit vollständig.)
+EXCLUDE_TEMP=""
 
 for d in "$GH"/*/; do
   rn=$(basename "$d"); [ -d "$d/.git" ] || continue; [ "$rn" = platform ] && continue


### PR DESCRIPTION
F1 `.windsurf`-Untrack-Sweep ist jetzt **flottenweit vollständig**: dev-hub als letztes Repo gesweept (achimdehnert/dev-hub#80, 0 synced `.windsurf/workflows` verbleibend, verifiziert via live API-Tree).

Der `EXCLUDE_TEMP="dev-hub"`-Eintrag in `tools/f1-windsurf-sweep.sh` war seit 2026-06-01 für eine aktive Fremd-Session gesetzt (Tool-Kommentar: „nach Abschluss ENTFERNEN!"). Diese Session ist aufgelöst (dev-hub#56/Traefik berührt kein `.windsurf`), daher wird der Exclude geleert.

Reiner Tooling-Cleanup, kein ADR nötig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)