### PR TITLE
docs(handover): research-hub#6 gemergt; falsche STOP-Diagnose korrigiert

### DIFF
--- a/AGENT_HANDOVER.md
+++ b/AGENT_HANDOVER.md
@@ -5,19 +5,28 @@ Enthält MCP-Tool-Mappings, Infra-Zugänge, Deploy-Targets und Scripting-Referen
 
 > **Stand: Juni 2026** — CC-first (ADR-230), cc-skill-dist, 7 MCP-Server
 
-## ⚡ Aktueller Stand (2026-06-10 — ref-sweep 12/12 ✅ vollständig abgeschlossen)
+## ⚡ Aktueller Stand (2026-06-10 — ref-sweep abgeschlossen; nur coach-hub#28 offen)
+
+**Diese Session (2026-06-10, später):** **research-hub#6 gemergt** (squash, `7b3260d`). Zwei
+unabhängige teardown-Bugs gefixt (beide mit Standalone-Repro reproduziert, dann CI-grün):
+(1) async-ORM leakt worker-thread-DB-Connection (`asyncio.run` schließt sie nie) →
+`being accessed by other users` — Fix `await sync_to_async(connections.close_all)()` im
+Service; (2) `transaction=True`-flush-TRUNCATE ohne CASCADE scheitert an
+`tenancy_module_membership` (django_tenancy FK→auth_user, ADR-130) — Fix conftest-Fixture
+`sql_flush allow_cascade=True`. ⚠️ **Vorherige Diagnose „django-tenancy nicht für 3.12
+verfügbar" war FALSCH** (Paket ist da, aus risk-hub/packages). Fleet-Pattern → Memory
+`feedback_transaction_true_async_test_teardown`. Nur noch **coach-hub#28** offen (Dep-Entscheid).
 
 **Diese Session (2026-06-10):** weltenhub#16 verifiziert gemergt (2026-06-09 16:46 UTC) → **ref-sweep 12/12 ✅ komplett**.
 
