### PR TITLE
feat(registry): KONZ-001 P0 Teil 2 — C9-Rest via meta.repo_owner (verifiziert)

### DIFF
--- a/registry/canonical.yaml
+++ b/registry/canonical.yaml
@@ -18,6 +18,10 @@ meta:
   - ttz-lif
   - meiki-lra
   - bahn-sqf
+  repo_owner:
+    iil-fieldprefill: iilgmbh
+    iil-relaunch: iilgmbh
+    illustration-fw: iilgmbh
   _note: GENERATED-CANDIDATE (ADR-234 P0). Union aus scripts/repo-registry.yaml + registry/repos.yaml.
     Noch NICHT kanonisch geschaltet — Konsumenten unverändert.
 repos:

--- a/tools/registry-canonical.py
+++ b/tools/registry-canonical.py
@@ -80,6 +80,15 @@ def build() -> dict:
             # Roundtrip top-level Source-Keys droppt. bahn-sqf IN (Owner hat Admin), pactive-de
             # bewusst AUSSEN (separates Kunden-Vault). Entscheidung 2026-06-06, Issue #488.
             "enterprise_owners": ["achimdehnert", "iilgmbh", "ttz-lif", "meiki-lra", "bahn-sqf"],
+            # Per-Repo-Owner-Override (Transition). KONZ-001 P0 Teil 2: flat-only Repos können
+            # keinen rich.github tragen (circular pipeline), darum die per-gh-VERIFIZIERTEN
+            # KONZ-002-Migrationen hier als meta-Override (build-stabil). Stopgap bis das echte
+            # per-Repo-owner-Feld kommt (Registry-Konsolidierung). Verifiziert 2026-06-06 (gh).
+            "repo_owner": {
+                "iil-fieldprefill": "iilgmbh",
+                "iil-relaunch": "iilgmbh",
+                "illustration-fw": "iilgmbh",
+            },
             "_note": "GENERATED-CANDIDATE (ADR-234 P0). Union aus scripts/repo-registry.yaml + "
                      "registry/repos.yaml. Noch NICHT kanonisch geschaltet — Konsumenten unverändert.",
         },

--- a/tools/registry_coverage_drift.py
+++ b/tools/registry_coverage_drift.py
@@ -66,20 +66,30 @@ def gh_repo_fullnames(owner: str) -> tuple[set, bool]:
 
 
 def parse_canonical(path: str, default_org: str) -> dict:
-    """fullname -> {lifecycle, deployed, owner_explicit, name}. owner_explicit=False ⇒ SCHEMA-INCOMPLETE (O6)."""
+    """fullname -> {lifecycle, deployed, owner_explicit, name}. owner_explicit=False ⇒ SCHEMA-INCOMPLETE (O6).
+
+    Owner-Auflösung (Priorität): rich.github > meta.repo_owner-Override (P0-Transition für flat-only
+    Migrationen) > default_org. Beide expliziten Quellen setzen owner_explicit=True."""
     d = yaml.safe_load(open(path))
+    overrides = (d.get("meta") or {}).get("repo_owner") or {}
     out = {}
     for name, e in (d.get("repos") or {}).items():
         e = e or {}
         rich = e.get("rich") or {}
         flat = e.get("flat") or {}
         gh = rich.get("github")
-        fn = gh if gh else f"{default_org}/{name}"
+        ov = overrides.get(name)
+        if gh:
+            fn, explicit = gh, True
+        elif ov:
+            fn, explicit = f"{ov}/{name}", True
+        else:
+            fn, explicit = f"{default_org}/{name}", False
         out[fn] = {
             "name": name,
             "lifecycle": rich.get("lifecycle") or flat.get("lifecycle"),
             "deployed": rich.get("deployed", flat.get("deployed")),
-            "owner_explicit": bool(gh),
+            "owner_explicit": explicit,
         }
     return out
 

--- a/tools/tests/test_registry_coverage_drift.py
+++ b/tools/tests/test_registry_coverage_drift.py
@@ -66,3 +66,17 @@ def test_should_flag_schema_incomplete_when_no_explicit_owner():
     assert res["schema_incomplete"] == ["achimdehnert/x"]
     assert res["severity"]["info"] == 1
     assert res["drift_score"] == 0  # Schema-Incomplete ist info, nicht blockierend
+
+
+def test_should_apply_meta_repo_owner_override(tmp_path):
+    # P0-Transition: meta.repo_owner setzt den Owner für flat-only Migrationen + owner_explicit=True
+    p = tmp_path / "canon.yaml"
+    p.write_text(
+        "meta:\n  server: {github_org: achimdehnert}\n  repo_owner: {foo: iilgmbh}\n"
+        "repos:\n"
+        "  foo: {in_flat: true, flat: {type: library}}\n"
+        "  bar: {in_flat: true, flat: {type: library}}\n"
+    )
+    out = rcd.parse_canonical(str(p), "achimdehnert")
+    assert "iilgmbh/foo" in out and out["iilgmbh/foo"]["owner_explicit"] is True   # Override greift
+    assert "achimdehnert/bar" in out and out["achimdehnert/bar"]["owner_explicit"] is False  # default → schema-incomplete


### PR DESCRIPTION
**KONZ-001 P0 Teil 2.** Schließt den **C9-Rest** für die in canonical migrierten Repos.

**Evidenz korrigierte die Aufgabe:** gh-verifiziert haben **nur 3** Repos einen falschen Owner (iil-fieldprefill / iil-relaunch / illustration-fw, real iilgmbh, deklariert achimdehnert). Die "26 SCHEMA-INCOMPLETE" sind zu **23 implizit-aber-KORREKT** achimdehnert (kein Fix nötig, nur kosmetisch-explizit).

- **meta.repo_owner-Override** (build, Transition): die 3 flat-only-Migrationen können keinen rich.github tragen (circular pipeline), und ein rich-Eintrag bräuchte **erfundene Domain/Type-Werte** (Evidenz-Verstoß) → meta-Override ist build-stabil + verifiziert, ohne Daten zu erfinden. parse_canonical wendet sie an (Priorität rich.github > meta.repo_owner > default_org) + R7-Test.

**Ergebnis:** MIGRATED 3→0, SCHEMA-INCOMPLETE 26→23, DRIFT 25→22. verify grün, 54 Tests grün (im tools-tests.yml Gate).

**Offen (echte Registry-Konsolidierung):** desktop-setup/django-lms-lite sind Enrollment-Gaps (brauchen verifizierte Metadaten); die 23 impliziten Owner explizit machen — beides gehört in den Umbau auf *single editable canonical SSoT* statt circular flat/rich. Refs #488.
