### PR TITLE
chore(adr): normalize status frontmatter to canonical lowercase enum

### DIFF
--- a/docs/adr/ADR-021-unified-deployment-pattern.md
+++ b/docs/adr/ADR-021-unified-deployment-pattern.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-02-10
 amended: 2026-06-01
 decision-makers: [Achim Dehnert]

--- a/docs/adr/ADR-056-deployment-preflight-and-pipeline-hardening.md
+++ b/docs/adr/ADR-056-deployment-preflight-and-pipeline-hardening.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-02-20
 amended: 2026-02-20
 decision-makers: [Achim Dehnert]

--- a/docs/adr/ADR-057-platform-test-strategy.md
+++ b/docs/adr/ADR-057-platform-test-strategy.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-02-20
 amended: 2026-02-20
 decision-makers: [Achim Dehnert]

--- a/docs/adr/ADR-058-platform-test-taxonomy.md
+++ b/docs/adr/ADR-058-platform-test-taxonomy.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-02-20
 amended: 2026-02-21
 decision-makers: [Achim Dehnert]

--- a/docs/adr/ADR-060-developer-workstation-ssh-configuration.md
+++ b/docs/adr/ADR-060-developer-workstation-ssh-configuration.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-02-21
 decision-makers: [Achim Dehnert]
 consulted: []

--- a/docs/adr/ADR-065-adr-numbering-filesystem-first.md
+++ b/docs/adr/ADR-065-adr-numbering-filesystem-first.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-02-22
 decision-makers: [Achim Dehnert]
 consulted: []

--- a/docs/adr/ADR-066-ai-engineering-team.md
+++ b/docs/adr/ADR-066-ai-engineering-team.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-02-22
 decision-makers: [Achim Dehnert]
 consulted: []

--- a/docs/adr/ADR-067-work-management-strategy.md
+++ b/docs/adr/ADR-067-work-management-strategy.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-02-23
 decision-makers: [Achim Dehnert]
 consulted: []

--- a/docs/adr/ADR-068-adaptive-model-routing.md
+++ b/docs/adr/ADR-068-adaptive-model-routing.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-02-23
 decision-makers: [Achim Dehnert]
 consulted: []

--- a/docs/adr/ADR-075-deployment-execution-strategy.md
+++ b/docs/adr/ADR-075-deployment-execution-strategy.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-02-23
 decision-makers: [Achim Dehnert]
 consulted: []

--- a/docs/adr/ADR-077-infrastructure-context-system.md
+++ b/docs/adr/ADR-077-infrastructure-context-system.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-02-23
 decision-makers: [Achim Dehnert]
 consulted: []

--- a/docs/adr/ADR-078-amendment-docker-healthcheck-convention.md
+++ b/docs/adr/ADR-078-amendment-docker-healthcheck-convention.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-02-24
 decision-makers: [Achim Dehnert]
 consulted: []

--- a/docs/adr/ADR-083-hybrid-adr-governance.md
+++ b/docs/adr/ADR-083-hybrid-adr-governance.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-02-25
 decision-makers: [Achim Dehnert]
 consulted: []

--- a/docs/adr/ADR-098-production-infrastructure-tuning-standard.md
+++ b/docs/adr/ADR-098-production-infrastructure-tuning-standard.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-098
 title: "Adopt 3-Layer Tuning Standard for PROD/DEV Hetzner Infrastructure"
-status: Accepted
+status: accepted
 date: 2026-03-04
 decision-makers: Achim Dehnert
 consulted: –

--- a/docs/adr/ADR-102-cloudflare-dns-cdn-migration.md
+++ b/docs/adr/ADR-102-cloudflare-dns-cdn-migration.md
@@ -1,5 +1,5 @@
 ---
-status: accepted (v2)
+status: accepted
 date: 2026-03-06
 decision-makers: Achim Dehnert
 consulted: Cascade

--- a/docs/adr/ADR-121-iil-outlinefw-story-outline-framework.md
+++ b/docs/adr/ADR-121-iil-outlinefw-story-outline-framework.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-121
 title: "iil-outlinefw — Story-Outline-Framework"
-status: Accepted
+status: accepted
 date: 2026-03-08
 decision-makers: [Achim Dehnert]
 consulted: []

--- a/docs/adr/ADR-130-content-store-shared-persistence.md
+++ b/docs/adr/ADR-130-content-store-shared-persistence.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-02-15
 amended: 2026-03-11
 decision-makers: [Achim Dehnert]

--- a/docs/adr/ADR-132-ai-context-defense-in-depth.md
+++ b/docs/adr/ADR-132-ai-context-defense-in-depth.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-02-27
 amended: 2026-03-11
 decision-makers: [Achim Dehnert]

