### PR TITLE
feat(repo-health): SUGGEST-Check gitignore-Cruft (NEXT.md/.windsurfignore/.windsurf/)

### DIFF
--- a/tools/repo_health_check.py
+++ b/tools/repo_health_check.py
@@ -308,6 +308,17 @@ def check_python_package(path: Path) -> HealthReport:
     passed, detail = _check_readme_content(path)
     add(CheckResult("README.md content", "SUGGEST", passed, detail))
 
+    # gitignore deckt generierte/Editor-Cruft ab (ADR-230, platform convention)
+    gi = (path / ".gitignore").read_text(encoding="utf-8") if (path / ".gitignore").exists() else ""
+    gi_lines = {line.strip() for line in gi.splitlines()}
+    for entry in ("NEXT.md", ".windsurfignore", ".windsurf/"):
+        add(CheckResult(
+            f"gitignore:{entry}",
+            "SUGGEST",
+            entry in gi_lines,
+            "" if entry in gi_lines else f"{entry} nicht in .gitignore",
+        ))
+
     # ── CI Workflows ──
     workflows_dir = path / ".github" / "workflows"
     add(CheckResult(
@@ -405,6 +416,17 @@ def check_django_app(path: Path) -> HealthReport:
     add(CheckResult("catalog-info.yaml", "SUGGEST", passed, detail))
     passed, detail = _check_readme_content(path)
     add(CheckResult("README.md content", "SUGGEST", passed, detail))
+
+    # gitignore deckt generierte/Editor-Cruft ab (ADR-230, platform convention)
+    gi = (path / ".gitignore").read_text(encoding="utf-8") if (path / ".gitignore").exists() else ""
+    gi_lines = {line.strip() for line in gi.splitlines()}
+    for entry in ("NEXT.md", ".windsurfignore", ".windsurf/"):
+        add(CheckResult(
+            f"gitignore:{entry}",
+            "SUGGEST",
+            entry in gi_lines,
+            "" if entry in gi_lines else f"{entry} nicht in .gitignore",
+        ))
 
     # Makefile contains DJANGO_SETTINGS_MODULE
     if _file_exists(path, "Makefile"):

--- a/tools/tests/test_repo_health_check.py
+++ b/tools/tests/test_repo_health_check.py
@@ -1,0 +1,100 @@
+"""Tests für repo_health_check.py — gitignore-Cruft-SUGGEST-Checks (#517)."""
+import importlib.util
+import pathlib
+import sys
+
+_MOD = pathlib.Path(__file__).resolve().parents[1] / "repo_health_check.py"
+_spec = importlib.util.spec_from_file_location("repo_health_check", _MOD)
+rhc = importlib.util.module_from_spec(_spec)
+sys.modules["repo_health_check"] = rhc  # required for @dataclass __module__ resolution
+_spec.loader.exec_module(rhc)
+
+CRUFT_ENTRIES = ("NEXT.md", ".windsurfignore", ".windsurf/")
+
+
+def _make_package(tmp_path: pathlib.Path, gitignore_lines: list[str]) -> pathlib.Path:
+    """Minimales Python-Package-Verzeichnis für check_python_package."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "x"\nversion = "0.1.0"\n'
+        '[project.urls]\nHomepage = "https://example.com"\n'
+    )
+    (tmp_path / "README.md").write_text("# x\n")
+    (tmp_path / ".gitignore").write_text("\n".join(gitignore_lines) + "\n")
+    src = tmp_path / "src" / "x"
+    src.mkdir(parents=True)
+    (src / "__init__.py").write_text("")
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    (tests / "test_x.py").write_text("def test_should_pass(): pass\n")
+    return tmp_path
+
+
+def _make_django(tmp_path: pathlib.Path, gitignore_lines: list[str]) -> pathlib.Path:
+    """Minimales Django-App-Verzeichnis für check_django_app."""
+    for fname in ("manage.py", "Dockerfile", "docker-compose.prod.yml", "README.md"):
+        (tmp_path / fname).write_text("")
+    (tmp_path / ".gitignore").write_text("\n".join(gitignore_lines) + "\n")
+    app = tmp_path / "app"
+    app.mkdir()
+    (app / "settings.py").write_text("")
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    (tests / "test_app.py").write_text("def test_should_pass(): pass\n")
+    return tmp_path
+
+
+# ── check_python_package ────────────────────────────────────────────────────
+
+def test_should_pass_gitignore_cruft_checks_python_package_when_entries_present(tmp_path):
+    path = _make_package(tmp_path, list(CRUFT_ENTRIES))
+    report = rhc.check_python_package(path)
+    for entry in CRUFT_ENTRIES:
+        result = next(r for r in report.results if r.name == f"gitignore:{entry}")
+        assert result.passed, f"expected passed for {entry}"
+        assert result.severity == "SUGGEST"
+
+
+def test_should_fail_gitignore_cruft_checks_python_package_when_entries_missing(tmp_path):
+    path = _make_package(tmp_path, [])
+    report = rhc.check_python_package(path)
+    for entry in CRUFT_ENTRIES:
+        result = next(r for r in report.results if r.name == f"gitignore:{entry}")
+        assert not result.passed, f"expected failed for {entry}"
+        assert result.severity == "SUGGEST"
+
+
+def test_should_not_block_python_package_when_gitignore_entries_missing(tmp_path):
+    path = _make_package(tmp_path, [])
+    report = rhc.check_python_package(path)
+    # SUGGEST failures must not appear in blocks_failed
+    block_names = {r.name for r in report.blocks_failed}
+    for entry in CRUFT_ENTRIES:
+        assert f"gitignore:{entry}" not in block_names
+
+
+# ── check_django_app ────────────────────────────────────────────────────────
+
+def test_should_pass_gitignore_cruft_checks_django_app_when_entries_present(tmp_path):
+    path = _make_django(tmp_path, list(CRUFT_ENTRIES))
+    report = rhc.check_django_app(path)
+    for entry in CRUFT_ENTRIES:
+        result = next(r for r in report.results if r.name == f"gitignore:{entry}")
+        assert result.passed, f"expected passed for {entry}"
+        assert result.severity == "SUGGEST"
+
+
+def test_should_fail_gitignore_cruft_checks_django_app_when_entries_missing(tmp_path):
+    path = _make_django(tmp_path, [])
+    report = rhc.check_django_app(path)
+    for entry in CRUFT_ENTRIES:
+        result = next(r for r in report.results if r.name == f"gitignore:{entry}")
+        assert not result.passed, f"expected failed for {entry}"
+        assert result.severity == "SUGGEST"
+
+
+def test_should_not_block_django_app_when_gitignore_entries_missing(tmp_path):
+    path = _make_django(tmp_path, [])
+    report = rhc.check_django_app(path)
+    block_names = {r.name for r in report.blocks_failed}
+    for entry in CRUFT_ENTRIES:
+        assert f"gitignore:{entry}" not in block_names


### PR DESCRIPTION
## Summary

- Neuer SUGGEST-Check `gitignore:<entry>` in `check_python_package` **und** `check_django_app` für die drei generierten/Editor-Artefakte `NEXT.md`, `.windsurfignore`, `.windsurf/`
- Exakter Zeilen-Match (kein Substring) → 0 False-Positives durch z. B. `# NEXT.md`
- Severity SUGGEST, kein BLOCK — Exit-Code 0 bei fehlenden Einträgen
- 6 neue Tests (passed/failed × beide Profile + kein-BLOCK-Schutz)

## Test plan

- [x] `python3 -m pytest tools/tests/test_repo_health_check.py -q` → 6 passed
- [x] Kein BLOCK bei fehlenden Einträgen verifiziert

Closes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)