### PR TITLE
chore(registry): REC-4 Guard gegen neue View-Direct-Reads (ADR-234 §11.1)

### DIFF
--- a/.github/workflows/registry-consistency.yml
+++ b/.github/workflows/registry-consistency.yml
@@ -19,6 +19,8 @@ on:
       - 'scripts/repo-registry.yaml'
       - 'registry/repos.yaml'
       - 'tools/registry-consistency-check.py'
+  pull_request:
+    branches: [main]        # REC-4 View-Reader-Guard fängt NEUE Direct-Reads vor dem Merge
 
 permissions:
   contents: read
@@ -43,3 +45,8 @@ jobs:
           # wenn jemand eine View von Hand editiert oder canonical.yaml ändert
           # ohne `flip` neu laufen zu lassen (committet ≠ generiert).
           python3 tools/registry-canonical.py verify
+      - name: View-Reader-Guard (HARTES GATE, ADR-234 §11.1 REC-4)
+        run: |
+          # FAILT, wenn NEUER Code die generierten Views direkt liest statt
+          # tools/registry_api.py — verhindert, dass die Views wieder SSoT werden.
+          python3 tools/check_registry_view_readers.py

--- a/docs/adr/ADR-045-secrets-management.md
+++ b/docs/adr/ADR-045-secrets-management.md
@@ -19,9 +19,9 @@ implementation_evidence:
 | **Author** | Achim Dehnert |
 | **Reviewers** | ADR Board |
 | **Supersedes** | — |
-| **Related** | ADR-021 (Unified Deployment), ADR-022 (Platform Consistency), ADR-044 (MCP-Hub Architecture), ADR-056 (Multi-Tenancy) |
+| **Related** | ADR-021 (Unified Deployment), ADR-022 (Platform Consistency), ADR-044 (MCP-Hub Architecture), ADR-072 (Multi-Tenancy) |
 | **Based on** | `konzept-env-secrets-management.md`, `review-secrets-management.md` |
-| **Version** | 3 (2026-02-21: implementation status review, ADR-056 gap added) |
+| **Version** | 3 (2026-02-21: implementation status review, ADR-072 gap added) |
 
 ---
 
