### PR TITLE
docs(adr): Ref-Cleanup (Renumbering-Dead-Refs) + Supersession-Backlink + Drift-SUGGEST-Gate

### DIFF
--- a/.github/workflows/adr-validate.yml
+++ b/.github/workflows/adr-validate.yml
@@ -25,3 +25,19 @@ jobs:
 
       - name: Validate all ADRs
         run: iil-adrfw validate docs/adr/
+
+      # ADR reference-drift report — SUGGEST / non-gating (repo-health-rule-discipline:
+      # new rules start as SUGGEST; structural deterministic only). Surfaces depends_on /
+      # references pointing at archived or missing ADR ids (renumbering-collision dead-refs).
+      # Does NOT fail the build yet; promote to gating once the existing dead-refs are cleaned.
+      - name: ADR reference-drift (SUGGEST, non-gating)
+        run: |
+          set +e
+          iil-adrfw staleness docs/adr/ 2>&1 | tee staleness.txt
+          drift=$(grep -c "does not exist" staleness.txt)
+          if [ "$drift" -gt 0 ]; then
+            echo "::warning title=ADR reference drift::$drift dangling ADR reference(s) (depends_on → archived/missing). Non-gating SUGGEST — see log. Promote to gating after cleanup."
+          else
+            echo "✓ No ADR reference drift."
+          fi
+          exit 0

--- a/docs/adr/ADR-021-unified-deployment-pattern.md
+++ b/docs/adr/ADR-021-unified-deployment-pattern.md
@@ -77,7 +77,7 @@ Compliance is verified by:
 1. **CI check**: Each service repo's `ci-cd.yml` references `achimdehnert/platform/.github/workflows/_ci-python.yml@v1` — reviewable in GitHub Actions tab.
 2. **Migration table**: §5 tracks each project's migration status; items are closed when the PR merges.
 3. **Health endpoint test**: `curl -sf https://<domain>/healthz/` returns `{"status": "ok"}` — verified post-deploy by `deploy-remote.sh`.
-4. **ADR-054 Architecture Guardian**: The agent checks new workflow files for platform-workflow usage on every PR.
+4. **Architecture Guardian** (`.github/workflows/guardian.yml`): checks new workflow files for platform-workflow usage on every PR.
 
 ### Consequences
 
@@ -137,7 +137,7 @@ Compliance is verified by:
 
 ## More Information
 
-- **Related ADRs**: ADR-008 (infrastructure), ADR-022 (code quality tooling), ADR-042 (dev environment deploy workflow), ADR-045 (secrets/SOPS), ADR-054 (LLM Agent Ecosystem / Architecture Guardian)
+- **Related ADRs**: ADR-008 (infrastructure), ADR-022 (code quality tooling), ADR-042 (dev environment deploy workflow), ADR-045 (secrets/SOPS)
 - **Traefik decision**: Deferred to a future ADR. Nginx retained consciously (see §2.10).
 - **SSH as root**: Conscious decision documented in §2.1.
 - **Migration tracking**: §5 lists all open migration tasks with priority.

--- a/docs/adr/ADR-072-multi-tenancy-schema-isolation.md
+++ b/docs/adr/ADR-072-multi-tenancy-schema-isolation.md
@@ -134,7 +134,7 @@ PostgreSQL `search_path` ist eine Connection-Property. Sobald die `django-tenant
 # VORHER (ADR-035, Row-Level):
 assessments = Assessment.objects.filter(tenant_id=request.tenant.id)  # Vergessen → Datenleck
 
-# NACHHER (ADR-056, Schema-Isolation):
+# NACHHER (ADR-072, Schema-Isolation):
 assessments = Assessment.objects.all()  # Automatisch im richtigen Schema
 ```
 
@@ -144,7 +144,7 @@ ADR-035 bleibt gültig für:
 - Interne Tools (dev-hub, mcp-hub) die keine SaaS-Mandanten bedienen
 - Services in der Übergangsphase vor Schema-Migration
 
-ADR-056 **erweitert** ADR-035 für SaaS-fähige Services. Die `platform_context`-Shared-Library (vendored) wird um Tenant-Utilities erweitert — kein neues separates Package.
+ADR-072 **erweitert** ADR-035 für SaaS-fähige Services. Die `platform_context`-Shared-Library (vendored) wird um Tenant-Utilities erweitert — kein neues separates Package.
 
 ### 4.3 Tenant-Context-Propagation über alle 3 Kanäle
 

--- a/docs/adr/ADR-074-multi-tenancy-testing-strategy.md
+++ b/docs/adr/ADR-074-multi-tenancy-testing-strategy.md
@@ -29,7 +29,7 @@ implementation_evidence:
 | **Autor**      | Achim Dehnert                                                        |
 | **Reviewer**   | –                                                                    |
 | **Supersedes** | –                                                                    |
-| **Relates to** | ADR-056 (Multi-Tenancy Schema Isolation), ADR-035 (Shared Django Tenancy), ADR-021 (Unified Deployment) |
+| **Relates to** | ADR-072 (Multi-Tenancy Schema Isolation), ADR-035 (Shared Django Tenancy), ADR-021 (Unified Deployment) |
 
 ---
 
