### PR TITLE
fix(registry): REC-4 Guard flaggt eigenes Test-File nicht mehr (live auf main rot)

### DIFF
--- a/tools/check_registry_view_readers.py
+++ b/tools/check_registry_view_readers.py
@@ -42,6 +42,7 @@ ALLOWED = {
     "tools/registry-canonical.py",
     "tools/registry-consistency-check.py",
     "tools/check_registry_view_readers.py",
+    "tools/tests/test_check_registry_view_readers.py",  # enthält View-Pfade als Test-Fixtures, kein Reader
     "tools/registry_view_readers.txt",
     "registry/canonical.yaml",
     "registry/repos.yaml",


### PR DESCRIPTION
## Incident

Der REC-4 View-Reader-Guard ist **versehentlich auf `main` gelandet** (via Parallel-Session: `docs/adr-deadref-batch`/PR #508 wurde von der REC-4-Commit abgezweigt und mitgemergt) — und **failt auf JEDEM offenen PR**, weil er sein **eigenes Test-File** als neuen Direct-Reader flaggt: `tools/tests/test_check_registry_view_readers.py` enthält die View-Pfade (`open('registry/repos.yaml')` …) als Test-Fixtures.

Da nur `guardian` ein Required-Check ist, blockiert er Merges nicht hart — aber er ist durchgehend rot (Lärm + falsches Signal).

## Root Cause

Die lokale Grün-Messung war eine **Fehlmessung**: die Baseline wurde via `git ls-files` erzeugt, während das Test-File noch **untracked** war → nicht in die Baseline aufgenommen. In CI (committet = tracked) wird es dann als „neuer Reader" geflaggt. Lehre: Guard, die `git ls-files` nutzt, lokal erst **nach** `git add` der eigenen Dateien verifizieren.

## Fix

`tools/tests/test_check_registry_view_readers.py` in `ALLOWED` aufnehmen — es enthält die View-Pfade als **Fixtures**, ist kein echter Konsument. Einzeilig. Baseline (21 Reader) bleibt unverändert korrekt; der Guard wird gegen den eigenen PR grün.

## Erwartung

`Registry-Konsistenz prüfen` auf diesem PR (und nach Merge auf allen anderen offenen PRs) wird wieder grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)