### PR TITLE
fix(workflows): session-start stash pop nur nach eigenem stash

### DIFF
--- a/.windsurf/workflows/session-start.md
+++ b/.windsurf/workflows/session-start.md
@@ -158,9 +158,14 @@ fi
 export TARGET_REPO
 
 # Aktuelles Repo synchronisieren
-git stash --quiet 2>/dev/null
+# Stash nur poppen wenn WIR etwas gestasht haben — bei cleanem Tree poppt
+# `git stash pop` sonst einen fremden alten Stash-Eintrag (Drift 2026-06-10)
+STASHED=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash --quiet 2>/dev/null && STASHED=1
+fi
 git pull --rebase --quiet
-git stash pop --quiet 2>/dev/null
+[ "$STASHED" -eq 1 ] && git stash pop --quiet 2>/dev/null
 
 # Kern-Repos (MCP-Infrastruktur)
 for repo in mcp-hub platform risk-hub; do


### PR DESCRIPTION
## Problem
Phase 0.4 macht `git stash` → `pull` → `git stash pop` bedingungslos. Bei **cleanem** Tree stasht der erste Befehl nichts, der `pop` holt dann den **obersten fremden Stash-Eintrag** aus früheren Sessions zurück — heute konkret: stale Stash von `feat/adr-pgvector-discovery` → Merge-Konflikte in `.windsurf/rules/*.md` direkt beim Session-Start.

## Fix
`STASHED`-Flag: gestasht wird nur bei dirty Tree, gepoppt nur wenn vorher wirklich gestasht wurde. Einziges Vorkommen des Patterns (repo-weit gegrept).

Nach Merge: CC-Skill-Kopien via cc-skill-dist regenerieren.

🤖 Generated with [Claude Code](https://claude.com/claude-code)