### PR TITLE
fix(platform-context): legacy HealthBypassMiddleware-Klasse entfernen (#312)

### DIFF
--- a/_ARCHIVED/packages/platform-context/src/platform_context/middleware.py
+++ b/_ARCHIVED/packages/platform-context/src/platform_context/middleware.py
@@ -250,18 +250,3 @@ class SubdomainTenantMiddleware(MiddlewareMixin):
             return model.objects.filter(**{slug_field: slug}).first()
         except Exception:
             return None
-
-
-class HealthBypassMiddleware(MiddlewareMixin):
-    """Bypass all middleware for health check endpoints (ADR-167).
-
-    Must be FIRST in MIDDLEWARE stack. Returns 200 immediately for
-    /livez/ and /healthz/ without tenant resolution or auth checks.
-    """
-
-    HEALTH_PATHS: frozenset[str] = frozenset(["/livez/", "/healthz/"])
-
-    def process_request(self, request: HttpRequest) -> HttpResponse | None:
-        if request.path in self.HEALTH_PATHS:
-            return HttpResponse("ok", content_type="text/plain")
-        return None


### PR DESCRIPTION
## Root Cause

`platform_context/middleware.py` enthielt **zwei** Definitionen mit demselben Namen:

1. **Zeile 103** — function-based `HealthBypassMiddleware` (v1.1, korrekt: non-GET → 405)
2. **Zeile 255** — `class HealthBypassMiddleware(MiddlewareMixin)` (legacy: jede Methode → 200)

In Python's Modul-Namespace gewinnt das letzte Assignment. Die Klasse überschrieb die Funktion, sodass `from platform_context.middleware import HealthBypassMiddleware` die buggy Klasse zurückgab.

**Betroffen:** nur Konsumenten, die das Modul direkt aus der Quelle importieren (editable install, z.B. `bfagent/vendor/platform_context`). Das published PyPI-Wheel (252 Zeilen, ohne Klasse) war bereits korrekt.

## Fix

Legacy-Klasse (Zeilen 255–267) aus `_ARCHIVED/packages/platform-context/src/platform_context/middleware.py` entfernt. Identische Änderung in `bfagent/vendor/platform_context` committed (selbe Datei, bfagent-Branch `chore/rueckbau-bfagent`).

## Verification

```
# Vorher (editable install):
$ python3 -c "from platform_context.middleware import HealthBypassMiddleware; print(type(...))"
<class 'type'>   # buggy Klasse

# Nachher:
<class 'function'>  # korrekte v1.1-Funktion
```

## Scope

- risk-hub shim (`src/common/middleware.py`): Kein Change nötig — Shim ist bereits dead code (try-Import der v0.7.0-Package gelingt, Fallback nie erreicht). Shim implementiert ohnehin Variant B (GET/HEAD only).

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)