@@ -76,7 +76,7 @@ Aktuell haben die Services keine Tenant-Isolation-Tests. ADR-035 hat Tenancy-Inf
 ### 1.3 Constraints
 
 - **`django-tenants>=3.6`** — `TenantTestCase` und `TenantClient` verfügbar
-- **`pytest-django`** — Standard in allen Services (ADR-056 §6)
+- **`pytest-django`** — Standard in allen Services (ADR-072 §6)
 - **Self-Hosted Runner** auf VPS — keine parallelen DB-Connections über Limits
 - **`platform_context`** als vendored Shared Library — Fixtures gehören hierhin
 - **PostgreSQL** in CI via GitHub Actions Service Container
@@ -516,7 +516,7 @@ with schema_context("public"): ...      # Expliziter public-Schema-Zugriff
 
 ### 7.3 Nicht in Scope
 
-- Performance-Tests / Load-Tests (ADR-056 §6, Phase 4)
+- Performance-Tests / Load-Tests (ADR-072 §6, Phase 4)
 - End-to-End-Tests mit echten Subdomains (Selenium/Playwright) — separates ADR
 - Contract-Tests zwischen Services — separates ADR
 
@@ -537,7 +537,7 @@ Compliance wird wie folgt verifiziert:
 
 - [django-tenants Test-Dokumentation](https://django-tenants.readthedocs.io/en/latest/test.html)
 - [pytest-django `transaction=True`](https://pytest-django.readthedocs.io/en/latest/database.html#transaction-tests)
-- ADR-056: Adopt PostgreSQL Schema Isolation for SaaS Multi-Tenancy
+- ADR-072: Adopt PostgreSQL Schema Isolation for SaaS Multi-Tenancy
 - ADR-035: Shared Django Tenancy Package
 
 ---

--- a/docs/adr/ADR-137-tenant-lifecycle-module-selfservice-rls.md
+++ b/docs/adr/ADR-137-tenant-lifecycle-module-selfservice-rls.md
@@ -2,6 +2,7 @@
 status: accepted
 date: 2026-03-11
 decision-makers: [Achim Dehnert]
+amends: [ADR-035]
 implementation_status: implemented
 implementation_evidence:
   - "Phase 1 (TenantManager + Lifecycle): DONE — risk-hub packages/django-tenancy/ v0.2.0"
@@ -153,6 +154,8 @@ class TenantManager(models.Manager):
 ```
 
 **Begründung**: ADR-035 entschied sich gegen auto-filter wegen Celery/Management-Command-Problemen. Dieser Entwurf löst das durch Fallback: ohne Context-Variable kein Filter. Admin-Queries nutzen `.unscoped()` explizit.
+
+> **Amends ADR-035 §2.2** (siehe `amends`-Frontmatter): kehrt dessen Entscheidung gegen automatisches tenant_id-Filtering bewusst um. Die Reversal ist damit im Frontmatter auffindbar, nicht nur in dieser Prosa.
 
 **Django Admin**: Der auto-filter Manager betrifft auch den Django Admin. Damit Staff-User alle Tenants sehen können, stellt das Package eine `TenantModelAdmin` Base-Class bereit:
 


### PR DESCRIPTION
ADR-Konsistenz-Scan **Items 7 / 8 / 10**. Jeder Repoint gegen die Quelle geprüft (keine geratenen Ziele).

## Item 7 — Renumbering-Dead-Refs
| ADR | Fix | Begründung |
|---|---|---|
| ADR-072, ADR-074 | `ADR-056` → `ADR-072` (6 Vorkommen) | 072 ist das **frühere 056**; alle Refs meinen Schema-Isolation. Aktives 056 = deployment-preflight (Kollision). Verifiziert: keine echte 056-Referenz in den Dateien |
| ADR-021 | `ADR-054 Architecture Guardian` → `guardian.yml` + toten Related-Ref entfernt | Guardian ist real (`.github/workflows/guardian.yml`); ADR-054 archiviert + off-topic |

## Item 8 — Supersession-Backlink
- **ADR-137 `amends: [ADR-035]`** + Reversal-Notiz: ADR-137 kehrt ADR-035 §2.2 („kein auto-filter") bewusst um (Security-relevant) — war nur in Prosa, jetzt im Frontmatter auffindbar.

## Item 10 — Drift-Gate (SUGGEST)
- `adr-validate.yml`: non-gating `iil-adrfw staleness` reference-drift-Report (`::warning`). Fängt den Dead-Ref-Typ fleet-weit. **Noch nicht gating** — Promotion nach Bestands-Cleanup (repo-health-rule-discipline: neue Regeln starten als SUGGEST).

## Bewusst offen
`depends_on → ADR-009 / ADR-113` (archiviert) in ADR-171/172/188/191/192/197/223: **kein FP-freies Repoint-Ziel** → vom SUGGEST-Gate gemeldet statt geraten.

validate: **183/183 grün**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)