-**Vorherige Session (2026-06-09 — F4-Fixes + Ref-Sweep-Abschluss):** `shared-ci v1.0.3` trägt `pg_isready -U test_user`-Fix. 5 multi-layer F4-Fixes für weltenhub, 3 für wedding-hub, 1 für onboarding-hub. Alle 12 Sweep-PRs gemergt (illustration#8, wedding#19, onboarding#2, travel-beat#38, tax-hub#4, recruiting-hub#7, dms-hub#3, cad-hub#23, billing-hub#6, mcp-hub#106/trading-hub#14, **weltenhub#16**). coach-hub#28 + research-hub#6 = STOP.
+**Vorherige Session (2026-06-09 — F4-Fixes + Ref-Sweep-Abschluss):** `shared-ci v1.0.3` trägt `pg_isready -U test_user`-Fix. 5 multi-layer F4-Fixes für weltenhub, 3 für wedding-hub, 1 für onboarding-hub. Alle 12 Sweep-PRs gemergt (illustration#8, wedding#19, onboarding#2, travel-beat#38, tax-hub#4, recruiting-hub#7, dms-hub#3, cad-hub#23, billing-hub#6, mcp-hub#106/trading-hub#14, **weltenhub#16**). coach-hub#28 + research-hub#6 = STOP (research-hub#6 inzwischen gefixt+gemergt, s.o.).
 
 **Davor (2026-06-09 — shared-ci v1.0.2):** `deploy_runs_on`-Fix → v1.0.2; mcp-hub + trading-hub forward-gefixt; alle 12 Sweep-PRs auf @v1.0.2 re-pointet. Drift: `feedback_sharedci_tag_stale_vs_platform_main`.
 
 **Davor (2026-06-08):** F4-acute ✅, ADR-212 Phase-1 ✅, F1 .windsurf-Untrack ✅.
 
 **Offen — direkt umsetzbar (erster Zug nächste Session):**
-- **coach-hub #28**: STOP — `django-lms-lite` ist privater GitHub-Repo, kein CI-Zugriff. Entscheiden: Dep öffentlich machen / mirror / manuell installieren / anderen Ansatz wählen.
-- **research-hub #6**: STOP — `django-tenancy` nicht für Python 3.12 verfügbar (kein Rad auf PyPI). Architektur-Entscheidung nötig.
+- **coach-hub #28**: STOP — `django-lms-lite` ist privater GitHub-Repo, kein CI-Zugriff (Test + Security Scan scheitern an `git clone … Authentication failed`). Entscheiden: Dep öffentlich machen / mirror / als Wheel vendoren / PAT-Zugriff fixen. = einzige offene ref-sweep-PR; Dep-Architektur-Entscheid, kein Test-Fix.
 - **M6 Profil B fertig:** nur noch manuell: App auf **„Any account"** + Install auf `iilgmbh`+`bahn-sqf` → dann `claude-ent iilgmbh` = Org-Admin. Details: `docs/PROFILE_B.md`.
 - **Branch-Protection-Lücke:** 0/14 Hubs haben required-status-checks auf `main` → no-bypass unenforced. ADR-Kandidat.
 - **#7 risk-hub→Enterprise-Transfer:** deferred (gegated hinter KONZ-002 S2).
@@ -32,11 +41,11 @@ Enthält MCP-Tool-Mappings, Infra-Zugänge, Deploy-Targets und Scripting-Referen
 | Prio | Task | Tier |
 |---|---|---|
 | 1 | **F4 CI-grün-Programm (Breite)** — weiterhin ~34 Repos rote main-CI; nächste Welle = Ruff/Config-Drift an der Quelle | `[Sonnet]` |
-| 2 | **ref-sweep abgeschlossen** ✅ — coach-hub#28 + research-hub#6 STOP (Architektur-Entscheid ausstehend) | `[du]` |
+| 2 | **ref-sweep abgeschlossen** ✅ — research-hub#6 gefixt+gemergt; nur noch coach-hub#28 (Dep-Entscheid `django-lms-lite`) | `[du]` |
 | 3 | **M6 Profil-B fertigstellen** — nur noch manuell: App „Any account" + Org-Installs iilgmbh/bahn-sqf | `[manuell]` |
 | 4 | **Branch-Protection-Entscheid** — required-status-checks fleet-weit ja/nein (ADR-Kandidat) | `[du/ADR]` |
 
-**✅ Erledigt (2026-06-10):** weltenhub#16 gemergt verifiziert → **ref-sweep 12/12 komplett**.
+**✅ Erledigt (2026-06-10):** weltenhub#16 gemergt verifiziert → **ref-sweep 12/12 komplett** · **research-hub#6** gemergt (2 teardown-Bugs gefixt: async-ORM-Connection-Leak + flush-CASCADE vs django_tenancy-FK).
 
 **✅ Erledigt (2026-06-09):** wedding-hub#19 · onboarding-hub#2 · weltenhub pytest-Fixes · F4-Fixes: weltenhub 5, wedding-hub 3, onboarding-hub 1 · **shared-ci `v1.0.2` + `v1.0.3`** · **mcp-hub#106** + **trading-hub#14** · 11/12 ref-sweep-PRs.
 


### PR DESCRIPTION
## Was

Aktualisiert `AGENT_HANDOVER.md` nach Merge von **research-hub#6**.

- ref-sweep ist jetzt **bis auf coach-hub#28** abgeschlossen (research-hub#6 gemergt, `7b3260d`).
- Zwei teardown-Bugs in research-hub#6 gefixt (beide mit Standalone-Repro reproduziert, dann CI-grün):
  1. async-ORM leakt worker-thread-DB-Connection (`asyncio.run` schließt sie nie) → `being accessed by other users` → `connections.close_all()` im Service.
  2. `transaction=True`-flush-`TRUNCATE` ohne `CASCADE` scheitert an `tenancy_module_membership` (django_tenancy FK→auth_user, ADR-130) → conftest-Fixture `sql_flush allow_cascade=True`.
- ⚠️ **Korrektur:** vorherige STOP-Begründung „django-tenancy nicht für Python 3.12 verfügbar" war eine **falsche Hypothese** (Paket ist vorhanden, aus `risk-hub/packages`). Bereinigt.
- Fleet-Pattern dokumentiert in Memory `feedback_transaction_true_async_test_teardown`.

Nur Doku — kein Code/CI-Impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)