--- a/docs/adr/ADR-139-shared-learning-platform-package.md
+++ b/docs/adr/ADR-139-shared-learning-platform-package.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-03-12
 amended: 2026-03-12
 decision-makers: [Achim Dehnert]

--- a/docs/adr/ADR-140-learn-hub.md
+++ b/docs/adr/ADR-140-learn-hub.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-03-12
 decision-makers: [Achim Dehnert]
 consulted: []

--- a/docs/adr/ADR-141-discord-agentic-coding-bridge.md
+++ b/docs/adr/ADR-141-discord-agentic-coding-bridge.md
@@ -1,5 +1,5 @@
 ---
-status: "draft"
+status: draft
 date: 2026-03-13
 decision-makers: [Achim Dehnert]
 consulted: []

--- a/docs/adr/ADR-142-unified-identity-authentik-platform-idp.md
+++ b/docs/adr/ADR-142-unified-identity-authentik-platform-idp.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-03-13
 decision-makers: [Achim Dehnert]
 consulted: []

--- a/docs/adr/ADR-143-knowledge-hub-outline-integration.md
+++ b/docs/adr/ADR-143-knowledge-hub-outline-integration.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-03-13
 decision-makers: [Achim Dehnert]
 consulted: []

--- a/docs/adr/ADR-144-doc-hub-paperless-ngx.md
+++ b/docs/adr/ADR-144-doc-hub-paperless-ngx.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-03-13
 decision-makers: [Achim Dehnert]
 consulted: []

--- a/docs/adr/ADR-145-knowledge-management-cascade-outline.md
+++ b/docs/adr/ADR-145-knowledge-management-cascade-outline.md
@@ -1,5 +1,5 @@
 ---
-status: "proposed"
+status: proposed
 date: 2026-03-14
 decision-makers: [Achim Dehnert]
 consulted: []

--- a/docs/adr/ADR-147-concept-templates-package.md
+++ b/docs/adr/ADR-147-concept-templates-package.md
@@ -1,5 +1,5 @@
 ---
-status: "proposed"
+status: proposed
 date: 2026-03-26
 decision-makers: [Achim Dehnert]
 consulted: []

--- a/docs/adr/ADR-149-dms-hub-dvelop-platform-service.md
+++ b/docs/adr/ADR-149-dms-hub-dvelop-platform-service.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-03-26
 updated: 2026-03-26
 version: 2

--- a/docs/adr/ADR-153-tax-hub-saas-architecture.md
+++ b/docs/adr/ADR-153-tax-hub-saas-architecture.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-03-25
 decision-makers: [Achim Dehnert]
 consulted: []

--- a/docs/adr/ADR-154-autonomous-coding-optimization.md
+++ b/docs/adr/ADR-154-autonomous-coding-optimization.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-03-31
 decision-makers: [Achim Dehnert]
 consulted: [Cascade AI]

--- a/docs/adr/ADR-169-enrichment-agent-pattern.md
+++ b/docs/adr/ADR-169-enrichment-agent-pattern.md
@@ -1,5 +1,5 @@
 ---
-status: Proposed
+status: proposed
 date: 2026-04-22
 amended: 2026-04-22
 decision-makers: Achim Dehnert

--- a/docs/adr/ADR-170-iil-ingest-document-ingestion-package.md
+++ b/docs/adr/ADR-170-iil-ingest-document-ingestion-package.md
@@ -1,5 +1,5 @@
 ---
-status: Accepted
+status: accepted
 date: 2026-04-23
 amended: 2026-04-23
 decision-makers: Achim Dehnert

--- a/docs/adr/ADR-171-temporal-rag-infrastructure.md
+++ b/docs/adr/ADR-171-temporal-rag-infrastructure.md
@@ -1,5 +1,5 @@
 ---
-status: Proposed
+status: proposed
 date: 2026-04-26
 amended: 2026-05-08
 decision-makers:

--- a/docs/adr/ADR-172-rag-mcp-server.md
+++ b/docs/adr/ADR-172-rag-mcp-server.md
@@ -1,5 +1,5 @@
 ---
-status: Proposed
+status: proposed
 date: 2026-04-26
 amended: 2026-04-26
 decision-makers:

--- a/docs/adr/ADR-173-document-intake-routing-pattern.md
+++ b/docs/adr/ADR-173-document-intake-routing-pattern.md
@@ -1,5 +1,5 @@
 ---
-status: Proposed
+status: proposed
 date: 2026-04-29
 decision-makers: Achim Dehnert
 consulted: []

