### PR TITLE
fix(ci): pg_isready -U test_user — fix self-hosted root-runner health check

### DIFF
--- a/.github/workflows/_ci-python.yml
+++ b/.github/workflows/_ci-python.yml
@@ -240,7 +240,7 @@ jobs:
           POSTGRES_PASSWORD: test_pass
           POSTGRES_DB: test_db
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U test_user"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 5
@@ -304,7 +304,7 @@ jobs:
           POSTGRES_PASSWORD: test_pass
           POSTGRES_DB: test_db
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U test_user"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 5
@@ -423,7 +423,7 @@ jobs:
           POSTGRES_PASSWORD: test_pass
           POSTGRES_DB: test_db
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U test_user"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 5


### PR DESCRIPTION
## Summary

- Self-hosted runners running as OS user `root` fail the postgres service health check: `pg_isready` defaults to the current OS user, which has no role in the freshly-created postgres container (POSTGRES_USER is `test_user`)
- Fixes `FATAL: role "root" does not exist` seen in onboarding-hub, weltenhub, and any other repos using this reusable workflow on root-running runners
- Change: `--health-cmd pg_isready` → `--health-cmd "pg_isready -U test_user"` (applied to all 3 postgres service definitions in unit-tests, integration-tests, contract-tests jobs)

## Test plan

- [ ] onboarding-hub F4 fix PR #3 (`fix/ruff-f4-ci-green`) will rerun automatically via `@main` and pass Unit Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)