### PR TITLE
docs(adr): Root Cause B (klare Magnet-Repoints) — Content Store 062→130, Agent-Team 100→107

### DIFF
--- a/docs/adr/ADR-087-hybrid-search-architecture.md
+++ b/docs/adr/ADR-087-hybrid-search-architecture.md
@@ -82,7 +82,7 @@ Dies ist eine bewusste Ausnahme, dokumentiert in Übereinstimmung mit ADR-072 §
 
 ### DB-Zuordnung
 
-Die `search_chunks` Tabelle wird in der **Content Store DB** (`content_store`, vgl. ADR-062) angelegt:
+Die `search_chunks` Tabelle wird in der **Content Store DB** (`content_store`, vgl. ADR-130) angelegt:
 - Content Store ist bereits für AI-generierte/verarbeitete Inhalte vorgesehen
 - `CONTENT_STORE_DSN` ist bereits als Secret konfiguriert (ADR-045)
 - Apps connecten über `SearchService` → Content Store DB (read/write via Service-Layer)
@@ -113,7 +113,7 @@ Query
 #### 1. Vector Store (pgvector)
 
 ```sql
--- Deployed in content_store DB (ADR-062)
+-- Deployed in content_store DB (ADR-130)
 CREATE EXTENSION IF NOT EXISTS vector;
 
 CREATE TABLE search_chunks (
@@ -201,7 +201,7 @@ class SearchService:
     """Platform-wide hybrid search service.
     
     All methods are sync — safe for Django views and Celery tasks.
-    Uses content_store DB connection (ADR-062).
+    Uses content_store DB connection (ADR-130).
     """
     
     DB_ALIAS = "content_store"
@@ -413,7 +413,7 @@ PLATFORM_SEARCH = {
 
 - **pgvector nicht installiert**: `SearchService.search()` fällt auf reine FTS zurück, loggt Warning
 - **Embedding-API nicht erreichbar**: Nur FTS-Ergebnisse werden geliefert, `vector_results = []`
-- **Content Store DB nicht erreichbar**: `SearchServiceUnavailableError` wird geworfen, App degradiert graceful (wie ADR-062 Content Store Pattern)
+- **Content Store DB nicht erreichbar**: `SearchServiceUnavailableError` wird geworfen, App degradiert graceful (wie ADR-130 Content Store Pattern)
 
 ## Pros and Cons of the Options
 
@@ -509,7 +509,7 @@ Compliance wird verifiziert durch:
 - **ADR-021**: Platform Infrastructure — Expand-Contract Migration (§2.16)
 - **ADR-035**: Shared Django Tenancy Package — `TenantModel` base class
 - **ADR-045**: Secret Management — `OPENAI_API_KEY` via SOPS
-- **ADR-062**: Content Store — DB-Zuordnung für `search_chunks`
+- **ADR-130**: Content Store — DB-Zuordnung für `search_chunks`
 - **ADR-072**: Multi-Tenancy Schema-Isolation — begründete Abweichung (Row-Level)
 
 ### External References

--- a/docs/adr/ADR-088-notification-registry.md
+++ b/docs/adr/ADR-088-notification-registry.md
@@ -86,7 +86,7 @@ Dies ist eine bewusste Ausnahme, dokumentiert in Übereinstimmung mit ADR-072 §
 3. Service dispatcht **einen Celery-Task pro Channel** (`dispatch_notification_task.delay(log_id)`)
 4. Celery-Task führt `channel.deliver()` aus und aktualisiert Log-Status + `retry_count`
 
-Dadurch wird kein `async_to_sync` benötigt (vgl. ADR-062 §Content Store Pattern).
+Dadurch wird kein `async_to_sync` benötigt (vgl. ADR-130 §Content Store Pattern).
 
 ### Retry-Policy
 
@@ -624,7 +624,7 @@ Compliance wird verifiziert durch:
 - **ADR-021**: Platform Infrastructure — Zero Breaking Changes (§6.3)
 - **ADR-035**: Shared Django Tenancy Package — `TenantModel` base class
 - **ADR-045**: Secret Management — Twilio/Discord/Telegram Secrets via SOPS
-- **ADR-062**: Content Store — Sync-Pattern Referenz (kein async_to_sync)
+- **ADR-130**: Content Store — Sync-Pattern Referenz (kein async_to_sync)
 - **ADR-072**: Multi-Tenancy Schema-Isolation — begründete Abweichung (Row-Level)
 
 ### External References

--- a/docs/adr/ADR-115-grafana-agent-controlling-dashboard.md
+++ b/docs/adr/ADR-115-grafana-agent-controlling-dashboard.md
@@ -13,7 +13,7 @@ Accepted
 
 ## Context
 
-Das AI Engineering Squad (ADR-100) führt Tasks über 25 Repos aus und nutzt den LLM Gateway (ADR-114) für alle LLM-Calls. Bisher gibt es kein zentrales Controlling für:
+Das AI Engineering Squad (ADR-107) führt Tasks über 25 Repos aus und nutzt den LLM Gateway (ADR-114) für alle LLM-Calls. Bisher gibt es kein zentrales Controlling für:
 
 - **Kosten**: Tatsächliche LLM-Token-Kosten pro Task, Repo, Model
 - **Dauer**: Wie lange dauern Tasks und einzelne LLM-Calls?
@@ -140,7 +140,7 @@ Preise werden als Konfiguration gepflegt (OpenRouter-Preise, Stand 2026-03):
 
 ## References
 
-- ADR-100: Extended Agent Team + Deployment Agent
+- ADR-107: Extended Agent Team + Deployment Agent
 - ADR-112: Agent Skill Registry + Persistent Context
 - ADR-113: pgvector Memory Store
 - ADR-114: Discord IDE-like Communication Gateway + LLM Gateway

--- a/docs/adr/ADR-156-reliable-deployment-pipeline.md
+++ b/docs/adr/ADR-156-reliable-deployment-pipeline.md
@@ -9,7 +9,7 @@ amends: ["ADR-075-deployment-execution-strategy.md"]
 related:
   - ADR-021-unified-deployment-pattern.md
   - ADR-022-code-quality-docker-standards.md
-  - ADR-062-content-store.md
+  - ADR-130-content-store-shared-persistence.md
   - ADR-075-deployment-execution-strategy.md
   - ADR-090-cicd-pipeline-python-postgres.md
   - ADR-107-extended-agent-team-deployment-agent.md
@@ -745,7 +745,7 @@ wird nach mehreren Calls "vergiftet" — auch nachfolgende READ-Ops hängen.
 
 - **ADR-075**: Read/Write-Split — dieses ADR amended die Write-Op-Policy
 - **ADR-022**: Code Quality + Docker Standards — `COMPOSE_PROJECT_NAME` Pflicht
-- **ADR-062**: Content Store — Fail-Closed-Prinzip für Migrations
+- **ADR-130**: Content Store — Fail-Closed-Prinzip für Migrations
 - **ADR-107**: Deployment Agent — `shell_exec` Allowlist, Tier-Rollback
 - **ADR-021 §2.14**: `infra-deploy` Repository als Deployment-API
 - **Review-Input**: `platform/docs/adr/inputs/ADR-156/` (7 Dateien inkl. korrigierter Scripts)


### PR DESCRIPTION
Full-Scan **Root Cause B** — die *klaren* Magnet-Nummern-Repoints (verifizierte Ziele):

| Falsch-Zitat | von | Ziel | Verifikation |
|---|---|---|---|
| `ADR-062` als „Content Store" | ADR-087 (5×), ADR-088 (2×), ADR-156 | **ADR-130** | 062 real = Billing-Service; 130 = `content_store` shared persistence (graceful degradation bestätigt) |
| `ADR-100` als „Agent Team" | ADR-115 (2×) | **ADR-107** | 100 real = iil-testkit; 107 = „Erweitertes Agent-Team + Deployment Agent" (exakter Titel-Match) |

ADR-156-Pfad `ADR-062-content-store.md` (konstruiert + falsch) → `ADR-130-content-store-shared-persistence.md`.

## Bewusst NICHT hier (= Entscheidung, kein Repoint)
Der **`ADR-054` „Architecture Guardian"-Phantom**: ~9 ADRs (056/057/058/059/061/177/223/184/231) zitieren einen „Architecture Guardian", aber 054 = archiviertes deployment-preflight. Der Guardian ist real (`guardian.yml`), bekam aber nie eine überlebende ADR → braucht Owner-Entscheidung (Guardian-ADR anlegen vs. alle Refs auf `guardian.yml` zeigen).

Jeder Repoint exakt-string + zähl-verifiziert. validate: grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)