### PR TITLE
fix(klickdummy-host): _widget-Dir 0755 erzwingen (Widget-404 bei umask 027)

### DIFF
--- a/infra/klickdummy-host/sync.sh
+++ b/infra/klickdummy-host/sync.sh
@@ -71,7 +71,9 @@ done <<< "$ENTRIES"
 # (via deploy.sh aus iil-klickdummy-SSoT gebündelt).
 WIDGET_SRC="${KLICKDUMMY_WIDGET:-/opt/klickdummy/widget.js}"
 if [ -f "$WIDGET_SRC" ]; then
-  mkdir -p "$TARGET/_widget"
+  # Dir explizit 0755: der nginx-Container liest als anderer User; der chmod-Loop
+  # unten deckt nur $WORK ab, nicht $TARGET/_widget → sonst 404 bei restriktiver umask.
+  install -d -m 0755 "$TARGET/_widget"
   install -m 0644 "$WIDGET_SRC" "$TARGET/_widget/widget.js"
   echo "  ✓ $TARGET/_widget/widget.js (zentrales Feedback-Widget)"
 else


### PR DESCRIPTION
Folgefix zu #512.

## Symptom
Nach #512-Deploy meldet `sync.sh` `✓ /srv/klickdummy/_widget/widget.js`, aber das Feedback-Widget bleibt im Browser **unsichtbar** — Seite lädt, nur der Widget-Chat-Button fehlt.

## Root Cause (verifizierter Code-Gap)
`sync.sh` legte `$TARGET/_widget` per `mkdir -p` an. Bei restriktiver `umask` (027) bekommt das **Verzeichnis** Mode `0750`. Der nginx-**Container** liest als `other` — ohne `o+rx` auf dem Dir kann er es nicht traversieren → `/_widget/widget.js` **404**, obwohl die Datei selbst `0644` ist. Der bestehende `chmod`-Loop deckt nur `$WORK` ab, nicht `$TARGET/_widget`.

## Fix
`install -d -m 0755 "$TARGET/_widget"` — erzwingt `o+rx` unabhängig von umask.

## Verifikation
- `bash -n` ok.
- Simulation unter `umask 027`: alt `mkdir` → `0750`, neu `install -d` → `0755`.
- Playwright gegen einen **faithful Host-Spiegel** (`widget.js` @ `/_widget/`, `/srv/klickdummy`-Layout): Widget rendert auf `ttz-werkleitung` **und** `werkleiter-skizze` (Chat-Button bottom-right), `/_widget/widget.js` → 200, keine Console-Fehler.

## Deploy (nach Merge, auf staging-platform)
```
scp infra/klickdummy-host/* staging-platform:/tmp/klickdummy/
ssh staging-platform "sudo mv /tmp/klickdummy/* /opt/klickdummy/ && sudo chown -R klickdummy-sync:klickdummy-sync /opt/klickdummy && sudo -u klickdummy-sync /opt/klickdummy/sync.sh"
```
Danach Browser **hart neu laden** (Cache!).

🤖 Generated with [Claude Code](https://claude.com/claude-code)