### PR TITLE
docs(adr): Konflikt-Korrekturen + future_risk Re-Eval-Notizen (Full-Scan Tail)

### DIFF
--- a/docs/adr/ADR-078-amendment-docker-healthcheck-convention.md
+++ b/docs/adr/ADR-078-amendment-docker-healthcheck-convention.md
@@ -12,6 +12,8 @@ implementation_status: implemented
 
 # Amendment: Docker HEALTHCHECK ausschließlich in docker-compose.prod.yml (amends ADR-021)
 
+> **Re-Eval-Trigger (ADR-Full-Scan 2026-06-06):** Healthcheck ist an den Python-3.12-Binaernamen gepinnt — bei Python-Upgrade anpassen.
+
 ---
 
 ## Context and Problem Statement

--- a/docs/adr/ADR-079-temporal-workflow-engine.md
+++ b/docs/adr/ADR-079-temporal-workflow-engine.md
@@ -13,6 +13,8 @@ implementation_evidence:
 
 # ADR-079: Adopt Temporal Self-Hosted as Primary Durable Workflow Engine
 
+> **Korrektur-Hinweis (ADR-Full-Scan 2026-06-06):** Frontmatter und §5 Migration-Tracking widersprechen sich zum Implementierungsstand. Vor Nutzung als implementiert den realen Temporal-Stand verifizieren.
+
 ## Metadaten
 
 | Attribut          | Wert                                                                              |

--- a/docs/adr/ADR-097-aifw-060-implementation-contract.md
+++ b/docs/adr/ADR-097-aifw-060-implementation-contract.md
@@ -21,6 +21,8 @@ implementation_evidence:
 
 # ADR-097: aifw 0.6.0 Implementation Contract — Models, Migration, Service Layer, and Public API
 
+> **Re-Eval-Trigger (ADR-Full-Scan 2026-06-06):** QualityLevel-Baender nennen konkrete aktuelle Modellnamen — bei naechster Modell-Generation pruefen/aktualisieren.
+
 | Field | Value |
 |-------|-------|
 | Status | **Accepted** (reviewed 2026-03-11) |

--- a/docs/adr/ADR-101-mcp-plattform-konzept.md
+++ b/docs/adr/ADR-101-mcp-plattform-konzept.md
@@ -8,6 +8,8 @@ informed: –
 
 # ADR-101: Adopt 3-Tier MCP Architecture for Platform-Wide Tool Orchestration
 
+> **Re-Eval-Trigger (ADR-Full-Scan 2026-06-06):** Token-Budget an Windsurfs 100-Tool-Limit + aktuelles Per-Tool-Schema gepinnt — bei Tool-Limit-/Modell-Aenderung re-evaluieren. Hinweis: E-10 (stdio-only) ueberschneidet sich mit ADR-224 (HTTP/SSE) — Abgleich offen.
+
 ## Metadaten
 
 | Attribut        | Wert |

--- a/docs/adr/ADR-103-ausschreibungs-hub-architektur-v3.md
+++ b/docs/adr/ADR-103-ausschreibungs-hub-architektur-v3.md
@@ -13,6 +13,8 @@ implementation_evidence:
 
 # ADR-103: ausschreibungs-hub — KI-gestützte Ausschreibungs- und Angebotsplattform
 
+> **Re-Eval-Trigger (ADR-Full-Scan 2026-06-06):** Embedding-Dimension 1536 ist hart kodiert (pgvector-Spalten + HNSW). Bei Wechsel des Embedding-Modells (naechste LLM-Generation) re-evaluieren.
+
 ## Metadaten
 
 | Attribut          | Wert                                                                              |

--- a/docs/adr/ADR-107-extended-agent-team-deployment-agent.md
+++ b/docs/adr/ADR-107-extended-agent-team-deployment-agent.md
@@ -14,6 +14,8 @@ implementation_evidence:
 
 # ADR-107: Erweitertes Agent-Team — Cascade als Tech Lead, Deployment Agent, Review Agent und explizite Rollenentlastung
 
+> **Korrektur-Hinweis (ADR-Full-Scan 2026-06-06):** Autonome Gate-2-Prod-Deploys widersprechen der live geltenden No-Auto-Prod-Invariante (deploy.yml; vgl. ADR-066/185 Gate-4 Human-Only). Bei Konflikt gilt No-Auto-Prod; Reconciliation offen.
+
 | Feld | Wert |
 |------|------|
 | **Status** | Accepted |

--- a/docs/adr/ADR-153-tax-hub-saas-architecture.md
+++ b/docs/adr/ADR-153-tax-hub-saas-architecture.md
@@ -891,7 +891,7 @@ apps/workflows/
 | **Domain (Public)** | `tax.iil.pet` (Landing + Registrierung) |
 | **Cloudflare DNS** | CNAME `*.tax` → Tunnel (proxied) + CNAME `tax` → Tunnel (proxied) |
 | **Wildcard-SSL** | Cloudflare Universal SSL (automatisch bei Proxy-Modus) |
