### PR TITLE
docs(adr): Secrets-Reconciliation (045↔159) + Auth-Korrektur (227 faktisch falsch)

### DIFF
--- a/docs/adr/ADR-045-secrets-management.md
+++ b/docs/adr/ADR-045-secrets-management.md
@@ -2,12 +2,14 @@
 status: accepted
 date: 2026-02-21
 decision-makers: Achim Dehnert
-implementation_status: implemented
+implementation_status: partial
 implementation_evidence:
   - "all hubs: decouple.config() for secrets"
 ---
 
 # ADR-045: Secrets & Environment Management
+
+> **Kanonisches Ziel (Secrets-Reconciliation 2026-06-06):** SOPS + `/run/secrets` (diese ADR) ist die beschlossene **Ziel-Architektur** fuer Plattform-Secrets — sicherer als plaintext `.env.prod` (relevant seit risk-hub/tax-hub Prod mit Kundendaten). **Status-Ehrlichkeit:** die Migration ist noch **unvollstaendig** (Phase 2/3/7 ausstehend, nur bfagent+dev-hub umgestellt) — die gelebte Realitaet laeuft derzeit ueber ADR-159 (`.env.prod`+decouple). Die Fertigstellung ist ein **gegateter Prod-/Mehr-Repo-Strang** (eigener Plan), kein Auto-Rollout. Loest den Full-Scan-Konflikt 045<->159 (Owner-Entscheidung: SOPS wiederbeleben).
 
 | Metadata | Value |
 |----------|-------|

--- a/docs/adr/ADR-159-shared-secrets-management.md
+++ b/docs/adr/ADR-159-shared-secrets-management.md
@@ -5,6 +5,8 @@ decision-makers: [Achim Dehnert]
 ---
 # ADR-159: Shared Secrets Management — Single Source of Truth für API Keys
 
+> **Re-Scope (Secrets-Reconciliation 2026-06-06):** Das hier beschriebene `.env.prod`+`decouple.config`-Modell ist der **derzeit deployte Ist-Zustand (Interim)**, NICHT das kanonische Ziel. Beschlossen (2026-06-06): Ziel-Architektur ist SOPS + `/run/secrets` aus ADR-045 (sicherer, verschluesselt-in-Git). Diese ADR bleibt die Doku der **laufenden Realitaet**, bis die SOPS-Migration abgeschlossen ist. Loest den Full-Scan-Konflikt 045<->159.
+
 - **Status:** accepted
 - **Date:** 2026-04-08
 - **Deciders:** Achim Dehnert, Cascade

--- a/docs/adr/ADR-227-klickdummy-feedback-bridge.md
+++ b/docs/adr/ADR-227-klickdummy-feedback-bridge.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-227
 title: "Klickdummy-Feedback-Bridge (Pfad B): CF-Worker statt User-PAT"
-status: proposed
+status: draft
 date: 2026-05-29
 deciders: [Achim Dehnert]
 consulted: []
@@ -18,6 +18,8 @@ scope:
 ---
 
 # ADR-227 — Klickdummy-Feedback-Bridge (Pfad B): CF-Worker statt User-PAT
+
+> WARNUNG **Korrektur erforderlich (Auth-Substrat falsch, 2026-06-06):** Diese ADR baut auf der Annahme, iil.pet liege hinter **Cloudflare Access** (ADR-216) — das ist **faktisch falsch**. ADR-216 etabliert **Authentik forwardAuth** (verifiziert: `platform/infra/klickdummy-host/` nutzt `klickdummy-sso`-Middleware + `outpost.goauthentik.io`; die Cloudflare-Praesenz ist ein *Tunnel* fuer Ingress, **nicht** *Access* fuer Auth). Zudem **architektonisch inkompatibel**: ein CF-Worker am Edge sieht die origin-seitige Authentik-Identitaet nicht (Cf-Access-Jwt-Assertion existiert nicht). **Redesign noetig** (Bridge-Auth auf Authentik-Identitaet neu aufsetzen) — daher Status `draft`. Loest den Full-Scan-Konflikt 227<->216.
 
 | Attribut       | Wert                                             |
 |----------------|--------------------------------------------------|


### PR DESCRIPTION
Die zwei verbleibenden **HIGH**-Konflikte aus dem Full-Scan, Owner-entschieden + geerdet.

## Secrets (ADR-045 ↔ 159) — Entscheidung: SOPS wiederbeleben
- **ADR-045** (SOPS + `/run/secrets`) = **kanonisches Ziel**; `implementation_status` ehrlich von `implemented` → **`partial`** (Phase 2/3/7 ausstehend, nur bfagent+dev-hub).
- **ADR-159** (`.env.prod` + decouple) re-scoped als **deployter Interim-Zustand**, nicht Ziel.
- ⚠️ **Implementierung** (Prod-Secret-Migration über ~25 Repos) = **gegateter eigener Prod-/Mehr-Repo-Strang**, bewusst NICHT in diesem PR (Scope-Checkpoint).

## Auth (ADR-227 ↔ 216) — 227 faktisch falsch
Verifiziert gegen die echte Deployment-Config: **216 = Authentik forwardAuth** (`platform/infra/klickdummy-host/` → `klickdummy-sso`-Middleware + `outpost.goauthentik.io`; Cloudflare = nur *Tunnel*, nicht *Access*). ADR-227s „Cloudflare Access"-Prämisse ist falsch **und** architektonisch inkompatibel (CF-Worker am Edge sieht origin-seitige Authentik-Identität nicht).
→ **ADR-227 → `status: draft`** (Redesign nötig: Bridge-Auth auf Authentik-Identität) + Korrektur-Note.

validate: **184/184 grün**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)