--- a/docs/adr/ADR-174-workflow-enforcement-ci-gate.md
+++ b/docs/adr/ADR-174-workflow-enforcement-ci-gate.md
@@ -1,7 +1,7 @@
 ---
 title: "ADR-174 — Workflow Enforcement: CI Gate + PR Checklist + Symlink Policy"
 date: 2026-04-29
-status: Accepted
+status: accepted
 deciders: achimdehnert
 implementation_status: partial
 implementation_evidence:

--- a/docs/adr/ADR-175-workflow-modularization-pattern.md
+++ b/docs/adr/ADR-175-workflow-modularization-pattern.md
@@ -2,7 +2,7 @@
 title: "ADR-175 — Adopt selective modularization for .windsurf/workflows/ files"
 date: 2026-04-29
 amended: 2026-05-31
-status: Accepted
+status: accepted
 deciders: achimdehnert
 implementation_status: implemented
 implementation_evidence:

--- a/docs/adr/ADR-180-package-consolidation-strategy.md
+++ b/docs/adr/ADR-180-package-consolidation-strategy.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-03-25
 updated: 2026-03-25
 version: 3

--- a/docs/adr/ADR-183-v2-concept-templates-package.md
+++ b/docs/adr/ADR-183-v2-concept-templates-package.md
@@ -1,5 +1,5 @@
 ---
-status: "proposed"
+status: proposed
 date: 2026-03-26
 updated: 2026-03-26
 version: 2

--- a/docs/adr/ADR-188-unified-vector-store.md
+++ b/docs/adr/ADR-188-unified-vector-store.md
@@ -1,5 +1,5 @@
 ---
-status: Accepted
+status: accepted
 date: 2026-05-07
 amended: 2026-05-08
 decision-makers:

--- a/docs/adr/ADR-207-cross-repo-ingest-doku-konvention.md
+++ b/docs/adr/ADR-207-cross-repo-ingest-doku-konvention.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-207
 title: "Cross-Repo Ingest- & Doku-Konvention (tiered, opt-in)"
-status: Accepted
+status: accepted
 date: 2026-05-16
 deciders: Plattform-Governance
 ---

--- a/docs/adr/ADR-220-oidc-trusted-publishing-for-pypi.md
+++ b/docs/adr/ADR-220-oidc-trusted-publishing-for-pypi.md
@@ -1,5 +1,5 @@
 ---
-status: "proposed"
+status: proposed
 date: 2026-05-18
 decision-makers: [Achim Dehnert]
 consulted: []

--- a/docs/adr/ADR-223-llm-model-screener.md
+++ b/docs/adr/ADR-223-llm-model-screener.md
@@ -1,5 +1,5 @@
 ---
-status: Proposed
+status: proposed
 date: 2026-05-08
 amended: 2026-05-08
 decision-makers:

--- a/docs/adr/ADR-226-library-ci-reusable-mandatory-secret-scan.md
+++ b/docs/adr/ADR-226-library-ci-reusable-mandatory-secret-scan.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: accepted
 date: 2026-05-18
 decision-makers: [Achim Dehnert]
 consulted: []


### PR DESCRIPTION
## Was

43 ADRs trugen nicht-kanonische `status`-Literale im Frontmatter. Alle auf den lowercase-Enum aus `adr_frontmatter.schema.json` normalisiert:

| Vorher | Anzahl | Nachher |
|---|---|---|
| `"accepted"` (quoted) | 26 | `accepted` |
| `Accepted` / `Proposed` (capitalized) | 12 | `accepted` / `proposed` |
| `"proposed"` / `"draft"` (quoted) | 4 | `proposed` / `draft` |
| `accepted (v2)` (ADR-102) | 1 | `accepted` |

**Status-Verteilung nachher:** 141 accepted · 36 proposed · 2 void · 2 superseded · 1 draft = 182.

## Warum

Erster, billigster Schritt zu einer **transparenten ADR-Basis** vor einer automatisierten Widerspruchs-/Notwendigkeits-/Zukunftsfestigkeits-Analyse über alle 182 ADRs. Maschinen-uniformer `status` ist Voraussetzung dafür, dass Tooling (`iil-adrfw`, kommender Scan) korrekt aggregiert.

## Sicherheit

- **Frontmatter-only by construction:** Body-Beispiele (ADR-083:142, ADR-211:659) und ADR-200s verwaister Zweit-YAML-Block bleiben unangetastet.
- Kein `status` ändert **Bedeutung** — rein Schreibweise/Quoting.
- `iil-adrfw validate docs/adr/`: **182/182 grün** (vorher wie nachher).
- Diff: 43 Dateien, je genau 1 Zeile, **0** Nicht-status-Zeilen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)