### PR TITLE
docs(konz-002): stale-Artefakte gegen Ground-Truth korrigiert (2026-06-08)

### DIFF
--- a/docs/runbooks/KONZ-002-gov-exit-firedrill.md
+++ b/docs/runbooks/KONZ-002-gov-exit-firedrill.md
@@ -1,9 +1,21 @@
 # Runbook — KONZ-002 GOV-Exit-Feuerübung (`central-gov` Handover-Readiness)
 
+> **⚠️ GEGENSTANDSLOS seit 2026-06-04 (verifiziert 2026-06-08).** Dieses Runbook beweist den
+> `exit_tests: handover-readiness` der Klasse **`central-gov`** — diese Klasse wurde mit der
+> Owner-Datenprämisse (2026-06-04) **RETIRED** (`governance/exit-classes.yaml`: central-gov-Block
+> auskommentiert/retired; ADR-236 Rahmenkorrektur 2026-06-04). `ttz-lif`/`meiki-lra` sind seither
+> `exit-likely` (Kundenprojekte, nur Code+Demo-Daten) — ihre Portabilität ist über den allgemeinen
+> `exit-likely`-Pfad gedeckt (Feuerübung Runde 1, KONZ-002 §15). Es existiert **kein** zentral
+> betriebener Souveränitäts-Single-Point mehr, der eine separate GOV-Handover-Übung verlangt.
+> **Aufbewahrt als historischer Kontext** — NUR reaktivieren, falls jemals reale Souveränitäts-/
+> Personendaten in eine GitHub-Org gelangen (dann eher `must-stay-local`, nicht `central-gov`).
+>
+> ---
+>
 > Beweist den `exit_tests: handover-readiness` der Klasse **`central-gov`**
 > ([`governance/exit-classes.yaml`](../governance/exit-classes.yaml)).
 > Governance: **[ADR-236](../adr/ADR-236-altd-enterprise-boundary.md)** §6 (Rest-Risiko).
-> Stand: 2026-06-03. **Drill auf Wegwerf-Org — NIE an `ttz-lif`/`meiki-lra` selbst.**
+> Stand: 2026-06-03 (Inhalt). **Drill auf Wegwerf-Org — NIE an `ttz-lif`/`meiki-lra` selbst.**
 
 ## Warum (das schärfste offene Rest-Risiko)
 

--- a/governance/exit-classes.yaml
+++ b/governance/exit-classes.yaml
@@ -7,8 +7,10 @@
 # "zweite Wahrheit", vor der OOTB-8 warnt). Pro Org nur: Klasse + Begründung + Owner
 # + review_by + tatsächliche teardown_authority + Abweichungen.
 #
-# Konsumenten (Soll): tools/exit-plan.py (Placement-Gate D3, CI-Gleichheits-Audit) —
-#   liest diese Datei noch NICHT (Follow-up: ADR-236 §2.5). Bis dahin manuell.
+# Konsumenten: tools/exit-plan.py (Placement-Gate D3, CI-Gleichheits-Audit) —
+#   KONSUMIERT diese Datei (verifiziert 2026-06-08: load_exit_classes() +
+#   Invarianten-Check teardown_authority≠none für exit-likely/must-stay-local).
+#   ADR-236 §2.5 Follow-up damit erledigt (vormals „liest noch NICHT" — stale).
 #
 # Faktenbasis (Live-API, 2026-06-03): Rolle achimdehnert je Org via
 #   `gh api orgs/<org>/memberships/achimdehnert --jq .role`


### PR DESCRIPTION
Zwei **verifizierte** Stale-Doc-Korrekturen aus der KONZ-002-Bestandsaufnahme (2026-06-08). Beide aus Quellcode/SSoT belegt, unabhängig von Enterprise-API-Zugriff.

## Fixes
1. **`governance/exit-classes.yaml`** — Kommentar behauptete „exit-plan.py liest diese Datei noch NICHT (Follow-up ADR-236 §2.5)". Quellcode-Check (`tools/exit-plan.py`): `load_exit_classes()` + Invarianten-Check `teardown_authority≠none` für `exit-likely`/`must-stay-local` → die SSoT **wird** konsumiert. Follow-up erledigt.
2. **`docs/runbooks/KONZ-002-gov-exit-firedrill.md`** — beweist `exit_tests` der Klasse `central-gov`; diese wurde 2026-06-04 (Owner-Datenprämisse) **retired**. Als gegenstandslos markiert, historischer Kontext erhalten. GOV-Orgs = `exit-likely` (über KONZ-002 §15 gedeckt).

## Bewusst NICHT enthalten
S2-Enforce-/Attach-/default-for-new-Stand: mit aktuellem Enterprise-PAT (ohne `admin:enterprise`) **403 → nicht verifizierbar**. Keine Behauptung. Re-Verifikation folgt separat mit passendem Scope (letzter belegter Stand: S2-Runbook „DONE 2026-06-03").

## Verifiziert (reproduzierbar, Org-/Repo-Ebene)
4 Member-Orgs · migrierte iilgmbh-Repos haben push_protection=enabled (keine bestätigte Schutzlücke) · Registry-MIGRATED-Drift=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)