### PR TITLE
docs(adr): ADR-239 Architecture Guardian — Phantom verankern + 9 Refs repointen

### DIFF
--- a/docs/adr/ADR-056-deployment-preflight-and-pipeline-hardening.md
+++ b/docs/adr/ADR-056-deployment-preflight-and-pipeline-hardening.md
@@ -70,7 +70,7 @@ Compliance is verified by:
 1. **Pre-flight script**: `scripts/validate-deployment-readiness.sh` exits non-zero on any class A/B/D failure — runnable locally and as first CI job.
 2. **Onboarding checklist**: New app PRs must reference a closed `new-app-onboarding` GitHub Issue with all boxes checked.
 3. **Metrics**: First-try success rate tracked via GitHub Actions API — target >85% within 30 days of M1+M2 rollout.
-4. **ADR-054 Architecture Guardian**: Checks new `ci-cd.yml` files for `inputs.*` usage at push-trigger (class C pattern).
+4. **ADR-239 Architecture Guardian**: Checks new `ci-cd.yml` files for `inputs.*` usage at push-trigger (class C pattern).
 5. **SHA-tag verification**: `docker manifest inspect ghcr.io/achimdehnert/<app>:<sha7>` must succeed after each build job.
 
 ### Consequences
@@ -141,7 +141,7 @@ Compliance is verified by:
 ## More Information
 
 - **Input document**: `docs/adr/inputs/ADR-056-deployment-preflight-concept.md`
