### PR TITLE
fix(registry): Hardening aus externem PR-#497-Review (REC-5/6/7/9/12)

### DIFF
--- a/tools/registry-canonical.py
+++ b/tools/registry-canonical.py
@@ -174,19 +174,27 @@ def _leading_comments(path: Path) -> str:
     return "\n".join(out).rstrip() + "\n" if out else ""
 
 
+# Exakte Zeilen-Identität der GEN_NOTICE-Konstante (REC-5: deterministisch statt Box-Zeichen-
+# Heuristik — robust, auch falls Schema-Docs je Box-Zeichen nutzen). Test: test_registry_canonical.
+_GEN_NOTICE_LINES = frozenset(GEN_NOTICE.strip("\n").splitlines())
+
+
+def _strip_gen_notice(text: str) -> str:
+    """Entfernt einen aus einem FRÜHEREN flip vorhandenen GEN_NOTICE-Block per exakter
+    Zeilen-Identität (kein Heuristik-Match), bevor flip ihn neu setzt — sonst akkumuliert jeder
+    Roundtrip einen weiteren Header (Doppel-Header-Bug, belegt beim C9-Lag-PR). Idempotent."""
+    return "\n".join(ln for ln in text.splitlines() if ln not in _GEN_NOTICE_LINES).strip("\n")
+
+
 def flip(canon: dict) -> int:
     """Schreibt BEIDE Altdateien als generierte Views aus canonical (ADR-234 P0 Flip).
     Erhält den wertvollen Schema-Doc-Header der reichen Datei verbatim; die flache
-    bekommt nur den GENERATED-Header (ihr alter 'auto-detection'-Header wäre nach Flip
-    irreführend). Danach muss `verify` weiterhin grün sein (semantisch)."""
-    # flip-Fix (2026-06-06): den ggf. aus einem FRÜHEREN flip bereits vorhandenen GEN_NOTICE
-    # entfernen, BEVOR wir ihn neu prepended — sonst akkumuliert jeder flip einen weiteren
-    # Header-Block (Doppel-Header-Bug, belegt beim C9-Lag-PR). Box-Zeilen (╔╗╚╝║) gehören
-    # ausschließlich zum GEN_NOTICE; die Schema-Docs nutzen sie nicht.
-    rich_header = "\n".join(
-        ln for ln in _leading_comments(RICH).splitlines()
-        if not any(c in ln for c in "╔╗╚╝║")
-    ).strip("\n")
+    bekommt nur den GENERATED-Header. Danach muss `verify` weiterhin grün sein (semantisch).
+
+    GRENZE (REC-7): `yaml.safe_dump` ist round-trip-**lossy** für Inline-Daten-Kommentare —
+    flip behebt NUR die Header-Akkumulation, nicht den Kommentar-Verlust innerhalb der Daten.
+    Vollständig verlustfrei wäre nur mit ruamel.yaml (eigene Entscheidung)."""
+    rich_header = _strip_gen_notice(_leading_comments(RICH))
     FLAT.write_text(GEN_NOTICE + "\n" + yaml.safe_dump(gen_flat(canon), sort_keys=False, allow_unicode=True, width=100))
     RICH.write_text(GEN_NOTICE + "\n" + rich_header + "\n" + yaml.safe_dump(gen_rich(canon), sort_keys=False, allow_unicode=True, width=100))
     print(f"✅ geflippt: {FLAT.relative_to(ROOT)} (frischer GEN-Header) + {RICH.relative_to(ROOT)} (Schema-Docs erhalten).")

--- a/tools/registry_coverage_drift.py
+++ b/tools/registry_coverage_drift.py
@@ -165,6 +165,21 @@ def main():
         owners, scope_source = list(DEFAULT_OWNERS), "FALLBACK (meta.enterprise_owners fehlt!)"
     discovered_unscoped = sorted(set(discover_owners()) - set(owners))
 
+    # REC-9: Owner-Provenienz — welche Repos beziehen ihren Owner aus dem TRANSITION-Override
+    # (meta.repo_owner), nicht aus der finalen Registry-Architektur. REC-12: Validierung der
+    # Governance-Inputs (unbekannte Override-Keys, Duplikate im Scope) — früh sichtbar machen.
+    repo_names = {(e or {}).get("flat", {}).get("name") or n for n, e in (d.get("repos") or {}).items()}
+    overrides = meta.get("repo_owner") or {}
+    owner_from_override = sorted(k for k in overrides if k in (d.get("repos") or {}))
+    validation = []
+    unknown = sorted(set(overrides) - set(d.get("repos") or {}))
+    if unknown:
+        validation.append(f"repo_owner-Keys ohne canonical-Repo: {unknown}")
+    if len(owners) != len(set(owners)):
+        validation.append("enterprise_owners enthält Duplikate")
+    if any(not o or "/" in o for o in overrides.values()):
+        validation.append("repo_owner-Werte leer oder nicht owner-normalisiert (kein 'owner/name' erwartet)")
+
     ground, truncated, failed = set(), [], []
     for o in owners:
         names, trunc = gh_repo_fullnames(o)
@@ -179,6 +194,8 @@ def main():
         "owners_queried": owners,
         "scope_source": scope_source,
         "discovered_unscoped": discovered_unscoped,  # Owner, die der Token sieht, aber NICHT im Scope → Review
+        "owner_from_override": owner_from_override,   # REC-9: Owner aus Transition-Override, nicht finaler Architektur
+        "validation": validation,                     # REC-12: Governance-Input-Probleme (Override-Keys/Duplikate)
         "owners_failed": failed,                      # leere/fehlgeschlagene Abfragen → Ergebnis unvollständig
         "truncation_warning": truncated,              # Limit erreicht → mögliche stille Lücke
         "schema_incomplete_count": res["severity"]["info"],
@@ -208,6 +225,10 @@ def main():
             print(f"  ⚠ ATTESTATION: {len(failed)} Owner-Abfrage(n) fehlgeschlagen ({','.join(failed)}) — Ergebnis UNVOLLSTÄNDIG")
         if truncated:
             print(f"  ⚠ ATTESTATION: Truncation bei {','.join(truncated)} (≥{LIMIT}) — mögliche stille Lücke")
+        for v in attestation["validation"]:
+            print(f"  ⚠ VALIDATION: {v}")
+        if attestation["owner_from_override"]:
+            print(f"  ℹ TRANSITION: Owner aus meta.repo_owner-Override (nicht finale Architektur): {', '.join(attestation['owner_from_override'])}")
         print(f"  Ground-Truth: {len(ground)} · canonical: {len(canonical)} · covered: {len(res['covered'])}")
         print(f"  SEVERITY: critical={s['critical']} · warn={s['warn']} · info/schema-incomplete={s['info']}")
         print(f"  ENROLLMENT-GAP ({len(res['enrollment_gap'])}):")

--- a/tools/tests/test_registry_canonical.py
+++ b/tools/tests/test_registry_canonical.py
@@ -1,0 +1,44 @@
+"""Tests für registry-canonical.py — flip-Idempotenz der GEN_NOTICE-Behandlung (REC-5/REC-6).
+
+Der flip-Doppel-Header-Bug (jeder Roundtrip akkumulierte einen weiteren GENERATED-Header) wird
+durch `_strip_gen_notice` (exakte Zeilen-Identität, nicht Box-Char-Heuristik) verhindert. Dieser
+Test pinnt die Idempotenz — er läuft im generischen tools-tests.yml Gate (#494).
+
+Run: `python3 -m pytest tools/tests/test_registry_canonical.py -q`
+(registry-canonical.py hat einen Bindestrich → via importlib geladen.)
+"""
+import importlib.util
+import pathlib
+import sys
+
+_TOOLS = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_TOOLS))  # registry-canonical.py macht modul-level `from registry_api import …`
+
+_SRC = _TOOLS / "registry-canonical.py"
+_spec = importlib.util.spec_from_file_location("registry_canonical", _SRC)
+rc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rc)
+
+DOCS = "# Schema-Doc Zeile 1\n# Schema-Doc Zeile 2\n"
+
+
+def test_should_strip_single_gen_notice_keep_docs():
+    out = rc._strip_gen_notice(rc.GEN_NOTICE + "\n" + DOCS)
+    assert out.strip() == DOCS.strip()
+
+
+def test_should_strip_accumulated_gen_notice_idempotently():
+    # Doppel-Header (der frühere Bug) → trotzdem nur Schema-Docs übrig
+    doubled = rc.GEN_NOTICE + rc.GEN_NOTICE + "\n" + DOCS
+    assert rc._strip_gen_notice(doubled).strip() == DOCS.strip()
+
+
+def test_should_leave_text_without_notice_unchanged():
+    assert rc._strip_gen_notice(DOCS).strip() == DOCS.strip()
+
+
+def test_should_not_strip_docs_that_merely_resemble_notice():
+    # Eine Schema-Doc-Zeile, die KEINE exakte GEN_NOTICE-Zeile ist, bleibt erhalten
+    text = "# GENERATED irgendwas anderes (kein exakter Match)\n" + DOCS
+    out = rc._strip_gen_notice(text)
+    assert "kein exakter Match" in out  # nicht versehentlich gestrippt (REC-5 Determinismus)


### PR DESCRIPTION
Härtung aus dem **externen PR-#497-Review** (Rückfluss-Gate: 12/12 RECs valid). Härtet die P0-Workarounds, **ohne sie zu zementieren** — die KONSOLIDIERUNG-RECs gehen bewusst in den ADR-234-Slice (sonst poliert man die Patches statt sie zu ersetzen, AD-3/M28-4-Warnung).

| REC | Fix |
|---|---|
| REC-5 | flip-Header-Strip per **exakter GEN_NOTICE-Zeilen-Identität** statt Box-Zeichen-Heuristik (deterministisch) |
| REC-6 | `test_registry_canonical.py` pinnt **flip-Idempotenz** (Doppel-Header → 1) im #494-Gate |
| REC-7 | `safe_dump`-Lossiness in der `flip()`-Docstring benannt |
| REC-9 | Tool-Attestation `owner_from_override` → markiert **Transition-Owner** (ℹ TRANSITION) |
| REC-12 | Validierung: unbekannte `repo_owner`-Keys, `enterprise_owners`-Duplikate (⚠ VALIDATION) |

**58 Tests grün.** Verifiziert: zweimal flippen → 1 Header. Refs #488.
