### PR TITLE
fix(registry): travel-beat prod_url → drifttales.app

### DIFF
--- a/registry/canonical.yaml
+++ b/registry/canonical.yaml
@@ -577,7 +577,7 @@ repos:
     in_rich: true
     flat:
       type: django
-      prod_url: travel-beat.iil.pet
+      prod_url: drifttales.app
       staging_url: staging.travel-beat.iil.pet
       port: 8089
       health: /livez/

--- a/scripts/repo-registry.yaml
+++ b/scripts/repo-registry.yaml
@@ -179,7 +179,7 @@ repos:
     health: /livez/
   travel-beat:
     type: django
-    prod_url: travel-beat.iil.pet
+    prod_url: drifttales.app
     staging_url: staging.travel-beat.iil.pet
     port: 8089
     health: /livez/


### PR DESCRIPTION
## Was
`flat.prod_url` von travel-beat war **stale** (`travel-beat.iil.pet`) und widersprach der eigenen Registry:
- `rich.url` = `https://drifttales.app`
- `docker-compose.prod.yml` → `Domains: drifttales.app, drifttales.com`

## Warum es zählt
`prod_url` treibt Health-Checks / `repo_checker` — der stale Wert zeigte auf eine nicht-öffentliche `.iil.pet`-Subdomain statt auf die Live-Domain.

## Änderung
- `registry/canonical.yaml` (SSoT) + `scripts/repo-registry.yaml` (flat-View, via flip-Generator).
- `registry/repos.yaml` (rich-View) nutzt `url:` und war bereits korrekt → unverändert.
- `registry-canonical.py verify` grün (flat+rich semantisch identisch).

Gefunden im Zuge der Tier-Klassifikation (S1, foundation/product).

🤖 Generated with [Claude Code](https://claude.com/claude-code)