### PR TITLE
docs(adr): Root Cause A — 4 Body-Nummern-Kollisionen korrigieren

### DIFF
--- a/docs/adr/ADR-180-package-consolidation-strategy.md
+++ b/docs/adr/ADR-180-package-consolidation-strategy.md
@@ -18,7 +18,7 @@ implementation_evidence:
 review_status: "reviewed — v2 re-reviewed, v3 addresses remaining 7 findings from ADR-146-v2-review.md"
 ---
 
-# ADR-146: Package Consolidation Strategy — 34 → 20 Packages (v3)
+# ADR-180: Package Consolidation Strategy — 34 → 20 Packages (v3)
 
 ## Änderungshistorie
 
@@ -47,7 +47,7 @@ ADR-027 entschied "Option A — Modulare Packages in `platform/packages/`" und l
 "Option B — Standalone PyPI / Ein Package mit Extras" ab. Die Erfahrung seit Februar 2026
 zeigt jedoch, dass 11 Einzelpackages in `platform/packages/` zu hoher Wartungslast führen
 und Consumer 3–5 separate `git+https://` Einträge in requirements.txt benötigen.
-ADR-146 wählt einen **Umbrella-Package-Ansatz als Kompromiss**: Sub-Packages bleiben
+ADR-180 wählt einen **Umbrella-Package-Ansatz als Kompromiss**: Sub-Packages bleiben
 intern eigenständig, werden aber über `iil-platform` gebündelt verteilt.
 
 ### Bestandsaufnahme (März 2026)
@@ -290,7 +290,7 @@ verteilt und erzeugen keine Consumer-Wartungslast:
 |--------|---------|
 | Alle `git+https://` eliminieren | Alle Sub-Packages auf PyPI publishen, Consumer auf PyPI-Pins migrieren |
 | `iil-` Prefix konsequent | Alle pip-Packages tragen `iil-` Prefix. Ausnahme: `nl2cad-core` (eigene Marke). |
-| INDEX.md aktualisieren | ADR-146 accepted, ADR-027 superseded |
+| INDEX.md aktualisieren | ADR-180 accepted, ADR-027 superseded |
 | Package-Inventar | `platform/docs/guides/package-inventory.md` mit Consumer-Matrix |
 
 ### Ergebnis-Übersicht
@@ -363,7 +363,7 @@ Bevor `iil-platform` als Umbrella funktioniert, MÜSSEN alle Sub-Packages auf Py
 ### Phase 4: Naming + Cleanup (Juli 2026) — Risiko: Niedrig
 
 1. Alle verbleibenden `git+https://` Installs durch PyPI-Pins ersetzen
-2. INDEX.md: ADR-146 → accepted, ADR-027 → superseded
+2. INDEX.md: ADR-180 → accepted, ADR-027 → superseded
 3. `platform/docs/guides/package-inventory.md` erstellen
 4. Finale Dokumentation
 

--- a/docs/adr/ADR-183-v2-concept-templates-package.md
+++ b/docs/adr/ADR-183-v2-concept-templates-package.md
@@ -8,13 +8,13 @@ consulted: []
 informed: []
 supersedes: []
 amends: []
-related: ["ADR-130-content-store-shared-persistence.md", "ADR-146-package-consolidation-strategy.md", "ADR-041-django-component-pattern.md", "ADR-022-platform-consistency-standard.md"]
+related: ["ADR-130-content-store-shared-persistence.md", "ADR-180-package-consolidation-strategy.md", "ADR-041-django-component-pattern.md", "ADR-022-platform-consistency-standard.md"]
 implementation_status: not_started
 implementation_evidence: []
 review_status: "v1 reviewed — 5 Blocker, 5 Kritisch korrigiert in v2"
 ---
 
-# ADR-147: `iil-concept-templates` — Shared Package für strukturierte Konzept-Vorlagen (v2)
+# ADR-183: `iil-concept-templates` — Shared Package für strukturierte Konzept-Vorlagen (v2)
 
 ## Änderungshistorie
 
@@ -59,7 +59,7 @@ dupliziert**, sondern für Phase A erweitert. Das Package liefert nur die
 - **DRY**: Template-Gliederung, PDF-Extraktion und LLM-Analyse sind domänenübergreifend identisch
 - **Bestehende Infrastruktur nutzen**: risk-hub `documents`-App als Upload-Backend
 - **outlinefw-Integration**: Framework-Registry + Gliederungs-Generierung via `iil-outlinefw`