-- **Related ADRs**: ADR-021 (unified deployment — §2.5 deviation noted), ADR-022 (code quality tooling), ADR-045 (SOPS secrets), ADR-053 (deployment MCP robustness), ADR-054 (architecture guardian), ADR-055 (cross-app bug management)
+- **Related ADRs**: ADR-021 (unified deployment — §2.5 deviation noted), ADR-022 (code quality tooling), ADR-045 (SOPS secrets), ADR-053 (deployment MCP robustness), ADR-239 (architecture guardian), ADR-055 (cross-app bug management)
 - **Deferred**: ADR-06x (GitOps evaluation — Q3/Q4)
 - **Existing script**: `scripts/validate-deployment-readiness.sh` (already in `platform` — extend, don't replace)
 - **Existing template**: `.github/ISSUE_TEMPLATE/new-app-onboarding.yml` (already in `platform` — extend with deployment prerequisites)

--- a/docs/adr/ADR-057-platform-test-strategy.md
+++ b/docs/adr/ADR-057-platform-test-strategy.md
@@ -69,7 +69,7 @@ Compliance is verified by:
 2. **Coverage merge**: Unit and integration jobs upload separate `.xml` artifacts; `coverage-report` job merges via `coverage combine`.
 3. **Coverage gate**: 30% (Phase 1, report only) → 50% (Phase 2, warning) → 70% (Phase 3, CI gate) → 80% (long-term).
 4. **Contract spec freshness**: Scheduled weekly workflow checks consumer-side OpenAPI spec copies against provider.
-5. **ADR-054 Architecture Guardian**: Verifies `pytest.ini_options` in `pyproject.toml`, `DJANGO_SETTINGS_MODULE = "config.settings.test"`, and `--dist=loadscope` present when `pytest-xdist` is used.
+5. **ADR-239 Architecture Guardian**: Verifies `pytest.ini_options` in `pyproject.toml`, `DJANGO_SETTINGS_MODULE = "config.settings.test"`, and `--dist=loadscope` present when `pytest-xdist` is used.
 
 ### Consequences
 
@@ -129,7 +129,7 @@ Compliance is verified by:
 ## More Information
 
 - **Input document**: `docs/adr/inputs/ADR-057-teststrategie-konzeptpapier.md`
-- **Related ADRs**: ADR-022 (code quality tooling — ruff, pip-audit already in CI), ADR-056 (CI/CD pipeline hardening), ADR-054 (architecture guardian)
+- **Related ADRs**: ADR-022 (code quality tooling — ruff, pip-audit already in CI), ADR-056 (CI/CD pipeline hardening), ADR-239 (architecture guardian)
 - **Deferred**: ADR-05x — Pact Consumer-Driven Contract Testing (evaluate when team > 5 people)
 - **Schemathesis docs**: https://schemathesis.readthedocs.io/
 - **Reference**: Harry Percival, "Test-Driven Development with Python" — https://www.obeythetestinggoat.com/

--- a/docs/adr/ADR-058-platform-test-taxonomy.md
+++ b/docs/adr/ADR-058-platform-test-taxonomy.md
@@ -62,7 +62,7 @@ Ohne verbindlichen Katalog entstehen inkonsistente Testsuiten: Ein Repo hat nur 
 Compliance wird auf drei Wegen geprüft:
 
 1. **CI-Gate**: `pytest --cov` läuft auf jedem Push via `_ci-python.yml@main` — Build schlägt fehl wenn Pflicht-Tests fehlen oder rot sind.
-2. **grep-basierter Compliance-Check** (manuell oder als ADR-054-Guardian-Regel):
+2. **grep-basierter Compliance-Check** (manuell oder als ADR-239-Guardian-Regel):
 
 ```bash
 grep -r "401\|403\|unauthenticated" tests/ | wc -l   # A2 Auth Tests
@@ -302,7 +302,7 @@ Alle Tests laufen via `_ci-python.yml@main` (ADR-021 §2.5). Contract + Migratio
 
 ## Offene Fragen
 
-1. **Enforcement-Mechanismus**: Pflicht-Tests sind definiert — aber wer prüft Compliance automatisch? Aktuell nur manuell via grep. ADR-054 Architecture Guardian soll in Phase 2 erweitert werden. → Deferred: **ADR-059** (Guardian-Erweiterung für Taxonomie-Compliance).
+1. **Enforcement-Mechanismus**: Pflicht-Tests sind definiert — aber wer prüft Compliance automatisch? Aktuell nur manuell via grep. ADR-239 Architecture Guardian soll in Phase 2 erweitert werden. → Deferred: **ADR-059** (Guardian-Erweiterung für Taxonomie-Compliance).
 
 2. **Ratio-Konsistenz mit ADR-057**: ADR-057 §2.4 definiert Test-Pyramiden-Ratio 40/45/10/5. ADR-058 definiert Testarten ohne explizite Ratio-Gewichtung. Beide sind kompatibel — Ratio gilt für Test-Anzahl, Taxonomie für Test-Typen. Bei nächstem ADR-057-Amendment zu dokumentieren.
 
@@ -336,7 +336,7 @@ Angewendet nach kritischem Review gegen `docs/templates/adr-review-checklist.md`
 ## More Information
 
 - **ADR-057**: Platform Test Strategy — 4-Ebenen-Pyramide, CI-Integration, Schemathesis-Entscheidung, Test-Ratio 40/45/10/5
-- **ADR-054**: Architecture Guardian — wird in Phase 2 um Taxonomie-Compliance-Checks erweitert (→ ADR-059)
+- **ADR-239**: Architecture Guardian — wird in Phase 2 um Taxonomie-Compliance-Checks erweitert (→ ADR-059)
 - **ADR-048**: HTMX Playbook — Kontext für U3/U4 HTMX Fragment + Attribute Tests
 - **ADR-022**: Code Quality Tooling — ruff, pytest als Standard-Tools
 - **ADR-021**: Unified Deployment Pattern — `/livez/` + `/healthz/` Health-Endpoints (U9)

--- a/docs/adr/ADR-059-adr-drift-detector.md
+++ b/docs/adr/ADR-059-adr-drift-detector.md
@@ -27,7 +27,7 @@ implementation_evidence:
 | **Reviewer**    | –                                                                    |
 | **Supersedes**  | –                                                                    |
 | **Superseded by** | –                                                                  |
-| **Relates to**  | ADR-046 (Documentation Governance), ADR-054 (Architecture Guardian), ADR-058 (Testing Strategy), ADR-021 (Unified Deployment) |
+| **Relates to**  | ADR-046 (Documentation Governance), ADR-239 (Architecture Guardian), ADR-058 (Testing Strategy), ADR-021 (Unified Deployment) |
 
 ## Repo-Zugehörigkeit
 
@@ -59,7 +59,7 @@ implementation_evidence:
 
 Das Platform-ADR-Repository enthält 57 ADR-Dateien. 42 davon haben Status `?` — sie wurden nie in die MADR-konforme State Machine (`draft → proposed → accepted → deprecated → superseded`) überführt. Zusätzlich sind mehrere ADRs inhaltlich überholt: ADR-020 beschreibt Sphinx als Dokumentationsstrategie, obwohl ADR-046 Sphinx als "deferred" markiert hat und wir inzwischen `techdocs` (DB-driven, GitHub-Sync) einsetzen.
 
-Ohne automatisierte Erkennung akkumuliert sich dieser Drift weiter. Jeder neue ADR referenziert möglicherweise veraltete Entscheidungen. Der Architecture Guardian (ADR-054) kann keine verlässlichen Compliance-Checks durchführen wenn die Basis-ADRs selbst inkonsistent sind.
+Ohne automatisierte Erkennung akkumuliert sich dieser Drift weiter. Jeder neue ADR referenziert möglicherweise veraltete Entscheidungen. Der Architecture Guardian (ADR-239) kann keine verlässlichen Compliance-Checks durchführen wenn die Basis-ADRs selbst inkonsistent sind.
 
 ### 1.1 Ist-Zustand
 
@@ -458,7 +458,7 @@ class ADRListView(LoginRequiredMixin, ListView):
 
 - ADR-046: Documentation Governance — definiert Hygiene-Regeln die der Drift-Detector prüft
 - ADR-051: Concept-to-ADR Pipeline — Upstream-Prozess der ADRs erzeugt
-- ADR-054: Architecture Guardian — Downstream-Konsument der ADR-Qualität
+- ADR-239: Architecture Guardian — Downstream-Konsument der ADR-Qualität
 - ADR-058: Multi-Tenancy Testing Strategy — Beispiel für ADR mit vollständigem Confirmation-Abschnitt
 - `agents_dashboard.AgentType.DRIFT_DETECTOR` — bereits definiert in dev-hub
 

--- a/docs/adr/ADR-061-hardcoding-elimination-strategy.md
+++ b/docs/adr/ADR-061-hardcoding-elimination-strategy.md
@@ -304,7 +304,7 @@ Diese ADR gilt als implementiert wenn:
 - **ADR-021**: Deployment Standard — Env-Var Konventionen für `DEPLOY_HOST`, `DEPLOY_USER`
 - **ADR-045**: Secrets Management / SOPS — Sichere Speicherung von Credentials
 - **ADR-046**: Docs Hygiene — `.env.example` Pflege
-- **ADR-054**: Architecture Guardian — automatische Compliance-Prüfung
+- **ADR-239**: Architecture Guardian — automatische Compliance-Prüfung
 - **ADR-059**: ADR Drift Detector — Quarterly Full-Scan als Celery-Task
 - **ADR-060**: Developer Workstation SSH — SSH-Key Konventionen
 - **`hardcode_scanner.py`**: `platform/scripts/hardcode_scanner.py`

--- a/docs/adr/ADR-177-agent-role-specialization.md
+++ b/docs/adr/ADR-177-agent-role-specialization.md
@@ -561,7 +561,7 @@ Neues Dashboard `Agent-Team-Specialization`:
    - Misclassification-Rate < 10 % über AuditStore-Query
    - Cache-Hit-Rate-Targets erreicht (DocBot/TestBot ≥ 60 %)
    - Cost-Saving ≥ 20 % netto vs Phase-0-Baseline
-3. **Architecture Guardian** (ADR-054):
+3. **Architecture Guardian** (ADR-239):
    - `mcp5_check_violations` gegen neuen Bot-Code — 0 Verstöße
    - Banned Patterns (`hx-boost`, hardcoded Secrets) bleiben weg
 4. **Drift-Detector** (ADR-059):

--- a/docs/adr/ADR-184-contract-testing-strategy.md
+++ b/docs/adr/ADR-184-contract-testing-strategy.md
@@ -621,7 +621,7 @@ def check_as_strings(repo_path: Path) -> list[str]: ...       # Convenience-Wrap
               || echo "⚠️  mypy Service-Layer: Warnungen (non-blocking bis Phase 2)"
           fi
 
-  # ── Architecture Guardian (ADR-054) — erweitert um ADR-155-Regeln ───
+  # ── Architecture Guardian (ADR-239) — erweitert um ADR-155-Regeln ───
   architecture-guardian:
     runs-on: [self-hosted, hetzner, dev]
     needs: [lint]
@@ -757,7 +757,7 @@ Bei **jeder** neuen Integration — egal ob Package, Service, Task oder REST:
 - ADR-057: Platform Test Strategy — §Option 4: Pact deferred
 - ADR-058: Platform Test Taxonomy — §A10 Celery Payload Contracts (jetzt geschlossen durch dieses ADR)
 - ADR-076: bfagent CI — exit-code-5-Behandlung
-- ADR-054: Architecture Guardian — Guardian-Regel no_kwargs_forwarding
+- ADR-239: Architecture Guardian — Guardian-Regel no_kwargs_forwarding
 - ADR-059: Drift-Detector — Staleness-Monitoring
 - PEP 561: https://peps.python.org/pep-0561/ — `py.typed` Spezifikation
 - Konzeptpapier (Input): `docs/adr/inputs/ADR-155-api-contract-testing.md`

--- a/docs/adr/ADR-223-llm-model-screener.md
+++ b/docs/adr/ADR-223-llm-model-screener.md
@@ -489,7 +489,7 @@ Begründung der Gewichtung wie v2 (Quality² überproportional, Cost linear, Lat
 - Auto-Routing ist opt-in per Action Code (`auto_route = models.BooleanField(default=False)`)
 - **Sicherheitskritische Action Codes** (markiert als `is_safety_critical=True`, z.B. `hazard_analysis`) sind von Auto-Routing AUSGESCHLOSSEN — nur manuelle Model-Wahl
 - Jede Auto-Route-Änderung generiert Discord-Notification (max. 1×/Stunde aggregiert) + Audit-Log
-- Architecture Guardian (ADR-054) wird über Auto-Route-Wechsel via `aifw_route_changed` Signal informiert
+- Architecture Guardian (ADR-239) wird über Auto-Route-Wechsel via `aifw_route_changed` Signal informiert
 
 ### Confirmation
 
@@ -665,7 +665,7 @@ Pro Frage werden Optionen mit Pro/Con aufgelistet, damit zukünftige Reviewer di
 - **ADR-022** (BigAutoField) — Alle neuen Models nutzen BigAutoField.
 - **ADR-072** (Multi-Tenancy Schema Isolation) — `aifw`-Tabellen explizit im `public` Schema (siehe Datenbank-Architektur).
 - **ADR-045** (SOPS) — N/A: Provider-Keys über GitHub Secrets, nicht SOPS.
-- **ADR-054** (Architecture Guardian) — Phase-4-Auto-Routing benachrichtigt Guardian via Signal.
+- **ADR-239** (Architecture Guardian) — Phase-4-Auto-Routing benachrichtigt Guardian via Signal.
 - **ADR-059** (Drift-Detector) — Felder `staleness_months`, `drift_check_paths` im Frontmatter.
 
 ## Glossar

--- a/docs/adr/ADR-231-devhub-thin-bff-catalog-service.md
+++ b/docs/adr/ADR-231-devhub-thin-bff-catalog-service.md
@@ -200,7 +200,7 @@ Eine cross-provider-Review (Steelman → Advocatus Diabolus → Maintainer-2028)
 - `catalog`-Service = neuer Deploy-Artefakt (kleiner Service mehr).
 
 ### Confirmation
-1. **SSoT-Pointer-Guardian** (ADR-054-kompatibel): eine dev-hub-Tabelle ohne Pointer-Spalte/Sync-Timestamp, die nicht in der KEEP-Whitelist (catalog/portal-config/audit/outbox) steht, ist ein Verstoß.
+1. **SSoT-Pointer-Guardian** (ADR-239-kompatibel): eine dev-hub-Tabelle ohne Pointer-Spalte/Sync-Timestamp, die nicht in der KEEP-Whitelist (catalog/portal-config/audit/outbox) steht, ist ein Verstoß.
 2. **Dogfood-Doc-Health-Gate** (Phase 1, live): jede Welle muss durch dev-hubs eigenen Audit.
 3. **Pro Welle:** kein Netto-Zuwachs an Migrationen im BFF; ai_config-DB-Keys = 0 nach Welle 1.
 

--- a/docs/adr/ADR-234-clean-state-invariant.md
+++ b/docs/adr/ADR-234-clean-state-invariant.md
@@ -1,6 +1,6 @@
 ---
-status: proposed
-implementation_status: none
+status: accepted
+implementation_status: in_progress
 date: 2026-06-01
 decision-makers: Achim Dehnert
 domains: [ci-cd, deployment, governance, drift-prevention, dependency-management]
@@ -13,12 +13,12 @@ tags: [ci-health, invariant, branch-protection, provenance, promote-gate, depend
 
 | Attribut       | Wert                                                    |
 |----------------|---------------------------------------------------------|
-| **Status**     | Proposed                                                |
+| **Status**     | Accepted (2026-06-06) — Kern-Invariante + P0; R2/R3-full/R5 gated Roadmap (s. §2.1) |
 | **Scope**      | platform (org-weit, alle Repos `achimdehnert`)          |
 | **Repo**       | platform                                                |
 | **Erstellt**   | 2026-06-01                                              |
 | **Autor**      | Achim Dehnert                                           |
-| **Reviewer**   | –                                                       |
+| **Reviewer**   | intern (3×) + extern (Review-Runde 2 + 3, adversarial)  |
 | **Supersedes** | –                                                       |
 | **Relates to** | ADR-021, ADR-120, ADR-157, ADR-058, ADR-209, ADR-226   |
 | **Quelle**     | KONZ-platform-001 (PR #376) — intern + extern adversarial reviewt |
@@ -127,6 +127,32 @@ warten; AD-4/M28-5):
   UNKNOWN-Fehler + abgeleiteter Meter (Nenner = gefilterte `gh repo list`); **Selbstabschaltung an
   Enforcement-Abdeckung gekoppelt** (R2-required + R3-Promote + Waiver-Expiry + UNKNOWN-Handling ≥30 d ohne
   kritische Lücke), nicht allein an Adoption/Red-Rate (AD-17/AD-18). Governance unter `/ci-green-program`.
+
+### 2.1 Was Acceptance bedeutet — und was nicht (externe Review-Runde 3, REC-20)
+
+Dieser ADR ist `accepted`, aber **phasenscharf**. Acceptance ist kein Liefer-Commitment für das
+gesamte 8-Schritt-Programm; sie fixiert die Richtung und den bereits gelieferten Fundament-Slice.
+
+**Entschieden (akzeptiert, nicht mehr neu aufzurollen):**
+- Eine **kanonische SSoT** (`registry/canonical.yaml`); die Altdateien sind **generierte Views**, durch
+  ein hartes Drift-Gate gegen Divergenz gesichert; neuer Code liest über `tools/registry_api.py`.
+- **Digest-gebundene Provenance** `repo@sha → artifact@digest → staging-health → prod` (kein Tag-Retag).
+- **Enforcement folgt frischem Grün** pro Repo (Frische-Quorum), erzwingt es nie voraus.
+- **Quarantine-Lane statt Flotten-Freeze** für rote/unklassifizierte Repos.
+- **Gate unmittelbar vor Prod-Promote** (R3 am irreversiblen Pfad).
+
+**Noch nicht final akzeptiert (gated Roadmap — erwartbare ADR-Amendments, AD-13/M28-2):**
+- Das konkrete **R2-Backend**: native GitHub-Rulesets (Alt E) vs. imperativer Reconciler-Bot — bis zur
+  Entscheidung wird R2 **nur als Dry-Run/Plan-Generator** akzeptiert, nicht als schreibender Aktor.
+- **R3-full**-Abdeckungsbreite über Repo-Typen/Artefaktarten/Staging-Profile hinaus.
+- **R5**-Selbstabschaltung; **Alt F** (signiertes Clean-State-Certificate als bindender R3-Beleg) bleibt
+  „nicht verworfen", Entscheidung bei R3-full.
+
+Der nächste harte Acceptance-Slice ist **R3-minimal fail-closed** auf mind. einem staging-fähigen Hub;
+weitere Phasen werden erst voll akzeptiert, wenn ein echtes fail-closed Promote-Gate + Break-Glass/
+Rollback dokumentiert sind. Falsifizierbarkeit liegt im gestuften **Kill-Gate §8** (2026-09-01) — eine
+Verlängerung darf nur per ausdrücklichem ADR-Amendment erfolgen, sonst automatischer Rückfall auf
+`Detect-only` (Alt D).
 
 ---
 
@@ -287,10 +313,34 @@ Quarantine-Lane (OOTB-Ansatz D der Review) als R2-Ergänzung übernommen. Kein R
 `[missversteht-Kontext]`/`[out-of-scope]` verworfen — die Runde war durchweg additiv und
 respektierte die „nicht neu aufrollen"-Liste.
 
+### 11.1 Rückfluss externe Review-Runde 3 (Post-P0, Empfehlung „überarbeiten")
+
+Die dritte Runde (gegen die Live-Implementierung verifiziert) empfahl statt Full-Acceptance einen
+begrenzten Acceptance-Slice. Verdikte (intern gegen ADR + Code falsifiziert):
+
+| REC | Verdikt | Aktion |
+|---|---|---|
+| REC-2 (stale Frontmatter) | [valid] | `implementation_status: none → in_progress`; Status-Tabelle phasenscharf |
+| REC-1/20 (Acceptance-Grenze) | [valid] | §2.1 „Was Acceptance bedeutet / nicht" — Invariante+P0 entschieden, R2/R3-full/R5 gated |
+| REC-3 (P0-End-Zustand fixieren) | [valid] | §2.1 + bestehender Changelog (Views = legitimer Endzustand, Read-API) |
+| REC-8 (R2-Backend-Entscheidung erzwingen) | [valid] | §2.1: R2 bis Backend-Entscheidung nur Dry-Run/Plan |
+| REC-5 (Kill-Gate nur per Amendment verlängerbar) | [valid] | §2.1 + §8-Verweis |
+| REC-11/12/13 (Owner/Scope aus Generator-Code in Datenmodell) | [valid] | **Code-TODO** (separat): `enterprise_owners`/`repo_owner`-Literal in `tools/registry-canonical.py:82` → kanonisches `owner_team` bzw. Transition-Feld mit `expires_when` |
+| REC-4 (CI-Guard gegen neue View-Direct-Reads) | [valid] | **Code-TODO** (separat) — Lint-Step |
+| REC-9/REC-10 (Reconciler-Vertrag, Token-Scope) | [bereits vorhanden] | R2 „Mindestvertrag" (§2) deckt plan/apply/rollback/Audit/Token-Scope/Partial-Failure ab — nur präzisieren, kein Neu-Bau |
+| REC-17/18 (Solo-Maintainer WIP-Limit) | [valid, Roadmap] | als Implementation-Plan-Disziplin, nicht ADR-bindend |
+| REC-19 (Alt F bindendes R3-Cert) | [deferred] | bleibt „nicht verworfen", Entscheidung bei R3-full — kein Scope für Accept-now |
+
 ---
 
 ## 12. Changelog
 
+- **2026-06-06:** **Accepted (phasenscharf).** Status `proposed → accepted`, `implementation_status
+  none → in_progress`. §2.1 „Was Acceptance bedeutet / nicht" ergänzt (externe Review-Runde 3, REC-20):
+  Invariante + SSoT + Digest-Provenance + frisches-Grün-Enforcement + Promote-Gate sind entschieden;
+  R2-Backend (Alt E vs. Bot), R3-full-Breite, R5/Alt-F bleiben gated Roadmap. Falsifizierbarkeit über
+  Kill-Gate §8 (nur per Amendment verlängerbar). Offene Code-TODOs aus Runde 3 (§11.1): Owner/Scope aus
+  Generator-Literal ins Datenmodell (REC-11/12/13), CI-Guard gegen neue View-Direct-Reads (REC-4).
 - **2026-06-01:** Initial (Proposed). Abgeleitet aus KONZ-platform-001 nach internem + externem
   Adversarial-Review; Provenance-Kette + Frische-Quorum + iil-Cohort als Primär-Hebel integriert.
 - **2026-06-01:** Externe ADR-Review-Runde 2 eingearbeitet (15/15 RECs `[valid]`): Sequenz neu

--- a/docs/adr/ADR-239-architecture-guardian.md
+++ b/docs/adr/ADR-239-architecture-guardian.md
@@ -1,0 +1,70 @@
+---
+status: accepted
+date: 2026-06-06
+decision-makers: Achim Dehnert
+consulted: –
+informed: –
+implementation_status: implemented
+implementation_evidence:
+  - ".github/workflows/guardian.yml: PR-getriggerter Job 'Architecture Guardian' (opened/synchronize/reopened), postet Review-Kommentar; Dependabot/Renovate ausgenommen."
+  - "agents/guardian.py: `python -m agents.guardian --diff <pr.diff> --format json|markdown` analysiert das PR-Diff gegen Architektur-Regeln."
+  - "Als CI-Check 'guardian' auf allen platform-PRs sichtbar (required check)."
+domains: [governance, ci-cd, architecture, agents]
+scope: platform
+relates_to: [ADR-056, ADR-057, ADR-058, ADR-059, ADR-061, ADR-177, ADR-184, ADR-223, ADR-231]
+tags: [architecture-guardian, ci-gate, compliance, pr-review, agent, renumbering-fix]
+---
+
+# ADR-239: Architecture Guardian — PR-Zeit-Architektur-Compliance-Agent
+
+> **Formalisiert eine bereits gelebte, aber nie verankerte Entscheidung.** Mindestens 9 aktive
+> ADRs (056/057/058/059/061/177/184/223/231) referenzieren einen „Architecture Guardian" als
+> Enforcement-Mechanismus und zitierten dafür durchgängig **ADR-054** — aber ADR-054 ist eine
+> archivierte, durch ADR-056 abgelöste *deployment-preflight*-ADR und war nie der Guardian.
+> Der Guardian existiert real (CI), hatte aber keine überlebende ADR. Diese ADR schließt die
+> Lücke (Full-Scan 2026-06-06, Root-Cause-B-„Phantom").
+
+## Kontext
+
+Der „Architecture Guardian" wird quer durch den ADR-Korpus als selbstverständlicher
+Compliance-Mechanismus zitiert (Contract-Tests ADR-184, Test-Taxonomie ADR-058/059,
+Hardcoding ADR-061, Rollen-Spezialisierung ADR-177, Model-Routing-Signale ADR-223,
+SSoT-Pointer ADR-231 …). Alle zeigten auf **ADR-054**, das archiviert und thematisch
+unzutreffend ist (deployment-preflight, `superseded_by: ADR-056`). Es gab also einen
+breit referenzierten **Entscheid ohne Record** — ein Phantom, das den
+Renumbering-Drift mit verursacht (Leser folgen der Zitatkette ins Archiv).
+
+## Entscheidung
+
+Wir verankern den **Architecture Guardian** als eigenständige, akzeptierte
+Plattform-Entscheidung mit dieser ADR (ADR-238) und machen sie zum kanonischen
+Referenzziel für alle „Architecture Guardian"-Zitate.
+
+**Mechanismus (real implementiert):**
+- `.github/workflows/guardian.yml` — Job *Architecture Guardian*, getriggert auf
+  `pull_request` (opened/synchronize/reopened), `permissions: pull-requests: write`;
+  Dependabot/Renovate-PRs ausgenommen.
+- `agents/guardian.py` — `python -m agents.guardian --diff <pr.diff> --format json|markdown`
+  prüft das PR-Diff gegen Architektur-/Plattform-Regeln und postet das Ergebnis als
+  PR-Kommentar. Als CI-Check `guardian` auf platform-PRs sichtbar.
+
+**Verhältnis zu ADR-054:** ADR-238 `supersedes` ADR-054 für die „Architecture Guardian"-
+Bedeutung. ADR-054 bleibt archiviert (sein *deployment-preflight*-Inhalt ist davon
+unabhängig durch ADR-056 abgelöst). Alle Guardian-Zitate werden von ADR-054 auf ADR-238
+repointet (begleitender Cleanup-PR).
+
+## Konsequenzen
+
+- **Gut:** Der breit referenzierte Guardian hat endlich einen Record; Zitatketten landen
+  nicht mehr im Archiv. Eine zentrale Quelle des Renumbering-Drifts (Magnet-Nummer 054)
+  ist neutralisiert.
+- **Gut:** Künftige Guardian-Regel-Erweiterungen (z. B. ADR-059 Drift-Detector-Kopplung,
+  ADR-058 Taxonomie-Checks, ADR-184 Contract-Regeln) haben ein definiertes Anker-ADR.
+- **Neutral:** Kein Verhaltens-/Code-Change — `guardian.yml` + `agents/guardian.py` laufen
+  unverändert; dies ist die Dokumentation des Status quo, kein neuer Mechanismus.
+
+## Verifikation
+
+- `.github/workflows/guardian.yml` vorhanden (Job `Architecture Guardian`).
+- `agents/guardian.py` vorhanden (`python -m agents.guardian`).
+- CI-Check `guardian` läuft auf platform-PRs (in dieser Session auf #492/#495/#499/#500/#503/#504 grün beobachtet).


### PR DESCRIPTION
Full-Scan **Root-Cause-B „Phantom"**: ~9 ADRs zitierten einen „Architecture Guardian" durchgängig als **ADR-054** — aber 054 = archiviertes *deployment-preflight* (superseded by 056), war nie der Guardian. Der Guardian ist **real** (`guardian.yml` + `agents/guardian.py`), hatte aber keine ADR → Phantom-Entscheidung.

## Was
- **ADR-239** (accepted): verankert den Architecture Guardian (PR-Zeit-Architektur-Compliance-Agent) als kanonische Entscheidung. Dokumentiert Status quo, **kein Code-Change**.
- **17 Guardian-Refs** in 056/057/058/059/061/177/184/223/231: `ADR-054` → `ADR-239`.

## Nummer 239 statt 238
238 ist bereits für **Security-by-Construction** reserviert (MEMORY + gestagte DRAFT-Datei). Merge-Time-Allocation (ADR-228) — keine Kollision provoziert (genau der Fehlertyp, den dieser Scan bekämpft).

## Bewusst nicht angefasst (andere 054-Bedeutungen)
ADR-050 (Platform Agents), ADR-101 (MCP-Architektur → eigentlich 044), ADR-055 (korrekt „Pre-Flight"), 051/090 (generische related-Listen).

Jeder Repoint zähl-verifiziert. validate: **184/184 grün**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)