-| **Nginx** | `server_name *.tax.iil.pet;` → `proxy_pass http://127.0.0.1:8096;` |
+| **Nginx** | `server_name *.tax.iil.pet;` → `proxy_pass http://127.0.0.1:8099;` |
 
 ### 7.4 Health & Monitoring (ADR-021 §2.2, ADR-078)
 
@@ -996,7 +996,7 @@ Basis für das Steuerberatungsbüro-Pilotprojekt aus ADR-152.
 |-------|---------|--------|-------|
 | 1 | ADR-153 erstellt | ✅ Done | 2026-03-25 |
 | 1 | ADR-152 als superseded markieren | ⬜ Pending | – |
-| 1 | Port 8096 in ADR-021 §2.9 Port-Registry eintragen | ⬜ Pending | – |
+| 1 | Port 8099 in ADR-021 §2.9 Port-Registry eintragen | ⬜ Pending | – |
 | 1 | Health-Endpoints `/livez/` + `/healthz/` implementieren | ⬜ Pending | – |
 | 1 | Django-Skeleton + Split Settings | ⬜ Pending | – |
 | 1 | apps/tenant/ + apps/billing/ Grundgerüst | ⬜ Pending | – |
@@ -1066,7 +1066,7 @@ Basis für das Steuerberatungsbüro-Pilotprojekt aus ADR-152.
 4. Schema-Isolation: Kanzlei A kann keine Mandanten von Kanzlei B sehen
 5. Stripe-Webhook: `checkout.session.completed` → Module aktiviert
 6. Trial: 30 Tage → automatisch `status="trial"`, dann Downgrade-Warning
-7. Port 8096 in ADR-021 §2.9 eintragen (**noch offen** — Migration Tracking Phase 1)
+7. Port 8099 in ADR-021 §2.9 eintragen (**noch offen** — Migration Tracking Phase 1)
 8. `catalog-info.yaml` vorhanden, `lifecycle: production` nach Phase 4
 9. `HandlerRegistry.get_handler_class("apps.workflows.handlers.email.SendEmailHandler")` liefert registrierten Handler
 10. `ExecutionLog.objects.filter(execution_id=X)` zeigt vollständiges Audit-Log mit Input/Output pro Action

--- a/docs/adr/ADR-186-headless-agent-coding-pipeline.md
+++ b/docs/adr/ADR-186-headless-agent-coding-pipeline.md
@@ -20,6 +20,8 @@ tags: [agent-coding, headless, devin, orchestrator, refactoring, quality-assuran
 
 # ADR-186: Adopt Headless Agent-Coding Pipeline via Devin CLI + Orchestrator Bridge for Polyrepo Automation
 
+> **Re-Eval-Trigger (ADR-Full-Scan 2026-06-06):** An Devin-CLI-Vendor + vendor-spezifische Modell-Tags gebunden — bei Tool-/Vendor-Wechsel re-evaluieren.
+
 **Devin CLI als Headless-Frontend, Orchestrator als Steuerungsschicht, Platform-Guardrails als Safety-Net.**
 
 ## Versionshistorie


### PR DESCRIPTION
Letzter mechanisch/grounded abschließbarer Teil des Full-Scan-Tails.

## Korrekturen (reality-grounded)
- **ADR-153 tax-hub**: realer **Config-Bug** — nginx `proxy_pass 8096` → **8099** (SSoT `infra/ports.yaml`; 8096 = illustration-hub). + Tracking-Zeilen.
- **ADR-107**: Korrektur-Hinweis — autonome Gate-2-Prod-Deploys widersprechen der **live No-Auto-Prod-Invariante** (vgl. ADR-066/185 Gate-4).
- **ADR-079**: Status-Hinweis — Frontmatter ↔ §5 Migration-Tracking widersprüchlich.

## future_risk Re-Eval-Trigger (die „Zukunftsfestigkeit"-Achse der Ausgangsfrage)
ADR-103 (embed-dim 1536) · ADR-097 (Modellnamen) · ADR-078 (py3.12-Binary) · ADR-186 (Devin-Vendor) · ADR-101 (Windsurf-100-Tool-Limit + E-10↔ADR-224 Transport-Abgleich). Notizen, keine Rewrites.

## Bewusst geflaggt, NICHT geraten (genuine Entscheidungen → Owner)
vector-store-canonical (087/187/188/171 inkompatible Embedding/Dim/Index), test-settings (179/057), Redundanz-Supersessions (147/183, 062/118, 155/184, 216/217, 229/230, 041/200, 133/097, 010/012/015), 104/105. Alle im Report `~/shared/adr-full-scan-report-2026-06-06.md` + vom SUGGEST-Drift-Gate getrackt.

validate: **grün**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)