-- **ADR-146**: Neues Package nur mit klarem Scope und ≥1 Consumer Tag 1, 2. Consumer geplant
+- **ADR-180**: Neues Package nur mit klarem Scope und ≥1 Consumer Tag 1, 2. Consumer geplant
 - **ADR-022**: BigAutoField, `BigIntegerField` tenant_id, Service-Layer, kein hardcoded SQL
 - **ADR-041**: Business-Logik im Service-Layer, nie in Views
 - **Platform-Standards**: Soft-Delete, public_id, i18n ab Tag 1
@@ -787,7 +787,7 @@ build-backend = "hatchling.build"
 [project]
 name = "iil-concept-templates"
 version = "0.1.0"
-description = "Shared schemas, frameworks and extraction for structured concept templates (ADR-147)"
+description = "Shared schemas, frameworks and extraction for structured concept templates (ADR-183)"
 readme = "README.md"
 license = {text = "Proprietary"}
 requires-python = ">=3.11"

--- a/docs/adr/ADR-184-contract-testing-strategy.md
+++ b/docs/adr/ADR-184-contract-testing-strategy.md
@@ -15,7 +15,9 @@ related:
   - ADR-022-code-quality.md
 ---
 
-# ADR-155: Adopt a Three-Layer Contract Testing Strategy for All Function and Method Calls
+# ADR-184: Adopt a Three-Layer Contract Testing Strategy for All Function and Method Calls
+
+> **Historie:** ursprünglich als ADR-155 entworfen; kanonische Nummer/Dateiname ist **ADR-184**. Artefakte unter `docs/adr/reviews/ADR-155-*` / `docs/adr/inputs/ADR-155-*` und der Code-Marker `# adr155-allow-kwargs` behalten die historische 155-Kennung bei (lebende Identifier).
 
 ## Metadaten
 

--- a/docs/adr/ADR-231-devhub-thin-bff-catalog-service.md
+++ b/docs/adr/ADR-231-devhub-thin-bff-catalog-service.md
@@ -52,7 +52,7 @@ größtenteils nicht besitzen sollte. Diese Besitz-Entscheidung ist die Bruchfl�
 **ADR-158 hat den richtigen Mechanismus bereits benannt** (Source-of-Truth-Matrix, „link-not-copy",
 D-5 „KEINE bidirektionalen Syncs"). dev-hub erfüllt ihn für die *Fremdsysteme* (Outline/Paperless:
 nur Deep-Links — `portal/services.py:resolve_outline_links` „KEIN Content-Copy") — **verletzt ihn
-aber für die In-House-Quellen** (Orchestrator/git/Runs forken Tabellen). ADR-230 zieht ADR-158 zu
+aber für die In-House-Quellen** (Orchestrator/git/Runs forken Tabellen). ADR-231 zieht ADR-158 zu
 Ende: dieselbe Disziplin für *alle* Spokes, plus die strukturelle Konsequenz (Entkernung des
 zustandsbehafteten Kerns).
 


### PR DESCRIPTION
Full-Scan **Root Cause A**: 4 ADRs trugen im *Body* die falsche Nummer — die strukturelle **Quelle** des plattformweiten Renumbering-Drifts (andere ADRs zitieren die Stale-Nummer → landen auf der falschen Datei).

| ADR | Body-H1 war | jetzt | Self-Refs |
|---|---|---|---|
| ADR-184 | `# ADR-155: Three-Layer Contract Testing` | `# ADR-184` + Historie-Note | — |
| ADR-180 | `# ADR-146: Package Consolidation` | `# ADR-180` | 3 (Package-Consolidation = self) |
| ADR-183 | `# ADR-147: concept-templates (v2)` | `# ADR-183` | Package-Rule 146→180, Pfad, pyproject |
| ADR-231 | Body „ADR-230 zieht ADR-158 zu" | „ADR-231 …" | self-ref (war 230) |

**Bewusst geschont** (kein Blind-Replace): ADR-184s Code-Marker `# adr155-allow-kwargs` (lebender Identifier in echtem Code) + die echten Dateipfade `docs/adr/reviews/ADR-155-*` / `inputs/ADR-155-*` — mit Historie-Note dokumentiert.

Jeder Edit exakt-string + zähl-verifiziert. validate: **183/183 grün**.

Hinweis: auf main liegt eine **lokal gestagte, nie committete** Fremd-Datei `ADR-DRAFT-security-by-construction-agent-containment.md` (fehlt `id`) — nicht Teil dieses PRs, nur lokales Artefakt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)