### PR TITLE
docs(adr): ADR-Konsistenz-Hygiene — Port-Selbstwiderspruch + Tenancy-Re-Scope

### DIFF
--- a/docs/adr/ADR-021-unified-deployment-pattern.md
+++ b/docs/adr/ADR-021-unified-deployment-pattern.md
@@ -189,7 +189,7 @@ Compliance is verified by:
 | `web_service` | `bfagent-web` | `risk-hub-web` | `web` ¹ | `weltenhub-web` | `web` | `devhub-web` | `coach-hub-web` |
 | `extra_services` | — | `risk-hub-worker` | `celery` | `weltenhub-celery weltenhub-beat` | `worker` | `devhub-celery devhub-beat` | `coach-hub-worker coach-hub-beat` |
 | `container` | `bfagent_web` | `risk_hub_web` | `travelbeat_web` | `weltenhub_web` | `pptx_hub_web` | `devhub_web` | `coach_hub_web` |
-| `host_port` | 8088 | 8090 | 8002 | 8081 | 8020 | 8085 | 8007 |
+| `host_port` | 8091 | 8090 | 8002 | 8081 | 8020 | 8085 | 8007 |
 | `database` | shared (`bfagent_db`) | own stack | own stack | shared (`bfagent_db`) | own stack | shared (`bfagent_db`) | own stack |
 | `python` | 3.11 | 3.12 | 3.12 | 3.12 | 3.12 | 3.12 | 3.12 |
 | `source_dir` | `.` | `src` | `apps` | `apps` | `src` | `.` | `apps` |

--- a/docs/adr/ADR-072-multi-tenancy-schema-isolation.md
+++ b/docs/adr/ADR-072-multi-tenancy-schema-isolation.md
@@ -6,12 +6,16 @@ consulted: –
 informed: –
 implementation_status: partial
 implementation_evidence:
-  - "6/9 UI-Hubs mit django_tenants Schema Isolation: travel-beat, weltenhub, coach-hub, cad-hub, billing-hub, dev-hub"
-  - "Fehlend: risk-hub, pptx-hub, trading-hub"
+  - "KORREKTUR 2026-06-06 (ADR-237 Audit, file:line-verifiziert): real schema-per-tenant nur travel-beat + tax-hub. coach-hub/billing-hub/dev-hub sind row-level (NICHT django_tenants) — die frühere 6/9-Liste war faktisch falsch. weltenhub/cad-hub: nicht nachgemessen."
   - "TenantAwareModel als Basis in platform_context"
 ---
 
 # ADR-072: Adopt PostgreSQL Schema Isolation for SaaS Multi-Tenancy
+
+> **Re-scoped durch [ADR-237].** Schema-per-tenant ist **nicht** der Plattform-Default,
+> sondern die **bewusste Ausnahme** für DSGVO-getriebene Hart-Isolation (z. B. tax-hub).
+> Default für Multi-Tenancy ist row-level `tenant_id` (ADR-035/109/137). Der unten
+> formulierte universelle „für alle SaaS"-Anspruch gilt nur noch für den Ausnahme-Pfad.
 
 | Attribut       | Wert                                                                 |
 |----------------|----------------------------------------------------------------------|

--- a/docs/adr/ADR-074-multi-tenancy-testing-strategy.md
+++ b/docs/adr/ADR-074-multi-tenancy-testing-strategy.md
@@ -13,6 +13,13 @@ implementation_evidence:
 
 # ADR-074: Multi-Tenancy Testing Strategy — Isolation, Propagation & CI Gates
 
+> **Geltungsbereich präzisiert durch [ADR-237].** Die Anti-Pattern-Regel in §4.6
+> (`filter(tenant_id=...)` verboten) gilt **ausschließlich in `TENANT_APPS` von
+> schema-per-tenant-Repos** (travel-beat, tax-hub). Im Plattform-**Default** (row-level
+> `tenant_id`, ADR-035/109/137) ist der explizite tenant-Filter bzw. ein erzwingender
+> Manager/RLS der **vorgeschriebene** Pfad — dort gilt diese Regel **nicht**. Hinweis:
+> der in §4.6 skizzierte CI-Linter ist derzeit **nicht implementiert** (Stand 2026-06-06).
+
 | Attribut       | Wert                                                                 |
 |----------------|----------------------------------------------------------------------|
 | **Status**     | Accepted                                                             |


### PR DESCRIPTION
Verifizierte, unzweideutige Fixes aus dem ADR-Konsistenz-Scan (Items 9 + 11). Jeder Edit ist gegen die Quelle geprüft (keine geratenen Ziele).

| ADR | Fix | Evidenz |
|---|---|---|
| ADR-021 §2.3 | bfagent host_port **8088 → 8091** | SSoT `infra/ports.yaml` (bfagent=8091, trading-hub=8088) + ADR-021 §2.9 — §2.3 war Selbstwiderspruch |
| ADR-072 | Re-Scope-Hinweis (Ausnahme via ADR-237) + **faktisch falsche evidence korrigiert** | file:line-Audit: coach-hub/billing-hub/dev-hub sind row-level, nicht django_tenants |
| ADR-074 | §4.6-Forbid-Regel auf TENANT_APPS/schema-Repos präzisiert + Linter als nicht-implementiert markiert | Zeile 436 war schon TENANT_APPS-gescoped; row-level-Default braucht den Filter |

Folge zu **ADR-237** (#495). validate: 183/183 grün (mit ADR-237).

🤖 Generated with [Claude Code](https://claude.com/claude-code)