### PR TITLE
docs(konzept): KONZ-002 idea→pilot + Registry-Reconciliation im S3-Runbook

### DIFF
--- a/docs/konzepte/KONZ-platform-002-enterprise-consolidation.md
+++ b/docs/konzepte/KONZ-platform-002-enterprise-consolidation.md
@@ -1,7 +1,7 @@
 ---
 concept_id: KONZ-platform-002
 title: Enterprise-Konsolidierung der IIL-Org-Topologie (Governance + native Secret-Prevention an einer Kontrollebene)
-pipeline_status: idea
+pipeline_status: pilot   # 2026-06-06: Status-Korrektur — S3 läuft real (Welle 0/1/2 transferiert, ADR-236 accepted); 'idea' war stale
 tier: T3
 owner: Achim Dehnert
 spec_refs: []          # keine ADR-211-Spec; Bezug = ADR-235 (Secret-Prevention-Posture) + platform#412

--- a/docs/runbooks/KONZ-002-s3-repo-transfer.md
+++ b/docs/runbooks/KONZ-002-s3-repo-transfer.md
@@ -76,6 +76,11 @@ Platzhalter: `<repo>` = Repo-Name, `<org>` = Ziel-Org (default `iilgmbh`).
 - [ ] Alte URL `github.com/achimdehnert/<repo>` **leitet weiter**.
 - [ ] Caller-Repos grün (keine gebrochenen reusable-Workflows).
 - [ ] Test-Secret-Commit wieder entfernen.
+- [ ] **Registry-Reconciliation (NEU 2026-06-06):** `canonical.yaml` `rich.github` des Repos auf `<org>/<repo>` ziehen (Schritt C9 ist sonst leicht zu vergessen — s.u.), dann
+  ```bash
+  python3 tools/registry_coverage_drift.py   # MIGRATED-Zeile des Repos MUSS verschwinden → covered
+  ```
+  Dieses Tool (KONZ-001 R5, PR #490) ist das **Migrations-Fortschritts-Meter**: solange ein transferiertes Repo als `MIGRATED (canonical=achimdehnert/… → real=iilgmbh/…)` auftaucht, ist C9 für dieses Repo offen.
 
 ### E. Rollback (innerhalb derselben Welle)
 
@@ -126,3 +131,4 @@ Canary = `desktop-setup` (Nicht-Code, 0 Secrets) → `iilgmbh`. **Transfer + Red
 ## Changelog
 - 2026-06-03: Initial — S3-Per-Repo-Transfer-Checkliste (Inventar/Transfer/Re-Provision/Verify/Rollback + Wellen).
 - 2026-06-03: Canary `desktop-setup` durchgeführt + Config-je-Repo-Typ-Regel (Code→17, Nicht-Code→slim via Org-Level-Attach) ergänzt; Step C erweitert.
+- 2026-06-06: **Registry-Reconciliation-Schritt** (Step D) + Drift-Meter `registry_coverage_drift` (KONZ-001 R5, PR #490) angebunden. **Befund:** das Meter zeigt **offenen C9-Lag** für die Welle-1/2-Repos — `iil-fieldprefill`, `iil-relaunch`, `illustration-fw`, `nl2iot-hub` stehen in `canonical.yaml` noch als `achimdehnert/…` (MIGRATED-Drift), `desktop-setup`/`django-lms-lite` fehlen ganz. **Offen:** `canonical.yaml` `rich.github` der bereits transferierten Repos auf `iilgmbh/…` nachziehen → schließt die MIGRATED-Drift (KONZ-001 ↔ KONZ-002 Kreuz-Validierung).


### PR DESCRIPTION
KONZ-002 stand auf `idea`, obwohl S3 **bereits läuft** (Welle 0/1/2 transferiert, ADR-236 accepted) → Status-Drift korrigiert.

**Kein neuer Runbook** (existiert: `KONZ-002-s3-repo-transfer.md`). Stattdessen: das Pilot-Tool `registry_coverage_drift` (PR #490) als **Migrations-Fortschritts-Meter** angebunden — und es liefert einen echten Befund (KONZ-001 ↔ KONZ-002 Kreuz-Validierung): **offener C9-Lag** — die bereits transferierten Welle-1/2-Repos stehen in `canonical.yaml` noch unter `achimdehnert` (MIGRATED-Drift) bzw. fehlen. Step D um Registry-Reconciliation ergänzt.