### PR TITLE
feat(pilot): registry_coverage_drift multi-owner + Migrations-Erkennung (#488)

### DIFF
--- a/tools/registry_coverage_drift.py
+++ b/tools/registry_coverage_drift.py
@@ -1,16 +1,20 @@
 #!/usr/bin/env python3
 """registry_coverage_drift.py — KONZ-001 R5 „Liar-Liste" (read-only, Pilot Sprint 1, Issue #488).
 
-Vergleicht die **Org-Ground-Truth** (`gh repo list`) gegen die **SSoT** `registry/canonical.yaml`
-und meldet die Widerspruchsmenge — NICHT die Grün-Liste, sondern die *Lügen*-Liste:
-- ENROLLMENT-GAP: Repos, die auf GitHub existieren, aber NICHT in canonical eingeschrieben sind
-  (der „unsichtbare" Repo — die tödlichste Lücke, KONZ-001 §5b R8/§6).
-- PHANTOM: canonical-Einträge ohne Org-Repo (stale/falsch).
+Vergleicht die **Org-Ground-Truth über ALLE Owner** (`gh repo list` je Owner) gegen die **SSoT**
+`registry/canonical.yaml` und meldet die Widerspruchsmenge — die *Lügen*-Liste, nicht die Grün-Liste:
+- ENROLLMENT-GAP: existiert bei einem Owner, NICHT in canonical.
+- PHANTOM: in canonical, bei keinem Owner.
+- MIGRATED: gleicher Repo-Name unter *anderem* Owner als canonical sagt (Owner-Drift) — z. B.
+  canonical `achimdehnert/iil-fieldprefill`, real `iilgmbh/iil-fieldprefill`. Eigene Klasse, weil es
+  KEIN echtes Enrollment-Loch ist, sondern eine laufende Org-Migration (KONZ-002).
 
-Read-only, **advisory** (exit 0). `--strict` → exit 1 bei Drift>0 — für den späteren gegateten
-Einsatz (KONZ-001 R2b, hinter org-weitem ADR); im Pilot Sprint 1 bewusst NICHT gated.
+**Multi-Owner (v2):** `achimdehnert` ist ein User, `iilgmbh` die Enterprise-Org — Repos liegen während
+der Migration auf beiden. Single-Owner-Ground-Truth lügt selbst (Befund 2026-06-06). Default-Owner-Set
+deckt alle vier ab.
 
-KONZ-platform-001 §5 R5 / §5b. Reiner Kern (`compute_drift`) ist netz-frei → R7-Fault-Injection (s. test).
+Read-only, **advisory** (exit 0); `--strict` → exit 1 (gated, KONZ-001 R2b, hinter org-weitem ADR).
+Reiner Kern (`compute_drift`) ist netz-frei → R7-Fault-Injection (s. test).
 """
 import argparse
 import json
@@ -21,6 +25,11 @@ from pathlib import Path
 import yaml
 
 CANONICAL = Path(__file__).resolve().parents[1] / "registry" / "canonical.yaml"
+DEFAULT_OWNERS = ["achimdehnert", "iilgmbh", "ttz-lif", "meiki-lra"]
+
+
+def _basename(full: str) -> str:
+    return full.split("/", 1)[-1]
 
 
 def canonical_fullnames(canonical_path: str, org: str) -> set:
@@ -33,29 +42,44 @@ def canonical_fullnames(canonical_path: str, org: str) -> set:
     return out
 
 
-def gh_repo_fullnames(org: str) -> set:
+def gh_repo_fullnames(owner: str) -> set:
     r = subprocess.run(
-        ["gh", "repo", "list", org, "--limit", "300", "--json", "nameWithOwner",
+        ["gh", "repo", "list", owner, "--limit", "300", "--json", "nameWithOwner",
          "-q", ".[].nameWithOwner"],
         capture_output=True, text=True)
     if r.returncode != 0:
-        sys.exit(f"gh repo list {org} fehlgeschlagen: {r.stderr[:200]}")
+        sys.exit(f"gh repo list {owner} fehlgeschlagen: {r.stderr[:200]}")
     return {ln.strip() for ln in r.stdout.splitlines() if ln.strip()}
 
 
-def compute_drift(org_repos: set, canonical_repos: set) -> dict:
-    """Reine Widerspruchsmenge — testbar OHNE Netz (R7 Fault-Injection)."""
+def compute_drift(ground: set, canonical: set) -> dict:
+    """Reine Widerspruchsmenge inkl. Owner-Migration — testbar OHNE Netz (R7 Fault-Injection)."""
+    raw_gap = ground - canonical
+    raw_phantom = canonical - ground
+    gap_by_base = {}
+    for fn in raw_gap:
+        gap_by_base.setdefault(_basename(fn), []).append(fn)
+    migrated = []
+    for pfn in raw_phantom:
+        base = _basename(pfn)
+        if base in gap_by_base:
+            migrated.append({"repo": base, "canonical": pfn, "reality": sorted(gap_by_base[base])[0]})
+    migrated_bases = {m["repo"] for m in migrated}
+    enrollment_gap = sorted(fn for fn in raw_gap if _basename(fn) not in migrated_bases)
+    phantom = sorted(fn for fn in raw_phantom if _basename(fn) not in migrated_bases)
     return {
-        "enrollment_gap": sorted(org_repos - canonical_repos),
-        "phantom": sorted(canonical_repos - org_repos),
-        "covered": sorted(org_repos & canonical_repos),
-        "drift_score": len(org_repos - canonical_repos) + len(canonical_repos - org_repos),
+        "enrollment_gap": enrollment_gap,
+        "phantom": phantom,
+        "migrated": sorted(migrated, key=lambda m: m["repo"]),
+        "covered": sorted(ground & canonical),
+        "drift_score": len(enrollment_gap) + len(phantom) + len(migrated),
     }
 
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--org", default=None, help="Default: meta.server.github_org aus canonical")
+    ap.add_argument("--owners", default=",".join(DEFAULT_OWNERS),
+                    help="Komma-Liste der GitHub-Owner (User+Orgs), die Ground-Truth bilden")
     ap.add_argument("--canonical", default=str(CANONICAL))
     ap.add_argument("--format", choices=["text", "json"], default="text")
     ap.add_argument("--strict", action="store_true",
@@ -63,20 +87,26 @@ def main():
     a = ap.parse_args()
 
     d = yaml.safe_load(open(a.canonical))
-    org = a.org or (d.get("meta") or {}).get("server", {}).get("github_org", "achimdehnert")
-    canon = canonical_fullnames(a.canonical, org)
-    orgs = gh_repo_fullnames(org)
-    res = compute_drift(orgs, canon)
+    canon_org = (d.get("meta") or {}).get("server", {}).get("github_org", "achimdehnert")
+    canon = canonical_fullnames(a.canonical, canon_org)
+    owners = [o.strip() for o in a.owners.split(",") if o.strip()]
+    ground = set()
+    for o in owners:
+        ground |= gh_repo_fullnames(o)
+    res = compute_drift(ground, canon)
 
     if a.format == "json":
-        print(json.dumps({"org": org, **res}, indent=2, ensure_ascii=False))
+        print(json.dumps({"owners": owners, "canonical_org": canon_org, **res}, indent=2, ensure_ascii=False))
     else:
-        print(f"=== registry_coverage_drift (KONZ-001 R5) — org={org} ===")
-        print(f"  Org-Repos (gh): {len(orgs)} · canonical: {len(canon)} · covered: {len(res['covered'])}")
-        print(f"  ENROLLMENT-GAP (auf Org, NICHT in SSoT): {len(res['enrollment_gap'])}")
+        print(f"=== registry_coverage_drift (KONZ-001 R5) — owners={','.join(owners)} ===")
+        print(f"  Ground-Truth (alle Owner): {len(ground)} · canonical: {len(canon)} · covered: {len(res['covered'])}")
+        print(f"  ENROLLMENT-GAP (existiert, NICHT in SSoT): {len(res['enrollment_gap'])}")
         for r in res["enrollment_gap"]:
             print(f"    + {r}")
-        print(f"  PHANTOM (in SSoT, kein Org-Repo): {len(res['phantom'])}")
+        print(f"  MIGRATED (Owner-Drift — canonical-Owner stale): {len(res['migrated'])}")
+        for m in res["migrated"]:
+            print(f"    ~ {m['repo']}: canonical={m['canonical']} → real={m['reality']}")
+        print(f"  PHANTOM (in SSoT, bei keinem Owner): {len(res['phantom'])}")
         for r in res["phantom"]:
             print(f"    - {r}")
         print(f"=== DRIFT-SCORE: {res['drift_score']} (0 = sauber) ===")

--- a/tools/tests/test_registry_coverage_drift.py
+++ b/tools/tests/test_registry_coverage_drift.py
@@ -17,6 +17,16 @@ _spec.loader.exec_module(rcd)
 ORG = {"achimdehnert/a", "achimdehnert/b", "achimdehnert/c"}
 
 
+def test_should_classify_owner_migration_separately():
+    # canonical sagt achimdehnert/a, Realität ist iilgmbh/a → MIGRATED, NICHT gap/phantom (Befund 2026-06-06)
+    ground = {"iilgmbh/a", "achimdehnert/b"}
+    canonical = {"achimdehnert/a", "achimdehnert/b"}
+    res = rcd.compute_drift(ground, canonical)
+    assert res["migrated"] == [{"repo": "a", "canonical": "achimdehnert/a", "reality": "iilgmbh/a"}]
+    assert res["enrollment_gap"] == [] and res["phantom"] == []
+    assert res["drift_score"] == 1  # Migration zählt als Drift (canonical-Owner stale)
+
+
 def test_should_report_zero_drift_when_aligned():
     res = rcd.compute_drift(ORG, set(ORG))
     assert res["drift_score"] == 0


### PR DESCRIPTION
Tool-Fix #1 aus der Triage. Single-Owner-Ground-Truth war blind (achimdehnert=User, iilgmbh=Enterprise-Org). Jetzt Union über alle 4 Owner + neue **MIGRATED**-Klasse (Owner-Drift sauber von Enrollment-Gap getrennt).

**Ehrliche Baseline (alle Owner):** 63 ground / 44 canonical → **DRIFT-SCORE 23** (19 enrollment-gap inkl. iilgmbh-6 + souveräne Hubs ttz/meiki, 4 migrated, 0 phantom). Drift 14→23 weil *ehrlicher*, nicht schlechter. 5 Tests grün. Read-only. Refs #488.