### PR TITLE
fix(registry): C9-Lag nl2iot-hub→iilgmbh + Schema-Blocker-Befund (P0)

### DIFF
--- a/registry/canonical.yaml
+++ b/registry/canonical.yaml
@@ -224,6 +224,7 @@ repos:
         django_settings_module: config.settings.production
         migrate_cmd: python manage.py migrate --noinput
         port: 19002
+        ingress: traefik
         hostnames:
         - staging-devhub.iil.pet
       oidc:
@@ -369,7 +370,7 @@ repos:
       name: nl2iot-hub
       repo: nl2iot-hub
       description: Natural-language-to-IoT — Developer Cockpit
-      github: achimdehnert/nl2iot-hub
+      github: iilgmbh/nl2iot-hub
       deployed: false
       type: python
       lifecycle: experimental

--- a/registry/repos.yaml
+++ b/registry/repos.yaml
@@ -104,7 +104,7 @@ domains:
   - name: nl2iot-hub
     repo: nl2iot-hub
     description: Natural-language-to-IoT — Developer Cockpit
-    github: achimdehnert/nl2iot-hub
+    github: iilgmbh/nl2iot-hub   # KONZ-002 S3 Welle 1 transferiert → C9-Lag 2026-06-06
     deployed: false
     type: python
     lifecycle: experimental


### PR DESCRIPTION
Schließt den C9-Lag für **nl2iot-hub** (sauber: repos.yaml-Source-Edit + build, verify grün, MIGRATED 4→3, Drift 23→22).

**Wichtiger Befund — die übrigen 3+2 sind NICHT per Daten-Edit schließbar (Schema-blockiert):**
- Kein Source-File kennt `iilgmbh` (grep=0); Owner ist global + sparse `rich.github`. Flat-only-Repos können den iilgmbh-Owner nicht ausdrücken.
- `flip` ist **lossy/buggy** (dupliziert Header, strippt Kommentare) → die ADR-234-P0-Registry-Transition ist unfertig/fragil.

→ Vollständige C9-Schließung = **KONZ-001 P0**: per-Repo `owner`-Feld + flip-Fix. Der Pilot hat damit den realen P0-Bedarf belegt. Refs #488.