@@ -62,9 +62,9 @@ All apps currently use `.env.prod` files on the Hetzner server (`88.198.191.108`
 `/run/secrets/` existiert noch nicht — wird beim ersten SOPS-Deploy erstellt.
 `.env.prod` bleibt als Fallback aktiv bis Phase 7 abgeschlossen ist.
 
-### Gap: ADR-056 Multi-Tenancy (travel-beat)
+### Gap: ADR-072 Multi-Tenancy (travel-beat)
 
-ADR-056 introduced `apps.tenants` with `Client` and `Domain` models in travel-beat.
+ADR-072 introduced `apps.tenants` with `Client` and `Domain` models in travel-beat.
 The tenant provisioning step (creating the default `drifttales` tenant) currently runs
 as an inline `manage.py shell` command in `deploy-remote.sh`. This is acceptable for
 Phase 1 but must be revisited in ADR-045 Phase 5:
@@ -459,7 +459,7 @@ Add SOPS decrypt step to GitHub Actions deploy workflow (`_deploy-hetzner.yml`):
     echo "All required secrets verified."'
 ```
 
-**Note (ADR-056 interaction):** For travel-beat, the SOPS decrypt step must run
+**Note (ADR-072 interaction):** For travel-beat, the SOPS decrypt step must run
 **before** `migrate_schemas`, as the DB connection requires `DATABASE_URL` from
 `/run/secrets/`. The tenant provisioning step in `deploy-remote.sh` is unaffected
 (it runs after container start, which reads from `/run/secrets/` via `read_secret()`).
@@ -598,7 +598,7 @@ when a concrete use case arises. This ADR focuses strictly on secrets.
    declare its required secrets (for Phase 5 verification step). Format TBD
    (e.g., `REQUIRED_SECRETS` list in `config/secrets.py` or `.secrets-manifest`).
 
-4. **ADR-056 interaction**: travel-beat uses `django-tenants` — the `DATABASE_URL`
+4. **ADR-072 interaction**: travel-beat uses `django-tenants` — the `DATABASE_URL`
    secret must be available before `migrate_schemas --shared` runs. The ordering
    in `_deploy-hetzner.yml` (SOPS decrypt → migrate → tenant provision) must be
    validated when Phase 5 is implemented.
@@ -611,4 +611,4 @@ when a concrete use case arises. This ADR focuses strictly on secrets.
 |---------|------|--------|
 | 1 | 2026-02-18 | Initial draft |
 | 2 | 2026-02-18 | Incorporates critical review R-01 through A-06 |
-| 3 | 2026-02-21 | Implementation status review: all phases still pending. `.sops.yaml` committed to `platform`. ADR-056 gap documented. Open Question 4 added. |
+| 3 | 2026-02-21 | Implementation status review: all phases still pending. `.sops.yaml` committed to `platform`. ADR-072 gap documented. Open Question 4 added. |

--- a/docs/adr/ADR-055-cross-app-bug-management.md
+++ b/docs/adr/ADR-055-cross-app-bug-management.md
@@ -191,7 +191,7 @@ Analysiere den Bug, finde die Ursache in `{repo_path}` und behebe ihn minimal.
 
 - **Implements**: ADR-015 (Platform Governance System)
 - **Extends**: ADR-049 (App Identity Standard)
-- **References**: ADR-054 (Deployment Pre-Flight Validation)
+- **References**: ADR-056 (Deployment Pre-Flight Validation & Pipeline Hardening)
 
 ---
 

--- a/docs/adr/ADR-101-mcp-plattform-konzept.md
+++ b/docs/adr/ADR-101-mcp-plattform-konzept.md
@@ -18,7 +18,7 @@ informed: –
 | **Autor**       | Cascade + Achim Dehnert |
 | **Reviewer**    | Claude (2026-03-06) |
 | **Supersedes**  | – |
-| **Relates to**  | ADR-044 (FastMCP-Standard), ADR-054 (MCP-Architektur), ADR-059 (Drift-Detector) |
+| **Relates to**  | ADR-044 (FastMCP-Standard), ADR-059 (Drift-Detector) |
 
 ## Repo-Zugehoerigkeit
 
@@ -480,7 +480,7 @@ eigene Kategorie zwingend (z.B. docs-search braucht pgvector).
 
 - [MCP Specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25)
 - ADR-044: MCP-Hub Architecture Consolidation (FastMCP-Standard)
-- ADR-054: MCP-Architektur Grundlagen
+- ADR-044: MCP-Hub Architecture Consolidation
 - ADR-059: Drift-Detector
 - ADR-062: Central Billing Service (billing-hub)
 - ADR-069: Web Intelligence MCP

--- a/docs/adr/ADR-131-shared-backend-services.md
+++ b/docs/adr/ADR-131-shared-backend-services.md
@@ -6,7 +6,7 @@ consulted: []
 informed: []
 supersedes: []
 amends: []
-related: ["ADR-022-platform-consistency-standard.md", "ADR-041-service-layer-pattern.md"]
+related: ["ADR-022-platform-consistency-standard.md", "ADR-192-django-service-layer-htmx-compliance-scanner.md"]
 implementation_status: implemented
 implementation_evidence:
   - "Own repo: https://github.com/achimdehnert/iil-django-commons (v0.3.0)"

--- a/docs/adr/ADR-133-shared-ai-services-package.md
+++ b/docs/adr/ADR-133-shared-ai-services-package.md
@@ -13,7 +13,7 @@ decision-makers: Achim Dehnert
 | **Status** | Proposed |
 | **Date** | 2026-02-28 |
 | **Author** | Achim Dehnert |
-| **Related** | ADR-089 (LiteLLM DB-driven), ADR-093 (AI Config App), ADR-091 (Shared Backend Services) |
+| **Related** | ADR-089 (LiteLLM DB-driven), ADR-093 (AI Config App), ADR-131 (Shared Backend Services) |
 
 ---
 

--- a/docs/adr/ADR-149-dms-hub-dvelop-platform-service.md
+++ b/docs/adr/ADR-149-dms-hub-dvelop-platform-service.md
@@ -15,7 +15,7 @@ related:
   - ADR-072-multi-tenancy-schema-isolation.md
   - ADR-075-deployment-execution-strategy.md
   - ADR-078-docker-healthcheck-convention.md
-  - ADR-146-package-consolidation-strategy.md
+  - ADR-180-package-consolidation-strategy.md
   - ADR-148-recruiting-hub-architecture.md
 implementation_status: partial
 implementation_evidence:
@@ -46,7 +46,7 @@ drift_check_paths:
 - **Mehrere Consumer-Hubs**: risk-hub (Compliance), billing-hub (Rechnungen), recruiting-hub (Verträge) benötigen DMS-Archivierung — eine eingebettete App pro Hub wäre Codeduplizierung.
 - **d.velop REST API verfügbar**: IIL hat d.velop Cloud gebucht (`https://iil.d-velop.cloud/`); API produktionsreif (JSON-HAL, Bearer-Auth, Webhook-Support).
 - **Entkopplung von Paperless-ngx**: Paperless-ngx (ADR-144) ist für IIL-interne Dokumente. d.velop ist für behördliche/kundenseitige revisionssichere Archivierung.
-- **Platform-Konsistenz**: Neuer Hub nach ADR-050-Pattern, neues Package nach ADR-146-Pattern.
+- **Platform-Konsistenz**: Neuer Hub nach ADR-050-Pattern, neues Package nach ADR-180-Pattern.
 
 ---
 
@@ -827,7 +827,7 @@ Diese ADR gilt als implementiert, wenn:
 | ADR-075 | Deployment via GitHub Actions |
 | ADR-078 | Docker HEALTHCHECK Convention |
 | ADR-144 | Paperless-ngx (IIL-intern) — Abgrenzung zu d.velop (Kunden-DMS) |
-| ADR-146 | Package Consolidation (iil-dvelop-client als neues Package) |
+| ADR-180 | Package Consolidation (iil-dvelop-client als neues Package) |
 
 ---
 

--- a/docs/adr/ADR-165-reflex-review-engine-with-grafana-controlling.md
+++ b/docs/adr/ADR-165-reflex-review-engine-with-grafana-controlling.md
@@ -3,7 +3,7 @@ title: "ADR-165: Adopt Plugin-based REFLEX Review Engine with Grafana Controllin
 status: accepted
 date: 2026-04-18
 deciders: [achimdehnert]
-depends_on: [ADR-163, ADR-164, ADR-082, ADR-066]
+depends_on: [ADR-163, ADR-164, ADR-116, ADR-066]
 implementation_status: partial
 implementation_evidence:
   - "iil-reflex/reflex/review/ — ReviewEngine, 4 plugins, CLI (Stage 1)"
@@ -531,7 +531,7 @@ ADR-165 ist bestätigt wenn:
 - **ADR-164**: Port Strategy — `ports.yaml` als Datenquelle für port_plugin
 - **ADR-162**: REFLEX UI Testing — Playwright-Integration (bleibt separat, §6.4)
 - **ADR-066**: Agent Team Architecture — Developer Agent für Auto-Fixes (§5.3)
-- **ADR-082**: Model Routing — Model-Tiers lean_local/budget_cloud/standard/high (§5.3)
+- **ADR-116**: Model Routing — Model-Tiers lean_local/budget_cloud/standard/high (§5.3)
 - **ADR-045**: Config via decouple — Secrets-Pattern für DB-Credentials
 
 <!-- Drift-Detector-Felder

--- a/docs/adr/ADR-167-three-tier-middleware-architecture.md
+++ b/docs/adr/ADR-167-three-tier-middleware-architecture.md
@@ -273,7 +273,7 @@ Compliance wird verifiziert durch:
 ## More Information
 
 - **ADR-021 (amended by this ADR):** Health Probes Convention.
-- **ADR-056:** Multi-Tenancy — `TenantPropagationMiddleware` für Service-zu-Service-Aufrufe.
+- **ADR-072:** Multi-Tenancy — `TenantPropagationMiddleware` für Service-zu-Service-Aufrufe.
 - **ADR-072:** Schema Isolation — `django-tenants` für Tier-3-Repos.
 - **ADR-146:** Platform Packages — `iil-platform-context` als Shared Package.
 - **ADR-161:** RLS Policies — Row-Level-Security für Tier-2-Repos.

--- a/docs/adr/ADR-177-agent-role-specialization.md
+++ b/docs/adr/ADR-177-agent-role-specialization.md
@@ -3,7 +3,7 @@ status: proposed
 date: 2026-04-30
 version: 1.4
 deciders: [achimdehnert, cascade]
-related: [ADR-068, ADR-077, ADR-138, ADR-173, ADR-174]
+related: [ADR-068, ADR-077, ADR-138, ADR-224, ADR-174]
 amends: [ADR-066]
 implementation_status: none
 last_reviewed: 2026-05-08
@@ -637,7 +637,7 @@ Neues Dashboard `Agent-Team-Specialization`:
 - ADR-068 — AuditStore (Logging-Pflicht)
 - ADR-077 — Catalog & Temporal
 - ADR-138 — Implementation Tracking
-- ADR-173 — Orchestrator MCP Server
+- ADR-224 — Orchestrator MCP Server
 - ADR-174 — QM Gate (ASSUMPTION[unverified] = 0)
 - `/agentic-coding` Workflow v6 → v7 (Wave 1)
 - `/session-start` Phase 2.5 (Wave 2)

--- a/docs/adr/ADR-220-oidc-trusted-publishing-for-pypi.md
+++ b/docs/adr/ADR-220-oidc-trusted-publishing-for-pypi.md
@@ -6,13 +6,13 @@ consulted: []
 informed: []
 supersedes: []
 amends: []
-related: ["ADR-210-library-ci-reusable-mandatory-secret-scan.md"]
+related: ["ADR-226-library-ci-reusable-mandatory-secret-scan.md"]
 implementation_status: none
 ---
 
 # Migrate token-based PyPI publish workflows to OIDC Trusted Publishing with protected environments
 
-> **Trigger**: ADR-210 closed the *secret-in-artifact* vector by gating every
+> **Trigger**: ADR-226 closed the *secret-in-artifact* vector by gating every
 > `publish-*.yml` before upload. The advocatus-diabolus pass surfaced that the
 > *next-larger* irreversible risk is now the publish **credential** itself: the
 > single-package legacy workflows authenticate with a long-lived, shared
@@ -22,7 +22,7 @@ implementation_status: none
 
 ## Context and Problem Statement
 
-After ADR-210, the platform's PyPI publish surface is split in two:
+After ADR-226, the platform's PyPI publish surface is split in two:
 
 * **Modern** — `publish-packages.yml` (django-tenancy, concept-templates,
   dvelop-client): already OIDC-based — `permissions: id-token: write`,
@@ -35,7 +35,7 @@ After ADR-210, the platform's PyPI publish surface is split in two:
 A long-lived API token that can publish *several* packages is a high,
 irreversible blast radius: a single leak (CI log, compromised dependency in
 the publish job, malicious PR that reaches the token) lets an attacker
-overwrite or yank any of those packages on the public index. ADR-210's
+overwrite or yank any of those packages on the public index. ADR-226's
 artifact scan does **not** mitigate credential compromise — different threat.
 
 OIDC Trusted Publishing removes the standing credential entirely: PyPI mints a
@@ -48,7 +48,7 @@ the irreversible action.
 
 * No standing secret to leak beats rotating a secret faster (eliminate, don't
   manage). The credential is the largest remaining irreversible PyPI risk
-  after ADR-210.
+  after ADR-226.
 * Consistency: one publish pattern, not modern-vs-legacy. `publish-packages.yml`
   already proves the target shape in this repo.
 * Defense in depth on the irreversible action: a protected `environment`
@@ -85,7 +85,7 @@ the irreversible action.
 * Good: **zero standing publish credential**; per-run, audience-scoped;
   per-repo+workflow+environment binding; human approval gate; one pattern
   platform-wide; `PYPI_API_TOKEN` secret can eventually be deleted.
-* Good: composes cleanly with the ADR-210 pre-publish secret gate (gate stays
+* Good: composes cleanly with the ADR-226 pre-publish secret gate (gate stays
   exactly where it is, before the publish step).
 * Bad / accepted: requires a **manual, per-project PyPI-side registration**
   (Trusted Publisher: owner + repo + workflow filename + environment) **before**
@@ -100,7 +100,7 @@ the irreversible action.
 
 Chosen: **Option 4**. Converge the legacy single-package publish workflows
 onto the OIDC + protected-environment pattern already used by
-`publish-packages.yml`, preserving the ADR-210 pre-publish secret gate.
+`publish-packages.yml`, preserving the ADR-226 pre-publish secret gate.
 
 Target shape for each legacy `publish-*.yml` (build/scan unchanged; only
 auth + environment change):
@@ -115,7 +115,7 @@ publish:
   steps:
     - ...build...
     - twine check dist/*
-    - uses: achimdehnert/platform/.github/actions/gitleaks-scan@main   # ADR-210 gate, unchanged
+    - uses: achimdehnert/platform/.github/actions/gitleaks-scan@main   # ADR-226 gate, unchanged
       with: { mode: sdist, source: dist, ... }
     - uses: pypa/gh-action-pypi-publish@release/v1                     # OIDC, no token env
 ```
@@ -135,7 +135,7 @@ publish:
 
 * Good: the largest remaining irreversible PyPI risk (standing shared token)
   is eliminated, not merely shortened; one publish pattern platform-wide.
-* Good: orthogonal to ADR-210 — the secret gate stays exactly where it is.
+* Good: orthogonal to ADR-226 — the secret gate stays exactly where it is.
 * Bad / accepted: a package whose Trusted Publisher is not yet registered
   **cannot publish** until step 1 is done. This is an ordering constraint, not
   a regression; documented in the rollout and the PR.
@@ -182,10 +182,10 @@ publish:
 
 ## More Information
 
-* ADR-210 — library CI reusable + the pre-publish secret gate this builds on.
+* ADR-226 — library CI reusable + the pre-publish secret gate this builds on.
 * `publish-packages.yml` — the in-repo reference implementation of the target
   pattern (OIDC + `environment: pypi` + `pypa/gh-action-pypi-publish`).
 * PyPI docs — Trusted Publishers / `pypa/gh-action-pypi-publish`.
-* Drift lesson `2026-05-18-secret-gate-wrong-workflow` (ADR-210 review): a
+* Drift lesson `2026-05-18-secret-gate-wrong-workflow` (ADR-226 review): a
   control must sit at the irreversible action — here the *credential* is that
   surface, so OIDC removes the standing credential rather than guarding it.

--- a/tools/check_registry_view_readers.py
+++ b/tools/check_registry_view_readers.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""check_registry_view_readers — Guard gegen NEUE Direct-Reads der generierten Registry-Views.
+
+ADR-234 §11.1 REC-4. Nach dem P0-Flip sind `scripts/repo-registry.yaml` (flat) und
+`registry/repos.yaml` (rich) GENERIERTE Views von `registry/canonical.yaml`. Bestehende
+Konsumenten dürfen sie weiter lesen (akzeptierter End-Zustand, ADR-234 Changelog 2026-06-01);
+NEUER Code soll die Read-API `tools/registry_api.py` nutzen, damit die Views nicht wieder zu
+faktischen SSoTs werden.
+
+Mechanik: deterministischer Text-Scan über `git ls-files`. Wer einen View-Pfad referenziert
+und NICHT in der eingefrorenen Baseline (`registry_view_readers.txt`) steht, lässt den Check
+fehlschlagen. Migration eines Konsumenten auf die API → Baseline schrumpft (informational, kein Fail).
+
+Pfad-präzise (REC-4): `registry/repos.yaml` (NICHT bare `repos.yaml` — kollidiert mit dem
+separaten `infra/klickdummy-host` `/opt/klickdummy/repos.yaml`, anderes File) +
+`repo-registry.yaml` (eindeutiger Basename der flat-View).
+
+Run:    python3 tools/check_registry_view_readers.py
+Update: python3 tools/check_registry_view_readers.py --update   # nur nach echter Konsumenten-Migration
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+BASELINE = Path(__file__).resolve().parent / "registry_view_readers.txt"
+
+# Pfad-präzise Marker der generierten Views. Bare `repos.yaml` BEWUSST nicht.
+VIEW_MARKERS = ("repo-registry.yaml", "registry/repos.yaml")
+
+# Nur Code/Config scannen — REC-4 zielt auf *Code*, das die Views liest. Doku (.md/.rst)
+# erwähnt die Pfade in Prosa und ist kein SSoT-Drift-Risiko (sonst False-Positive bei jedem
+# neuen ADR, der den Pfad nennt).
+CODE_SUFFIXES = (".py", ".sh", ".yml", ".yaml", ".toml", ".cfg", ".ini")
+
+# Registry-Maschinerie selbst — kein "Konsument": Generator, Read-API, Drift-Gate, die
+# Views + canonical, dieser Guard + seine Baseline.
+ALLOWED = {
+    "tools/registry_api.py",
+    "tools/registry-canonical.py",
+    "tools/registry-consistency-check.py",
+    "tools/check_registry_view_readers.py",
+    "tools/registry_view_readers.txt",
+    "registry/canonical.yaml",
+    "registry/repos.yaml",
+    "registry/github_repos.yaml",
+    "scripts/repo-registry.yaml",
+    "registry/sync_registry.py",
+    ".github/workflows/registry-consistency.yml",
+    ".github/workflows/registry-lint.yml",
+}
+
+
+def _tracked_files() -> list[str]:
+    out = subprocess.run(
+        ["git", "-C", str(ROOT), "ls-files"], capture_output=True, text=True, check=True
+    )
+    return out.stdout.splitlines()
+
+
+def find_readers(root: Path, files: list[str]) -> set[str]:
+    """Dateien, die einen View-Pfad referenzieren — ohne Maschinerie/Archiv."""
+    readers = set()
+    for rel in files:
+        if rel in ALLOWED or rel.startswith("_ARCHIVED/"):
+            continue
+        if not rel.endswith(CODE_SUFFIXES):
+            continue
+        try:
+            text = (root / rel).read_text(errors="ignore")
+        except (OSError, UnicodeError):
+            continue
+        if any(m in text for m in VIEW_MARKERS):
+            readers.add(rel)
+    return readers
+
+
+def load_baseline() -> set[str]:
+    if not BASELINE.exists():
+        return set()
+    return {
+        ln.strip()
+        for ln in BASELINE.read_text().splitlines()
+        if ln.strip() and not ln.startswith("#")
+    }
+
+
+def write_baseline(readers: set[str]) -> None:
+    header = (
+        "# Eingefrorene Baseline der LEGITIMEN Direct-Reader der generierten Registry-Views\n"
+        "# (ADR-234 §11.1 REC-4). NEUE Reader hier NICHT eintragen — stattdessen\n"
+        "# tools/registry_api.py (flat/rich/repos/repo) nutzen. Regenerieren NUR nach echter\n"
+        "# Migration eines Konsumenten auf die API:\n"
+        "#   python3 tools/check_registry_view_readers.py --update\n"
+    )
+    BASELINE.write_text(header + "\n".join(sorted(readers)) + "\n")
+
+
+def main(argv: list[str]) -> int:
+    readers = find_readers(ROOT, _tracked_files())
+    if "--update" in argv:
+        write_baseline(readers)
+        print(f"✅ Baseline aktualisiert: {len(readers)} Reader → {BASELINE.relative_to(ROOT)}")
+        return 0
+
+    baseline = load_baseline()
+    if not baseline:
+        print("FEHLER: Baseline fehlt — erst `--update` (committed) laufen lassen.", file=sys.stderr)
+        return 2
+
+    new = readers - baseline
+    gone = baseline - readers
+    if gone:
+        print(
+            f"ℹ {len(gone)} Baseline-Reader lesen die Views nicht mehr (Migration?) — "
+            f"optional `--update`: {', '.join(sorted(gone))}"
+        )
+    if new:
+        print("🔴 NEUE Direct-Reads der generierten Registry-Views (ADR-234 §11.1 REC-4):")
+        for r in sorted(new):
+            print(f"   - {r}")
+        print("\n   Die Views (scripts/repo-registry.yaml, registry/repos.yaml) sind GENERIERT.")
+        print("   Neuer Code liest die Registry über tools/registry_api.py")
+        print("   (flat()/rich()/repos()/repo()). Falls dieser Reader bewusst legitim ist,")
+        print("   begründe ihn und nimm ihn per `--update` in die Baseline auf.")
+        return 1
+
+    print(f"✅ Keine neuen View-Direct-Reads ({len(readers)} bekannte Reader, Baseline eingehalten).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/registry_view_readers.txt
+++ b/tools/registry_view_readers.txt
@@ -1,0 +1,26 @@
+# Eingefrorene Baseline der LEGITIMEN Direct-Reader der generierten Registry-Views
+# (ADR-234 §11.1 REC-4). NEUE Reader hier NICHT eintragen — stattdessen
+# tools/registry_api.py (flat/rich/repos/repo) nutzen. Regenerieren NUR nach echter
+# Migration eines Konsumenten auf die API:
+#   python3 tools/check_registry_view_readers.py --update
+.github/scripts/push_project_facts.py
+.github/workflows/platform-audit.yml
+.github/workflows/pypi-ci-adoption-gate.yml
+.github/workflows/scaffold-tests.yml
+.github/workflows/sync-registry-to-devhub.yml
+infra/scripts/validate_tenancy.py
+scripts/audit_platform.py
+scripts/checks/doc_profile_check.sh
+scripts/checks/klickdummy_registry.sh
+scripts/checks/staging_generated_drift.sh
+scripts/checks/staging_oidc_redirects.sh
+scripts/checks/staging_port_range.sh
+scripts/dev-portal.py
+scripts/drift_check.py
+scripts/gen_project_facts.py
+scripts/gen_project_facts.sh
+scripts/list_megatest_repos.py
+scripts/render_staging.py
+scripts/setup_repo.py
+tests/megatest/test_meta.py
+tools/repo_checker.py

--- a/tools/tests/test_check_registry_view_readers.py
+++ b/tools/tests/test_check_registry_view_readers.py
@@ -1,0 +1,47 @@
+"""R7 Fault-Injection für check_registry_view_readers (ADR-234 §11.1 REC-4, KONZ-001 R7).
+
++/-: API-only-Datei ist kein Reader; injizierter Direct-Read einer View wird geflaggt;
+der klickdummy-`repos.yaml`-Basename (anderes File) wird NICHT fälschlich geflaggt;
+Maschinerie (registry_api etc.) ist allowlisted.
+
+Run: `python3 -m pytest tools/tests/test_check_registry_view_readers.py -q`
+"""
+import importlib.util
+import pathlib
+
+_SRC = pathlib.Path(__file__).resolve().parents[1] / "check_registry_view_readers.py"
+_spec = importlib.util.spec_from_file_location("crvr", _SRC)
+crvr = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(crvr)
+
+
+def _write(root, rel, text):
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+
+
+def test_should_not_flag_api_consumer(tmp_path):
+    _write(tmp_path, "scripts/good.py", "from registry_api import flat\nflat()\n")
+    assert crvr.find_readers(tmp_path, ["scripts/good.py"]) == set()
+
+
+def test_should_flag_new_direct_read_of_rich_view(tmp_path):
+    _write(tmp_path, "scripts/bad.py", "open('registry/repos.yaml')\n")
+    assert crvr.find_readers(tmp_path, ["scripts/bad.py"]) == {"scripts/bad.py"}
+
+
+def test_should_flag_direct_read_of_flat_view(tmp_path):
+    _write(tmp_path, "scripts/bad2.py", "yaml.safe_load(open('scripts/repo-registry.yaml'))\n")
+    assert crvr.find_readers(tmp_path, ["scripts/bad2.py"]) == {"scripts/bad2.py"}
+
+
+def test_should_not_flag_klickdummy_bare_repos_yaml(tmp_path):
+    # infra/klickdummy-host nutzt /opt/klickdummy/repos.yaml — anderes File, kein registry/-Pfad.
+    _write(tmp_path, "infra/klickdummy-host/sync.sh", 'REPOS_FILE="/opt/klickdummy/repos.yaml"\n')
+    assert crvr.find_readers(tmp_path, ["infra/klickdummy-host/sync.sh"]) == set()
+
+
+def test_should_ignore_allowed_machinery(tmp_path):
+    _write(tmp_path, "tools/registry_api.py", "open('registry/repos.yaml')\n")
+    assert crvr.find_readers(tmp_path, ["tools/registry_api.py"]) == set()


### PR DESCRIPTION
## Was

Hartes CI-Gate, das **neue** Direct-Reads der generierten Registry-Views (`scripts/repo-registry.yaml`, `registry/repos.yaml`) verhindert. ADR-234 §11.1 **REC-4**.

## Warum

Nach dem P0-Flip sind beide Altdateien **generierte Views** von `registry/canonical.yaml`. Bestehende Konsumenten dürfen sie weiter lesen (akzeptierter End-Zustand, ADR-234 Changelog 2026-06-01) — aber *neuer* Code soll die Read-API `tools/registry_api.py` nutzen, sonst werden die Views schleichend wieder zu faktischen SSoTs und untergraben die gerade akzeptierte SSoT-Invariante.

## Mechanik (klein + deterministisch)

- `tools/check_registry_view_readers.py` — Text-Scan über `git ls-files`, Baseline-Diff.
  - **Pfad-präzise:** `registry/repos.yaml` + `repo-registry.yaml` — *nicht* bare `repos.yaml` (kollidiert mit dem separaten `infra/klickdummy-host` `/opt/klickdummy/repos.yaml`, verifiziert anderes File).
  - **Code-only** (`.py/.sh/.yml/.yaml/...`) — Doku-Prosa, die den Pfad nennt, triggert nicht.
  - Maschinerie (registry_api, Generator, Drift-Gate, Views, canonical) allowlisted.
  - Neuer Reader nicht in Baseline → **exit 1** mit Hinweis auf `registry_api.py`. Migration eines Konsumenten → Baseline schrumpft (informational, kein Fail; `--update`).
- `tools/registry_view_readers.txt` — eingefrorene Baseline (**21** aktuelle Reader).
- `tools/tests/test_check_registry_view_readers.py` — +/- Fault-Injection (R7-Dogfood, KONZ-001 R7), läuft in `tools-tests.yml`.
- `registry-consistency.yml` — Guard als hartes Gate + `pull_request`-Trigger (fängt vor dem Merge).

## Verifiziert (lokal)

- Fault-Injection: neuer Direct-Read → `exit 1`; nach Cleanup `exit 0`.
- 5/5 Tests grün.
- Gate-Disziplin (lane-memory): CI-Step + `paths`/`pull_request`-Trigger + Test **im selben PR**.

## Scope

Nur die 4 Guard-Dateien. Unabhängig von PR #505 (ADR-Acceptance). REC-11/13 (`owner_team`-Feld) ist als Checklist-Punkt in Issue #488 getrackt, nicht hier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)