### PR TITLE
adr(186): Playback v1.3 aus mcp-hub — Unified Agent Loop statt Devin-CLI

### DIFF
--- a/docs/adr/ADR-186-headless-agent-coding-pipeline.md
+++ b/docs/adr/ADR-186-headless-agent-coding-pipeline.md
@@ -1,28 +1,31 @@
 ---
 status: proposed
 date: 2026-05-07
-version: 1.2
+version: 1.3
 decision-makers: [Achim Dehnert]
 consulted: [Cascade]
 informed: []
 supersedes: []
 amends: [ADR-141]
-related: [ADR-066, ADR-068, ADR-075, ADR-077, ADR-080, ADR-081, ADR-082, ADR-116, ADR-141, ADR-156, ADR-177, ADR-185]
-implementation_status: none
-last_reviewed: 2026-05-08
+related: [ADR-045, ADR-059, ADR-066, ADR-068, ADR-075, ADR-077, ADR-081, ADR-116, ADR-138, ADR-177]
+implementation_status: partial
+implementation_evidence:
+  - "mcp-hub orchestrator_mcp/headless/ — Phase 1 (CLI adapters, bridge, services, 44 tests)"
+last_reviewed: 2026-06-10
 staleness_months: 6
 drift_check_paths:
-  - orchestrator_mcp/agents/
-  - scripts/headless_agent/
-  - .github/workflows/_headless-agent.yml
-tags: [agent-coding, headless, devin, orchestrator, refactoring, quality-assurance, testing, polyrepo]
+  - orchestrator_mcp/headless/
+tags: [agent-coding, headless, aifw, agent-loop, orchestrator, quality-assurance, testing, polyrepo]
 ---
 
-# ADR-186: Adopt Headless Agent-Coding Pipeline via Devin CLI + Orchestrator Bridge for Polyrepo Automation
+# ADR-186: Use Unified Agent Loop on aifw for Headless Coding Pipeline
 
-> **Re-Eval-Trigger (ADR-Full-Scan 2026-06-06):** An Devin-CLI-Vendor + vendor-spezifische Modell-Tags gebunden — bei Tool-/Vendor-Wechsel re-evaluieren.
-
-**Devin CLI als Headless-Frontend, Orchestrator als Steuerungsschicht, Platform-Guardrails als Safety-Net.**
+> **Provenienz-Hinweis (2026-06-10):** Diese Datei ist der Playback der in mcp-hub
+> weiterentwickelten v1.3 (`mcp-hub/docs/adr/ADR-186-headless-agent-coding-pipeline.md`,
+> Commit `1e6ce04`). Die hier zuvor liegende v1.2 entschied „Devin CLI + Orchestrator-Bridge"
+> und widersprach damit der tatsächlich implementierten Architektur. Kanonische Heimat
+> dieser Entscheidung ist ab jetzt wieder platform; die mcp-hub-Kopie ist als
+> non-canonical gebannert.
 
 ## Versionshistorie
 
@@ -30,715 +33,392 @@ tags: [agent-coding, headless, devin, orchestrator, refactoring, quality-assuran
 |---------|-------|------------|
 | 1.0 | 2026-05-07 | Erstentwurf — Architektur, Use Cases, Gate-Modell, Implementierungsplan |
 | 1.1 | 2026-05-07 | Review-Fixes: Titel als Decision Statement, Consequences-Sektion, Glossar, Secret-Management, catalog-info.yaml, ADR-075-Klassifikation |
-| 1.2 | 2026-05-08 | Status draft→proposed, Open Questions beantwortet, CLI-Backend-Entscheidung: Aider Primary (Open Source), Implementierungsplan Phase 1 geschärft |
+| 1.2 | 2026-05-08 | Status draft→proposed, CLI-Backend-Entscheidung: Aider Primary, Devin optional |
+| 1.3 | 2026-05-07 (mcp-hub) / 2026-06-10 (platform-Playback) | **Architektur-Reversal:** Unified Agent Loop auf aifw als Primary, CLI-Adapter (Claude Code/Devin/Aider) nur Fallback. Löst die v1.2-Blocker: Live-Budget-Abort, Inline-ScopeLock, ein Routing für alle Konsumenten. Der Re-Eval-Trigger aus dem ADR-Full-Scan 2026-06-06 (Devin-Vendor-Bindung) ist damit aufgelöst. |
 
 ---
 
-## 1. Kontext & Problemstellung
+## Context and Problem Statement
 
-### Das Cascade-Dilemma
+The platform requires autonomous code quality enforcement across 19+ repos.
+Manual Cascade sessions don't scale for recurring tasks (sweeps, test gen,
+refactoring). We need a headless pipeline that invokes AI coding agents
+without human interaction, with proper budget control, scope locking, and
+security isolation.
 
-Cascade/Windsurf ist die primäre IDE für agentic coding auf der IIL-Plattform. Die Agent-Infrastruktur ist ausgereift:
+**Critical architectural insight (v1.3)**: CLI-based agents (Claude Code,
+Devin, Aider) are opaque subprocesses. We lose cost control mid-run,
+ScopeLock is only post-hoc, and model routing is fragmented across three
+parallel systems. The unified Agent Loop built on aifw solves all three.
 
-- **Orchestrator MCP** (ADR-066): Developer, Guardian, Tester, Planner, Merger — 6 aktive Agent-Rollen
-- **Agent Role Specialization** (ADR-177): DocBot, TestBot, FeatureBot, ReEngineerBot, ArchitectBot — 5 spezialisierte Agents mit deterministischem Routing
-- **Guardrails** (ADR-081): ScopeLock, PreExecution, PostVerify, Rollback L1-L4
-- **LLM-Routing** (ADR-116): DB-driven Model-Selection mit Budget-Tracking
-- **REFLEX** v0.5.0: Deterministische ADR-Compliance über 19 Repos
-- **pgvector Memory**: Persistente Sessions, Error-Patterns, Repo-Context
+## Decision Drivers
 
-**Problem**: Diese gesamte Infrastruktur ist **IDE-gebunden**. Es gibt keinen Weg, sie programmatisch von außen zu triggern — kein CLI, kein API, kein Headless-Modus. Konsequenzen:
+- Autonomous nightly quality sweeps across all platform repos
+- Budget control to prevent runaway costs — **live, not post-hoc**
+- Security: no secret leakage to AI subprocesses
+- Scope isolation: agents can only modify allowed files — **inline, not after**
+- Vendor independence: **any model via aifw** (any known/sensible LLM provider)
+- Central LLM routing: **one config for all consumers** (Django, headless, CI)
+- Full observability: **every token, every tool call logged**
 
-| Szenario | Heute | Gewünscht |
-|----------|-------|-----------|
-| Nightly Quality-Sweep über 19 Repos | ❌ Unmöglich | ✅ Cron-Job, 03:00 UTC |
-| PR-spezifischer semantischer Code-Review | ❌ Manuell in IDE | ✅ GitHub Actions Gate |
-| Batch-Refactoring (z.B. Service-Layer-Migration) | ❌ Repo-für-Repo in IDE | ✅ Ein Script, N Repos |
-| Automatisierte Test-Generierung für uncovered Code | ❌ Manuell pro Modul | ✅ Coverage-Diff → Testcases |
-| Cross-Repo-Konsistenz-Check (über Pattern-Matching hinaus) | ❌ Nur REFLEX (Regex/AST) | ✅ LLM-semantisch + REFLEX |
+## Considered Options
 
-### ADR-141 Gap
+1. **Devin CLI as primary** — Cognition's managed agent, opaque subprocess
+2. **Aider CLI as primary** — Open-source, but CLI = black box
+3. **Claude Code CLI as primary** — Anthropic-official, best CLI but still opaque
+4. **Unified Agent Loop on aifw** — Full control, transparent, vendor-independent
 
-ADR-141 (Discord → Agentic Coding Bridge) definiert einen StepExecutor-basierten Agent, der Code via Celery-Tasks schreibt und PRs öffnet. **Problem**: ADR-141 baut die gesamte Execution-Engine selbst (StepExecutor + ToolRegistry + LLMClient). Das ist ein enormer Implementierungsaufwand (~19h) und dupliziert Fähigkeiten, die Devin Terminal bereits als fertiges Produkt mitbringt.
+## Decision Outcome
 
-### Devin Terminal als Beschleuniger
+**Chosen: Option 4 — Unified Agent Loop on aifw, with CLI adapters as fallback.**
 
-Devin CLI (`devin -p`) bietet:
+### Why not CLI-primary (v1.2 approach)?
 
-- **Headless Single-Turn-Modus**: Prompt → Antwort → Exit (wie `grep` oder `ruff`)
-- **Nativer Zugriff auf `.windsurf/rules/*.md`**: Alle bestehenden Cascade-Rules gelten automatisch
-- **MCP-Server-Integration**: Kann MCP-Server als Tools nutzen
-- **Permission-Modes**: `bypass` (Headless), `autonomous` (Sandbox), `normal` (interaktiv)
-- **Strukturierte Outputs**: JSON-Output per Prompt-Engineering erzwingbar
+| Problem | CLI Adapter | Unified Loop |
+|---------|-------------|--------------|
+| Model routing | 3 parallel worlds (aifw, litellm, CLI-internal) | ONE aifw router |
+| Cost tracking | estimated post-hoc | exact, token-for-token, live abort |
+| ScopeLock | post-execution validation | **inline at every tool call** |
+| Observability | stdout parsing (fragile) | every step in audit log |
+| Vendor lock-in | Claude CLI = Anthropic only | any model via aifw |
+| Free tier (Groq) | needs separate adapter | just a routing config |
+| Testability | subprocess mocking | pure Python unit tests |
 
-**Die Kernidee**: Devin CLI als **Execution-Frontend** nutzen, aber die **Steuerungslogik** (Routing, Guardrails, Memory, Audit) im Orchestrator belassen.
+### Pros and Cons of the Options
 
----
+#### Option 1: Devin CLI as primary
 
-## 2. Entscheidungskriterien (Decision Drivers)
+- Good: Managed cloud sandbox (no local infra)
+- Good: Multi-file refactoring across complex codebases
+- Bad: Opaque subprocess — no live cost control
+- Bad: Vendor lock-in (Cognition)
+- Bad: `DEVIN_API_TOKEN` required (additional secret management)
+- Bad: No native `.windsurf/rules` reading (BLOCKER-1)
 
-- **Orchestrator-Hoheit**: LLM-Routing, Budget-Tracking und Gate-System bleiben im Orchestrator (ADR-066, ADR-116, ADR-177) — kein Parallel-System
-- **Guardrails-Konsistenz**: ScopeLock (ADR-081) muss auch im Headless-Modus greifen
-- **Kosteneffizienz**: LLM-Kosten müssen trackbar und budgetierbar sein
-- **Polyrepo-Skalierung**: Muss über 19+ Repos in Batch-Läufen funktionieren
-- **DSGVO-Compliance**: Mandanten-Code darf nicht unkontrolliert an externe Cloud-Inferenz
-- **Inkrementelle Adoption**: Kein Big-Bang — stufenweise aktivierbar pro Use Case
-- **Reversibilität**: Jeder Schritt muss rückgängig machbar sein ohne Datenverlust
+#### Option 2: Aider CLI as primary
 
----
+- Good: Open-source, GDPR-compliant (own API keys)
+- Good: Local execution (no cloud dependency)
+- Bad: Opaque subprocess — stdout parsing for results
+- Bad: No tool-use loop (commit-oriented, not analysis-oriented)
+- Bad: Limited to Anthropic/OpenAI models
 
-## 3. Betrachtete Optionen
+#### Option 3: Claude Code CLI as primary
 
-### Option A: ADR-141 StepExecutor (Custom-Build)
+- Good: Officially supported by Anthropic
+- Good: `--allowedTools` for defense-in-depth
+- Good: `--output-format json` documented and stable
+- Bad: Still opaque subprocess — no live budget abort
+- Bad: Vendor lock-in (Anthropic only)
+- Bad: ScopeLock only post-execution (worktree discard on violation)
 
-Alles selbst bauen: Git-Clone → StepExecutor → LLMClient → PR.
+#### Option 4: Unified Agent Loop on aifw (chosen)
 
-- **Pro**: Volle Kontrolle, kein externer Vendor
-- **Contra**: ~19h Aufwand, dupliziert Devin-Fähigkeiten, kein Codebase-Verständnis ohne Indexierung
+- Good: Full cost control — live abort mid-generation
+- Good: Inline ScopeLock — tool rejects forbidden writes before they happen
+- Good: Vendor-independent — any model via aifw routing config
+- Good: Full observability — every token and tool call logged
+- Good: Pure Python — testable without subprocess mocking
+- Good: Free-tier capable (Groq, Ollama) for read-only tasks
+- Bad: aifw requires refactoring to extract DB-independent core (prerequisite)
+- Bad: Own tool implementations need maintenance
+- Bad: May be less capable than Claude Code for very complex multi-file tasks
 
-### Option B: Devin CLI standalone (wie im devin.zip Bundle)
-
-Devin CLI direkt mit eigenen Prompts und eigenem JSON-Parsing aufrufen.
-
-- **Pro**: Schnell aufgesetzt, sofort nutzbar
-- **Contra**: Umgeht Orchestrator komplett — kein LLM-Routing, kein Budget, kein Memory, keine Guardrails
-
-### Option C: Devin CLI + Orchestrator-Bridge ✅
-
-Devin CLI als Execution-Frontend, Orchestrator als Steuerungsschicht:
-
-```
-Orchestrator (Routing + Guards + Memory + Audit)
-    ↓ wählt Agent-Typ, Modell, Budget, Scope
-    ↓ baut Prompt mit Platform-Context
-Devin CLI (Execution)
-    ↓ devin -p --model {routed_model} -- {enriched_prompt}
-    ↓ führt Code-Analyse/Refactoring/Test-Generierung aus
-Orchestrator (Verification + Storage)
-    ↓ parsed Output, prüft ScopeLock, speichert in pgvector
-    ↓ öffnet PR / erstellt Issue / sendet Discord-Notification
-```
-
-- **Pro**: Nutzt bestehende Orchestrator-Infrastruktur UND Devins Code-Verständnis, schnellste Time-to-Value
-- **Contra**: Abhängigkeit von Devin-Vendor (mitigierbar: Devin ist austauschbar durch jedes CLI-Tool)
-
-### Option D: GitHub Actions + LLM direkt (ohne Devin)
-
-Eigener GH-Actions-Workflow, der litellm/aifw direkt aufruft.
-
-- **Pro**: Kein Vendor-Lock-in
-- **Contra**: Kein Codebase-Indexing, kein File-System-Zugriff im Runner, limitierte Kontextfenster
-
-### Option E: Aider CLI als Alternative zu Devin
-
-Open-Source-CLI-Agent (aider) statt Devin.
-
-- **Pro**: Open Source, kein Vendor-Lock-in, günstig
-- **Contra**: Kein nativer Zugriff auf `.windsurf/rules/`, kein MCP-Support, weniger Codebase-Verständnis
-
----
-
-## 4. Entscheidung
-
-**Option C: Devin CLI + Orchestrator-Bridge** — mit Fallback auf Option E (Aider) als Exit-Strategie.
-
-### Begründung
-
-1. **Kein Parallel-System**: Orchestrator (ADR-066) bleibt die Single Source of Truth für Routing, Budget und Guardrails
-2. **Time-to-Value**: Devin CLI ist sofort nutzbar — kein StepExecutor-Build nötig
-3. **Rule-Kompatibilität**: Devin liest `.windsurf/rules/*.md` nativ — keine Doppelpflege
-4. **Austauschbarkeit**: Die Bridge-Schicht abstrahiert das CLI-Tool — Devin kann durch Aider, Claude Code CLI oder jedes andere Tool ersetzt werden
-5. **Amends ADR-141**: Die Headless-Pipeline ersetzt den Custom-StepExecutor aus ADR-141 durch ein Vendor-CLI + Orchestrator-Bridge-Pattern
-
-### Konsequenzen
-
-#### Positiv
-
-- **Quality Up**: Semantische Analyse findet Verstöße die REFLEX (Regex/AST) nicht erkennen kann (z.B. indirekte ORM-Calls, SRP-Verstöße)
-- **Batch-Fähigkeit**: Nightly Quality-Sweeps über 19 Repos erstmals möglich — bisher nur interaktiv in IDE
-- **Automatisierte Tests**: Coverage-Lücken werden systematisch geschlossen statt manuell pro Modul
-- **Kostentransparenz**: Alle LLM-Kosten über Orchestrator Budget-Guards trackbar (~$85/Monat bei vollem Betrieb)
-- **Vendor-Unabhängigkeit**: CLIAdapter-Abstraktion erlaubt Backend-Wechsel (Devin → Aider → Claude Code) ohne Orchestrator-Änderung
-- **ADR-141 beschleunigt**: ~19h Custom-StepExecutor-Build entfällt, Vendor-CLI übernimmt Execution
-- **Guardrails greifen identisch**: ScopeLock, Budget-Guards und Gate-System gelten im Headless-Modus wie in Cascade
-
-#### Negativ
-
-- **Vendor-Abhängigkeit (Devin)**: Mitigiert durch CLIAdapter-Abstraktion und Aider-Fallback, aber Primär-Backend ist kommerziell
-- **LLM-Kosten**: ~$85/Monat laufende Kosten bei vollem Betrieb (Quality-Sweep + Tests + Refactoring + Security)
-- **Nicht-Determinismus**: LLM-basierte Analyse hat False Positives/Negatives — ergänzt REFLEX, ersetzt es nicht
-- **Secret-Management**: Neue API-Keys (DEVIN_API_KEY, ANTHROPIC_API_KEY) müssen sicher verwaltet werden
-- **Complexity Budget**: Neue Komponente (HeadlessBridge) erhöht die Systemkomplexität des Orchestrators
-
-#### Neutral
-
-- REFLEX bleibt unverändert als deterministische Baseline
-- Cascade IDE-Workflows bleiben unverändert
-- pgvector Memory-Store wird mitgenutzt (kein neuer Store)
-
----
-
-## 5. Architektur
-
-### 5.1 Komponentenübersicht
+### Architecture v1.3
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                    TRIGGER LAYER                                 │
-│  Cron │ GitHub Actions │ Discord /code │ CLI manual              │
-└──────────────┬──────────────────────────────────────────────────┘
-               │
-               ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                 ORCHESTRATOR LAYER (mcp-hub)                     │
-│                                                                  │
-│  ┌──────────────┐  ┌───────────────┐  ┌──────────────────────┐  │
-│  │ TaskRouter    │  │ BudgetGuard   │  │ ContextBuilder       │  │
-│  │ (ADR-177)     │  │ (ADR-116)     │  │ (platform-context +  │  │
-│  │ select_agent()│  │ $-Limit/Task  │  │  pgvector Memory)    │  │
-│  └──────┬───────┘  └───────┬───────┘  └──────────┬───────────┘  │
-│         │                  │                      │              │
-│         ▼                  ▼                      ▼              │
-│  ┌─────────────────────────────────────────────────────────────┐ │
-│  │              HeadlessBridge                                  │ │
-│  │  - Baut enriched Prompt (Context + Rules + Task)            │ │
-│  │  - Mappt ModelTier → Devin --model Flag                     │ │
-│  │  - Ruft CLI auf (subprocess, timeout, cwd=repo)             │ │
-│  │  - Parsed JSON-Output                                       │ │
-│  │  - Prüft ScopeLock (ADR-081) auf changed files              │ │
-│  └──────────────────────────┬──────────────────────────────────┘ │
-│                             │                                    │
-│  ┌──────────────┐  ┌───────┴───────┐  ┌──────────────────────┐  │
-│  │ AuditStore   │  │ ResultHandler │  │ MemoryStore          │  │
-│  │ (ADR-068)    │  │ PR / Issue /  │  │ (pgvector)           │  │
-│  │              │  │ Discord / Log │  │                      │  │
-│  └──────────────┘  └───────────────┘  └──────────────────────┘  │
-└─────────────────────────────────────────────────────────────────┘
-               │
-               ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                  EXECUTION LAYER (austauschbar)                   │
-│                                                                  │
-│  ┌──────────────────────────────────────────────────────────┐    │
-│  │  Devin CLI (Primary)                                      │    │
-│  │  devin -p --model {model} --permission-mode bypass -- ... │    │
-│  └──────────────────────────────────────────────────────────┘    │
-│                          ODER                                    │
-│  ┌──────────────────────────────────────────────────────────┐    │
-│  │  Aider CLI (Fallback)                                     │    │
-│  │  aider --model {model} --message "..." --yes              │    │
-│  └──────────────────────────────────────────────────────────┘    │
-│                          ODER                                    │
-│  ┌──────────────────────────────────────────────────────────┐    │
-│  │  Claude Code CLI (Future)                                 │    │
-│  │  claude -p "..." --model {model} --allowedTools ...       │    │
-│  └──────────────────────────────────────────────────────────┘    │
-└─────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────┐
+│                    aifw (erweitert — CLI + HTTP + Python)      │
+│                                                              │
+│  ┌───────────────────────────────────────────────────────┐   │
+│  │  Routing Engine (DB-driven OR yaml fallback)           │   │
+│  │  action_code → provider + model + budget + fallback    │   │
+│  └─────────┬─────────────┬──────────────┬────────────────┘   │
+│            │             │              │                     │
+│  ┌─────────┴──┐  ┌──────┴────┐  ┌──────┴─────┐  ┌───────┐  │
+│  │ Anthropic  │  │   OpenAI  │  │  Groq FREE │  │Ollama │  │
+│  └────────────┘  └───────────┘  └────────────┘  └───────┘  │
+└──────────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌──────────────────────────────────────────────────────────────┐
+│              Agent Loop (orchestrator_mcp/headless)            │
+│                                                              │
+│   while budget.remaining > 0:                                │
+│     response = aifw.complete(                                │
+│       action_code = task.action_code,                        │
+│       messages = conversation,                               │
+│       tools = SCOPED_TOOLS,         ← ScopeLock built-in    │
+│     )                                                        │
+│     budget.spend(response.usage)    ← live cost tracking    │
+│     if budget.exceeded: ABORT       ← immediate, not later  │
+│                                                              │
+│     for tool_call in response.tool_calls:                    │
+│       result = sandbox.execute(tool_call)  ← scope-checked  │
+│       audit.log(tool_call, result)         ← full trace     │
+│                                                              │
+│   Tools (scope-aware, sandbox-aware):                        │
+│   ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌─────────┐  │
+│   │  Read  │ │  Edit  │ │  Grep  │ │  Bash  │ │RunTests │  │
+│   │  File  │ │  File  │ │ Search │ │(allow) │ │ (pytest)│  │
+│   └────┬───┘ └────┬───┘ └────┬───┘ └────┬───┘ └────┬────┘  │
+│        └───────────┴──────────┴──────────┴──────────┘        │
+│                           │                                  │
+│   ┌───────────────────────┴──────────────────────────────┐   │
+│   │  Sandbox (git worktree) + ScopeLock (inline reject)   │   │
+│   └──────────────────────────────────────────────────────┘   │
+└──────────────────────────────────────────────────────────────┘
+
+                    FALLBACK (complex tasks only)
+                           │
+              ┌────────────┼────────────┐
+         ┌────┴────┐  ┌───┴────┐  ┌────┴────┐
+         │  Claude  │  │ Devin  │  │  Aider  │
+         │Code CLI │  │  CLI   │  │   CLI   │
+         └─────────┘  └────────┘  └─────────┘
 ```
 
-### 5.2 catalog-info.yaml (ADR-077)
+### Routing Decision
 
-`mcp-hub/catalog-info.yaml` muss um die HeadlessBridge als Component erweitert werden:
+```
+IF task.complexity <= moderate AND task.type in (sweep, review, test_gen, docs):
+    → Agent Loop (aifw + Tools)
+    → Full control, full transparency
+    → Model: Groq FREE (read-only) or Claude Sonnet (write)
 
-```yaml
-spec:
-  components:
-    - name: headless-bridge
-      type: agent-bridge
-      lifecycle: experimental
-      owner: alpha-team
-      description: "Orchestrator-gesteuerte Headless Agent-Coding Pipeline"
-      dependsOn:
-        - component:orchestrator-mcp
-        - resource:pgvector-memory
+ELIF task.complexity == complex AND needs multi-file deep reasoning:
+    → Claude Code CLI (subprocess fallback)
+    → For 50+ file refactoring where Claude's toolchain excels
+
+ELIF task.requires_cloud_sandbox:
+    → Devin CLI (cloud VM for dependency installation)
 ```
 
-Erfolgt im selben PR wie Phase 1 (CLIAdapter-Implementierung).
+### aifw Extension Required
 
-### 5.3 HeadlessBridge — Kern-Abstraktion
+```
+aifw/ (erweitert)
+├── core/
+│   ├── engine.py          # CompletionEngine (DB-unabhängig)
+│   ├── routing.py         # Route: DB-driven OR yaml OR env
+│   ├── cost.py            # Token counting + budget enforcement
+│   └── tool_use.py        # Tool-call dispatch + schema
+├── django/                # Bestehende Django-Integration
+│   └── integration.py     # sync_completion() wrapper
+├── cli/                   # NEU: python -m aifw complete
+│   └── __main__.py
+├── http/                  # NEU: aifw serve --port 8099
+│   └── server.py
+└── providers/
+    ├── anthropic.py
+    ├── openai.py
+    ├── groq.py            # NEU (free tier)
+    └── ollama.py          # NEU (local/private)
+```
+
+### Key Blocker Fixes (from external review, still valid)
+
+| # | Issue | Fix |
+|---|-------|-----|
+| B1 | CLI doesn't read `.windsurf/rules` | System prompt contains platform rules |
+| B2 | Devin CLI flag syntax wrong | Corrected (fallback adapter only) |
+| B3 | ScopeLock after execution too late | **Tool rejects write inline** |
+| B4 | Full os.environ passed to subprocess | env_isolation (fallback only) |
+| B5 | Repo allowlist not enforced | DB-backed check before loop starts |
+| B6 | `text=True` without error handling | Not applicable (no subprocess in primary) |
+| B7 | Finding duplication across runs | content_hash + UniqueConstraint dedup |
+
+## Implementation
+
+Location: `mcp-hub/orchestrator_mcp/headless/`
+
+```
+headless/
+├── __init__.py
+├── models.py                  # SQLAlchemy models (4 tables)
+├── agent_loop/                # PRIMARY — eigener Tool-Use Loop
+│   ├── __init__.py
+│   ├── loop.py                # AgentLoop: while budget > 0
+│   ├── tools/                 # Scope-aware tool implementations
+│   │   ├── read_file.py
+│   │   ├── edit_file.py       # ScopeLock inline
+│   │   ├── grep_search.py
+│   │   ├── bash_exec.py       # Command allowlist
+│   │   └── run_tests.py
+│   └── routing.py             # Task → action_code → aifw
+├── adapters/                  # FALLBACK — CLI für komplexe Tasks
+│   ├── __init__.py            # CLIAdapter ABC + DTOs
+│   ├── claude.py              # Claude Code CLI
+│   ├── devin.py               # Devin CLI
+│   └── aider.py               # Aider CLI
+├── services/
+│   ├── bridge.py              # HeadlessBridge orchestrator (dispatches)
+│   ├── sandbox.py             # Git worktree + subprocess management
+│   ├── env_isolation.py       # Subprocess env allowlist (fallback only)
+│   ├── scope_lock.py          # ADR-081 ScopeLock (inline + post-hoc)
+│   ├── cost_tracker.py        # Atomic budget reservation (row locks)
+│   ├── prompt_builder.py      # Anti-injection prompt assembly
+│   └── result_parser.py       # JSON output validation
+└── tests/
+    ├── test_agent_loop.py
+    ├── test_tools.py
+    ├── test_adapters.py
+    ├── test_env_isolation.py
+    ├── test_prompt_builder.py
+    ├── test_result_parser.py
+    └── test_scope_lock.py
+```
+
+### Agent Loop — Tool Interface
 
 ```python
-from __future__ import annotations
-
-import subprocess
-import json
-import logging
-from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
-from enum import Enum
-from pathlib import Path
-from typing import Any
-
-log = logging.getLogger("headless-bridge")
-
-
-class CLIBackend(str, Enum):
-    """Austauschbare CLI-Backends."""
-    DEVIN = "devin"
-    AIDER = "aider"
-    CLAUDE = "claude"
-
-
-@dataclass(frozen=True)
-class HeadlessTask:
-    """Input für einen Headless-Agent-Run."""
-    repo_path: Path
-    task_type: str          # TaskType aus ADR-177
+class Tool(ABC):
+    name: str
     description: str
-    scope_paths: list[str]  # Erlaubte Pfade (ScopeLock Allowlist)
-    budget_usd: float = 5.0
-    timeout_seconds: int = 900  # 15 Min Default
-
-
-@dataclass
-class HeadlessResult:
-    """Strukturiertes Ergebnis eines Headless-Runs."""
-    repo: str
-    task_type: str
-    success: bool
-    findings: list[dict[str, Any]] = field(default_factory=list)
-    changes: list[dict[str, Any]] = field(default_factory=list)
-    tests_generated: list[str] = field(default_factory=list)
-    error: str | None = None
-    cost_usd: float = 0.0
-    model_used: str = ""
-    session_id: str | None = None
-
-
-class CLIAdapter(ABC):
-    """Abstraktion über CLI-Backends — Devin, Aider, Claude Code."""
+    parameters: dict  # JSON Schema
 
     @abstractmethod
-    def execute(
-        self,
-        prompt: str,
-        repo_path: Path,
-        model: str,
-        timeout: int,
-    ) -> tuple[str, str | None]:
-        """Execute prompt, return (stdout, error)."""
+    def execute(self, args: dict, sandbox: Sandbox) -> ToolResult:
+        """Execute tool within sandbox. ScopeLock enforced HERE."""
         ...
 
+class EditFileTool(Tool):
+    name = "edit_file"
 
-class DevinAdapter(CLIAdapter):
-    """Devin CLI via subprocess."""
-
-    def execute(self, prompt, repo_path, model, timeout):
-        cmd = [
-            "devin", "-p",
-            "--model", model,
-            "--permission-mode", "bypass",
-            "--", prompt,
-        ]
-        try:
-            result = subprocess.run(
-                cmd, cwd=repo_path,
-                capture_output=True, text=True,
-                timeout=timeout, check=False,
-            )
-            if result.returncode != 0:
-                return "", f"Exit {result.returncode}: {result.stderr[:500]}"
-            return result.stdout, None
-        except subprocess.TimeoutExpired:
-            return "", f"Timeout after {timeout}s"
-        except FileNotFoundError:
-            return "", "devin binary not found in PATH"
-
-
-class AiderAdapter(CLIAdapter):
-    """Aider CLI als Fallback-Backend."""
-
-    def execute(self, prompt, repo_path, model, timeout):
-        cmd = [
-            "aider",
-            "--model", model,
-            "--message", prompt,
-            "--yes",          # Non-interactive
-            "--no-git",       # Wir managen Git selbst
-        ]
-        try:
-            result = subprocess.run(
-                cmd, cwd=repo_path,
-                capture_output=True, text=True,
-                timeout=timeout, check=False,
-            )
-            return result.stdout, None if result.returncode == 0 else result.stderr[:500]
-        except subprocess.TimeoutExpired:
-            return "", f"Timeout after {timeout}s"
+    def execute(self, args, sandbox):
+        path = args["path"]
+        if not sandbox.scope.allows_write(path):
+            return ToolError(f"ScopeLock: write to '{path}' denied")
+        sandbox.write(path, args["new_content"])
+        return ToolSuccess(f"Written {len(args['new_content'])} bytes")
 ```
 
-### 5.4 ModelTier → CLI-Model Mapping
-
-Der Orchestrator routet nach ADR-177. Die Bridge übersetzt:
-
-```python
-# Orchestrator ModelTier → Devin --model Flag
-TIER_TO_DEVIN_MODEL: dict[str, str] = {
-    "gpt_low":  "haiku-4.5",       # Docs, Typos, Lint
-    "swe":      "swe-1.6",         # Features, Bugfixes, Refactor
-    "opus":     "opus-4.7",        # Architecture, Security, ADR
-}
-
-# Fallback: Orchestrator ModelTier → Aider --model Flag
-TIER_TO_AIDER_MODEL: dict[str, str] = {
-    "gpt_low":  "anthropic/claude-haiku-4-5-20251001",
-    "swe":      "anthropic/claude-sonnet-4-6-20260217",
-    "opus":     "anthropic/claude-opus-4-6-20260205",
-}
-```
-
-### 5.5 Gate-Modell (konsistent mit ADR-066)
-
-| Use Case | Gate | Automatisierung | Approval |
-|----------|------|----------------|----------|
-| Read-only Quality-Sweep (Findings only) | Gate 0 | Vollautomatisch | Keine |
-| Test-Generierung (neuer Code) | Gate 1 | Automatisch + Notification | User wird informiert |
-| Refactoring (bestehender Code ändern) | Gate 2 | Vorbereitet, Branch + PR | Human-Review vor Merge |
-| Cross-Repo-Batch-Refactoring | Gate 3 | Vorbereitet, je 1 PR/Repo | Explizite Freigabe pro Repo |
-| Security-Patches | Gate 2 | Branch + PR | Human-Review vor Merge |
-
-**Invariante**: Headless-Pipeline darf **niemals** direkt auf `main` pushen — immer Branch + PR.
-
----
-
-## 6. Use Cases im Detail
-
-### 6.1 Nightly Quality-Sweep (Gate 0 — Read-only)
-
-```
-Cron 03:00 UTC → headless_sweep.py
-    for repo in PLATFORM_REPOS:
-        1. Orchestrator: select_agent(task_type="quality_sweep") → DocBot + gpt_low
-        2. ContextBuilder: platform-context + REFLEX-Baseline + letzte Error-Patterns
-        3. HeadlessBridge: devin -p "Semantic quality check, return JSON findings"
-        4. ResultHandler: Findings → pgvector Memory + Markdown-Report
-        5. Vergleich mit REFLEX-Baseline: nur semantische Delta-Findings reporten
-    Aggregat-Summary → Discord #quality-reports
-```
-
-**Output**: JSON + Markdown pro Repo, aggregierte Summary. **Kein Code-Change.**
-
-**Mehrwert über REFLEX hinaus**:
-- "Diese View delegiert an `_helper()` die ORM-Calls macht" (REFLEX: ✅, da kein direkter `Model.objects` in View)
-- "Diese Migration ist nicht blue-green-safe wegen concurrent index lock" (REFLEX: kann Index-Locking nicht analysieren)
-- "Dieser Service hat 3 Verantwortlichkeiten — SRP-Verstoß" (REFLEX: kein Semantic-Understanding)
-
-### 6.2 Automatisierte Test-Generierung (Gate 1)
-
-```
-Trigger: Coverage-Report zeigt Module < 80%
-    1. Orchestrator: select_agent(task_type="test") → TestBot + gpt_low
-    2. ContextBuilder: Coverage-Diff + bestehende Test-Patterns + Factories
-    3. HeadlessBridge: devin -p "Generate tests for uncovered paths in {module}"
-    4. ScopeLock: Nur tests/**/*.py darf geschrieben werden
-    5. Guardian: ruff + pytest auf generierte Tests
-    6. ResultHandler: Branch test/auto-{date} → PR
-    7. Discord: "🧪 Auto-Tests für {repo}: +12 Tests, Coverage 74% → 83%"
-```
-
-**ScopeLock-Config für Test-Generierung**:
-```python
-SCOPE_TEST_GEN = {
-    "allow": ["tests/**/*.py", "apps/*/tests/**/*.py", "conftest.py"],
-    "deny": ["apps/*/models.py", "apps/*/views.py", "apps/*/services.py",
-             "migrations/**", ".env*", "docker-compose*", "Dockerfile*"],
-}
-```
-
-### 6.3 Batch-Refactoring (Gate 2)
-
-```
-Trigger: Manuell oder Issue mit Label [headless-refactor]
-    Beispiel: "Migriere alle repos von unique_together auf UniqueConstraint"
-    1. Orchestrator: select_agent(task_type="refactor") → ReEngineerBot + swe
-    2. Für jedes Repo:
-        a. ContextBuilder: Repo-spezifische Models + ADR-Referenz
-        b. HeadlessBridge: devin -p "Refactor unique_together → UniqueConstraint"
-        c. ScopeLock: Nur models.py + migrations darf geändert werden
-        d. Guardian: ruff + django check + migrate --check
-        e. Tester: pytest
-        f. Branch refactor/unique-constraint-{date} → PR
-    3. Discord: "🔧 Batch-Refactoring: 14/19 Repos → PRs erstellt"
-```
-
-### 6.4 PR-spezifischer semantischer Code-Review (Gate 0)
-
-```yaml
-# .github/workflows/semantic-review.yml
-on:
-  pull_request:
-    paths: ['apps/**/*.py']
-
-jobs:
-  semantic-review:
-    runs-on: self-hosted
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run semantic review
-        run: |
-          python scripts/headless_agent/pr_review.py \
-            --pr-diff "$(gh pr diff ${{ github.event.number }})" \
-            --repo ${{ github.repository }} \
-            --output-format github-comment
-      - name: Post review comment
-        # ... posts findings as PR comment
-```
-
-### 6.5 Cross-Repo-Konsistenz-Analyse (Gate 0)
-
-```
-Trigger: Wöchentlich oder nach ADR-Update
-    "Prüfe ob alle 19 Repos ADR-177 Agent-Naming-Konventionen einhalten"
-    1. Für jedes Repo:
-        HeadlessBridge: "Check compliance with ADR-177 naming, return JSON"
-    2. Aggregation: Matrix-Report {Repo × Standard → ✅/❌}
-    3. Delta zu letzter Woche: nur neue Violations reporten
-    4. pgvector: Trend-Daten für Governance-Dashboard
-```
-
-### 6.6 Automatisierte Security-Analyse (Gate 2)
-
-```
-Trigger: Nightly oder nach dependency-Update
-    1. Orchestrator: select_agent(task_type="security") → ArchitectBot + opus
-    2. HeadlessBridge: "Analyze authentication flows, session handling,
-       CSRF patterns — focus on semantic vulnerabilities that bandit misses"
-    3. Findings → Issue mit Label [security-review]
-    4. Bei critical: Discord @achim + E-Mail
-```
-
----
-
-## 7. DSGVO & Code-Souveränität
-
-| Aspekt | Risiko | Mitigation |
-|--------|--------|------------|
-| **Code an Cognition Cloud** | HOCH bei Mandanten-Code | Repo-Allowlist: nur eigene Repos, keine Mandanten-Repos |
-| **Prompt-Inhalte** | MITTEL | Keine personenbezogenen Daten in Prompts, nur Code-Patterns |
-| **Output-Speicherung** | GERING | Findings in eigenem pgvector, nicht bei Cognition |
-| **Exit-Strategie** | — | Aider-Fallback benötigt keine externe Cloud (eigener API-Key) |
-
-### Repo-Klassifikation
-
-```python
-class RepoClassification(str, Enum):
-    OWN_CODE = "own_code"           # Eigener Code → Headless erlaubt
-    MANDANT_CODE = "mandant_code"   # Mandanten-Code → nur lokale Inferenz
-    SENSITIVE = "sensitive"          # Trading, Billing → nur manuell
-
-HEADLESS_ALLOWED: dict[str, RepoClassification] = {
-    "travel-beat": RepoClassification.OWN_CODE,
-    "coach-hub": RepoClassification.OWN_CODE,
-    "risk-hub": RepoClassification.OWN_CODE,
-    "dev-hub": RepoClassification.OWN_CODE,
-    "weltenhub": RepoClassification.OWN_CODE,
-    "bfagent": RepoClassification.OWN_CODE,
-    "pptx-hub": RepoClassification.OWN_CODE,
-    "mcp-hub": RepoClassification.OWN_CODE,
-    # ...
-    "trading-hub": RepoClassification.SENSITIVE,  # IBKR-Code → kein Headless
-}
-```
-
-### Secret-Management
-
-`DEVIN_API_KEY` und `ANTHROPIC_API_KEY` (für Aider-Fallback) werden wie folgt verwaltet:
-
-- **CI (GitHub Actions)**: Als GitHub Org-Secret unter `Settings → Secrets → Actions` (ADR-021 §2.6)
-- **Server (Cron-Jobs)**: Via SOPS-verschlüsselte `.env`-Datei unter `/opt/mcp-hub/.env.headless` (ADR-045)
-- **Lokal (Entwicklung)**: Via `~/.config/devin/config.json` (Devin-eigene Config, nicht im Repo)
-
----
-
-## 8. Kosten-Modell
-
-### Kosten pro Use Case
-
-| Use Case | Modell | Tokens/Repo | $/Repo | $/Monat (19 Repos, 1×/Woche) |
-|----------|--------|-------------|--------|-------------------------------|
-| Quality-Sweep | gpt_low (Haiku) | ~8K | ~$0.01 | ~$0.76 |
-| Test-Generierung | gpt_low (Haiku) | ~15K | ~$0.02 | ~$1.52 |
-| Refactoring | swe (Sonnet) | ~25K | ~$0.20 | ~$15.20 |
-| Security-Analyse | opus | ~20K | ~$0.80 | ~$60.80 |
-| PR-Review | swe (Sonnet) | ~10K | ~$0.08 | ~$6.08 (angenommen 20 PRs/Woche) |
-
-**Geschätzte Gesamtkosten**: ~$85/Monat bei vollem Betrieb.
-
-### Budget-Guards (ADR-116)
-
-```python
-HEADLESS_BUDGET_LIMITS = {
-    "quality_sweep": 0.50,      # $0.50 pro Sweep (alle Repos)
-    "test_generation": 1.00,    # $1.00 pro Batch
-    "refactoring": 5.00,        # $5.00 pro Refactoring-Run
-    "security_analysis": 10.00, # $10.00 pro Security-Sweep
-    "pr_review": 0.50,          # $0.50 pro PR
-}
-```
-
-Hard-Stop bei Budget-Überschreitung → `BudgetExceededError` → Discord-Alert.
-
----
-
-## 9. Implementierungsplan
-
-| Phase | Inhalt | Aufwand | Abhängig von | Status |
-|-------|--------|---------|-------------|--------|
-| **0** | ADR-186 finalisieren (draft→proposed, Open Questions) | 1h | — | ✅ |
-| **0.5** | `pip install aider-chat` + API-Key konfigurieren + Smoke-Test | 0.5h | ANTHROPIC_API_KEY | ⬜ |
-| **1** | `CLIAdapter`-Abstraktion + `AiderAdapter` (Primary) + `DevinAdapter` (Optional) | 3h | Phase 0.5 | ⬜ |
-| **2** | `HeadlessBridge` mit Orchestrator-Integration (Routing, Budget, Context) | 4h | Phase 1 | ⬜ |
-| **3** | Quality-Sweep-Script (`headless_sweep.py`) — Gate 0, read-only | 2h | Phase 2 | ⬜ |
-| **4** | Cron-Setup + Discord-Notification für Sweep-Results | 1h | Phase 3 | ⬜ |
-| **5** | Test-Generator (`headless_test_gen.py`) — Gate 1, ScopeLock tests-only | 3h | Phase 2 | ⬜ |
-| **6** | PR-Review-Integration (`pr_review.py`) + GitHub Actions Workflow | 3h | Phase 2 | ⬜ |
-| **7** | Batch-Refactoring-Engine (`headless_refactor.py`) — Gate 2 | 4h | Phase 2 | ⬜ |
-| **8** | pgvector-Audit + Trend-Dashboard-Daten | 2h | Phase 3 | ⬜ |
-| **9** | Validierung: 2 Wochen Pilotbetrieb auf 3 Repos | — | Phase 4-6 | ⬜ |
-
-**Gesamt: ~23h über 4-5 Sessions.**
-
-### Pilot-Repos
-
-1. **dev-hub** — niedrigstes Risiko, 0 REFLEX-Findings, gute Test-Coverage
-2. **coach-hub** — mittlere Komplexität, gute CI-Gates
-3. **risk-hub** — höhere Komplexität, domänenspezifischer Code
-
-### Rollout
-
-| Woche | Aktivität |
-|-------|-----------|
-| 1 | Phase 1-3: Bridge + Quality-Sweep auf dev-hub |
-| 2 | Phase 4-5: Cron + Test-Generator auf dev-hub + coach-hub |
-| 3 | Phase 6-7: PR-Review + Refactoring auf Pilot-Repos |
-| 4 | Phase 8-9: Audit + Validierung, Rollout auf alle OWN_CODE Repos |
-
----
-
-## 10. Sicherheits-Gates
-
-| Gate | Mechanismus | ADR-Referenz |
-|------|------------|--------------|
-| **Repo-Allowlist** | `HEADLESS_ALLOWED` Dict — nur klassifizierte Repos | ADR-186 §7 |
-| **Branch-Protection** | Agent pusht nur `headless/{use-case}/{date}` — nie `main` | ADR-081 |
-| **ScopeLock** | Per-Use-Case Scope-Config: Test-Gen darf nur tests/ schreiben | ADR-081 |
-| **Budget-Guard** | Hard-Stop pro Use-Case-Kategorie | ADR-116 |
-| **DSGVO-Klassifikation** | `SENSITIVE` und `MANDANT_CODE` Repos sind gesperrt | ADR-186 §7 |
-| **Guardian-Verification** | ruff + bandit + pytest auf jeden Output | ADR-066 |
-| **Human-Review** | Gate 2+ → PR mit manueller Review-Pflicht | ADR-066 |
-| **Audit-Trail** | Jeder Run → pgvector Memory + AuditStore | ADR-068 |
-| **Kill-Switch** | `HEADLESS_ENABLED=false` in Orchestrator-Config → sofort aus | — |
-
----
-
-## 11. Abgrenzung
-
-- **Kein Ersatz für Cascade** — interaktive IDE-Arbeit bleibt in Cascade
-- **Kein Auto-Merge** — PRs werden immer manuell reviewed (Gate 2+)
-- **Kein Prod-Zugriff** — Agent arbeitet nur mit Git, nie mit laufenden Containern
-- **Kein Ersatz für REFLEX** — REFLEX bleibt für deterministische Pattern-Checks, Headless-Pipeline für semantische Analyse
-- **Kein eigener LLM-Stack** — LLM-Routing über Orchestrator (ADR-116/177), nicht über Devin-eigenes Routing
-- **Agent-Op, kein Infra-Op** — HeadlessBridge ist eine Agent-Operation (ADR-066 Agent-Team), keine Infrastruktur-Operation (ADR-075). Write-Ops betreffen Git-Branches und PRs, nicht Server-Deployments. ADR-075 Infra-Deploy-Regeln greifen daher nicht.
-- **Scope Phase 1**: Quality-Sweep + Test-Generierung — kein Multi-File-Refactoring
-- **Devin CLI ist austauschbar** — CLIAdapter-Abstraktion erlaubt Backend-Wechsel
-
----
-
-## 12. Vergleichsmatrix: Headless-Pipeline vs. Bestand
-
-| Fähigkeit | REFLEX | Cascade | Headless-Pipeline (ADR-186) |
-|-----------|--------|---------|----------------------------|
-| Deterministisch | ✅ | — | ❌ (LLM-basiert) |
-| Semantisches Verständnis | ❌ | ✅ | ✅ |
-| Headless/Batch | ❌ | ❌ | ✅ |
-| Polyrepo-Sweep | ✅ (schnell) | ❌ | ✅ (langsamer, tiefer) |
-| Kosten | $0 | IDE-Lizenz | ~$85/Monat |
-| Guardrails | Eigene Rules | Orchestrator | Orchestrator (identisch) |
-| Memory/Context | ❌ | pgvector | pgvector (identisch) |
-| Code-Änderungen | ❌ | ✅ | ✅ (Gate 1+) |
-| Test-Generierung | ❌ | ✅ (manuell) | ✅ (automatisch) |
-
----
-
-## 13. Confirmation
-
-| Kriterium | Messung |
-|-----------|---------|
-| Quality-Sweep findet ≥ 3 semantische Findings die REFLEX nicht findet | Manueller Vergleich nach Phase 3 |
-| Test-Generator erhöht Coverage um ≥ 5% auf Pilot-Repos | `coverage report` pre/post |
-| Budget-Guard verhindert Überschreitung bei 100% der Runs | AuditStore-Query |
-| ScopeLock blockiert Out-of-Scope-Änderungen bei 100% der Runs | Testcase |
-| CLIAdapter-Wechsel (Devin → Aider) funktioniert ohne Orchestrator-Änderung | Integrations-Test |
-| Headless-Pipeline ist per Kill-Switch deaktivierbar | Config-Test |
-
----
-
-## 14. Open Questions
-
-| # | Frage | Status | Entscheidung/Kontext |
-|---|-------|--------|----------------------|
-| Q1 | Devin CLI Lizenzkosten bei Headless-Nutzung? | **Entschieden** | Devin wird NICHT als Primary eingesetzt. Aider (Open Source) ist Primary-Backend — keine Lizenzkosten. Devin optional als Premium-Backend falls Budget vorhanden. |
-| Q2 | Aider als gleichwertiger Fallback — oder nur Notfall? | **Entschieden** | Aider ist **Primary Backend** (Open Source, `pip install aider-chat`, nutzt eigenen Anthropic/OpenAI API-Key). Devin CLI = Optional Premium. Claude Code CLI = Future wenn verfügbar. |
-| Q3 | pgvector Disk-Space für Trend-Daten (Nightly × 19 Repos × 365 Tage)? | **Entschieden** | 90-Tage Retention für Detail-Findings, Aggregat-Metriken unbegrenzt. ~500 KB/Tag × 90 = ~45 MB — kein Disk-Problem. Cleanup via Celery periodic task. |
-| Q4 | Soll PR-Review in CI blocking sein oder nur Comment? | **Entschieden** | Phase 1: nur Comment (non-blocking). Nach 4 Wochen Pilotbetrieb: False-Positive-Rate evaluieren. Bei <10% FP-Rate: blocking aktivieren. |
-| Q5 | Temporal-Integration für Long-Running-Refactorings? | Deferred | Erst nach Phase 9 Validierung. Aktueller Scope: Single-Repo, Single-Turn. Multi-Repo-Batch sequenziell. |
-
----
-
-## 15. Deferred Decisions
-
-| Entscheidung | Begründung | Zieldatum | Tracking |
-|--------------|------------|-----------|----------|
-| RL-basiertes Routing für Headless-Tasks | Erst nach 3+ Monaten AuditStore-Daten | 2026-Q4 | Kein eigenes ADR — Erweiterung von ADR-177 |
-| Cloud-Delegation (Devin Cloud) | DSGVO-Klärung für Mandanten-Code pending | 2026-Q3 | Kein eigenes ADR — Erweiterung von ADR-186 §7 |
-| Parallel-Execution über Repos | Requires Temporal (ADR-077) | 2026-Q4 | Kein eigenes ADR — Trigger: Sweep-Duration > 60 Min |
-| Custom Devin Skills für Platform-Standards | Evaluieren nach Phase 9 Erfahrung | 2026-Q3 | Kein eigenes ADR — Feature in HeadlessBridge |
-
----
-
-## 16. Glossar
-
-| Begriff | Erklärung |
-|---------|-----------|
-| **ADR** | Architecture Decision Record — dokumentierte Architekturentscheidung im MADR-4.0-Format |
-| **AST** | Abstract Syntax Tree — Baumdarstellung von Quellcode für statische Analyse |
-| **Budget-Guard** | Orchestrator-Komponente die LLM-Kosten pro Task-Kategorie limitiert (Hard-Stop bei Überschreitung) |
-| **Cascade** | IDE-basierter AI-Coding-Agent (Windsurf IDE), primäres interaktives Entwicklungswerkzeug |
-| **CLI** | Command Line Interface — Kommandozeilen-Schnittstelle |
-| **CLIAdapter** | Abstrakte Schnittstelle die verschiedene CLI-Backends (Devin, Aider, Claude Code) austauschbar macht |
-| **Devin CLI** | Kommerzielles CLI-Tool von Cognition AI für headless Code-Analyse und -Generierung |
-| **DSGVO** | Datenschutz-Grundverordnung — EU-Verordnung zum Schutz personenbezogener Daten |
-| **Gate** | Kontrollstufe im Agent-Workflow: Gate 0 = autonom, Gate 1 = Notify, Gate 2 = Human-Review, Gate 3 = Explizite Freigabe, Gate 4 = Human-Only (ADR-066) |
-| **Guardian** | Agent-Rolle die jeden Output auf Lint-Fehler, Security-Verstöße und Test-Failures prüft (ruff + bandit + pytest) |
-| **HeadlessBridge** | Neue Orchestrator-Komponente die CLI-Backends mit Routing, Budget und Guardrails verbindet |
-| **Headless-Modus** | Betrieb ohne grafische Oberfläche — Prompt rein, Ergebnis raus, kein menschliches Eingreifen nötig |
-| **LLM** | Large Language Model — KI-Sprachmodell (z.B. Claude, GPT) das Code analysieren und generieren kann |
-| **MCP** | Model Context Protocol — Standard-Schnittstelle zwischen AI-Systemen und externen Tools/Datenquellen |
-| **Orchestrator** | Zentrale Steuerungskomponente (mcp-hub) die Agent-Routing, Budget-Tracking und Guardrails verwaltet |
-| **pgvector** | PostgreSQL-Erweiterung für Vektor-Ähnlichkeitssuche — wird als persistenter Memory-Store genutzt |
-| **Polyrepo** | Architekturmuster bei dem jedes Projekt ein eigenes Git-Repository hat (Gegenteil: Monorepo) |
-| **PR** | Pull Request — Änderungsvorschlag auf GitHub der vor dem Merge reviewed wird |
-| **REFLEX** | Deterministic ADR-Compliance-Tool (Regex/AST-basiert) — prüft Code gegen Platform-Regeln ohne LLM |
-| **ScopeLock** | Guardrail (ADR-081) das festlegt welche Dateipfade ein Agent lesen/schreiben darf |
-| **SOPS** | Secrets OPerationS — Mozilla-Tool zur verschlüsselten Speicherung von Secrets in Git |
-| **SRP** | Single Responsibility Principle — jede Klasse/Funktion hat genau eine Verantwortlichkeit |
-
----
-
-## 17. References
-
-- **ADR-066** — AI Engineering Squad (Gate-System, Agent-Rollen)
-- **ADR-068** — AuditStore (Logging-Pflicht)
-- **ADR-075** — Infra-Deploy (Write-Ops via GitHub Actions)
-- **ADR-077** — Catalog & Temporal
-- **ADR-080** — Multi-Agent Coding Team Pattern
-- **ADR-081** — Agent Guardrails & Code Safety (ScopeLock)
-- **ADR-082** — LLM Tool Integration & Autonomous Coding (StepExecutor)
-- **ADR-116** — Dynamic Model Router (Budget-Tracking)
-- **ADR-141** — Discord → Agentic Coding Bridge (amended: Execution via CLI statt Custom-StepExecutor)
-- **ADR-156** — Job Duration Estimation
-- **ADR-177** — Agent Role Specialization (5 Bots, deterministisches Routing)
-- **ADR-185** — Deploy Agent Pattern (Gate-controlled Deployments)
-- **REFLEX** v0.5.0 — Deterministische ADR-Compliance
-- Devin Terminal CLI — cli.devin.ai
-- Aider — aider.chat (Open-Source CLI Agent)
+### Database Tables
+
+- `headless_repo_allowlist` — repo whitelist with classification + kill-switch
+- `headless_runs` — audit log for every pipeline execution
+- `headless_findings` — deduplicated semantic findings (content_hash)
+- `headless_budgets` — per-category budget with atomic reservation
+
+### Security Model
+
+1. **Inline ScopeLock**: Tool rejects forbidden writes before they happen
+2. **Worktree Sandbox**: Disposable git worktree, discarded on violation
+3. **Live Budget Abort**: Loop stops immediately when budget exceeded
+4. **Prompt Hardening**: Delimiter-based user input isolation + injection detection
+5. **Atomic Budget**: `SELECT FOR UPDATE` row locks prevent race conditions
+6. **Repo Allowlist**: DB-backed, classification-aware (own_code only)
+7. **Env Isolation**: Only for CLI fallback adapters (HARD_DENY frozenset)
+
+### Confirmation
+
+Compliance with this ADR is verified by:
+
+1. **Unit tests**: `orchestrator_mcp/headless/tests/` — all pass in CI (44 tests)
+2. **ScopeLock enforcement**: Integration test proves tool rejects forbidden writes
+3. **Budget abort**: Test confirms loop exits when budget exceeded mid-run
+4. **Audit log**: Every `headless_runs` entry has full trace (status, cost, duration)
+5. **Nightly sweep metrics**: Discord weekly report shows finding count + cost per repo
+6. **REFLEX rule**: `headless.no_direct_litellm` — blocks direct litellm usage in headless/
+
+### Model Routing (via aifw)
+
+| action_code | Default Model | Fallback | Budget |
+|-------------|---------------|----------|--------|
+| `quality_sweep` | `groq/llama-3.3-70b` | `claude-haiku` | $0 (free) |
+| `pr_review` | `groq/llama-3.3-70b` | `claude-haiku` | $0 (free) |
+| `docstring_gen` | `groq/llama-3.3-70b` | `claude-haiku` | $0 (free) |
+| `test_generation` | `claude-sonnet-4-6` | `groq/llama-70b` | $0.50/run |
+| `refactoring` | `claude-sonnet-4-6` | — | $1.00/run |
+| `security_audit` | `claude-sonnet-4-6` | — | $0.50/run |
+| `complex_refactor` | Claude Code CLI (fallback) | — | $5.00/run |
+
+## Consequences
+
+### Positive
+
+- **One routing config for ALL consumers** — Django, headless, CI, MCP
+- Autonomous nightly quality enforcement across all 19 repos at **$0 cost** (Groq)
+- Live budget abort — never overspend
+- Inline ScopeLock — impossible to write to forbidden paths
+- Full observability — every token, every tool call in audit log
+- Vendor-independent — swap model via config, not code
+- Pure Python — testable without subprocess mocking
+
+### Negative
+
+- aifw requires refactoring to extract DB-independent core
+- Own tool implementations need maintenance
+- Tool-use loop may be less capable than Claude Code for very complex tasks
+
+### Neutral
+
+- CLI adapters remain as fallback (not wasted, just demoted)
+- Git worktree sandbox shared between both paths
+- Groq free tier has rate limits (30 req/min) — sufficient for nightly sweeps
+
+## Open Questions
+
+1. **aifw Core-Extraction scope**: Should aifw's DB-independent engine be a
+   separate ADR (ADR-187)? Decision deferred until Phase 2 starts.
+   → Preliminary answer: Yes, aifw CLI/HTTP extension warrants its own ADR.
+2. **Complexity threshold for CLI fallback**: What defines "moderate" vs. "complex"?
+   → Preliminary: >20 files changed OR >3 interdependent modules = complex → CLI fallback.
+3. **Temporal integration**: Should the Agent Loop be wrapped in a Temporal workflow
+   for durability and retry? → Phase 1: No. Runs synchronously. Re-evaluate in Phase 5.
+4. **Nightly sweep scheduling**: GitHub Actions cron or Temporal schedule?
+   → Decision: GitHub Actions scheduled workflow (ADR-075 compliance: write-ops via Actions).
+5. **API key rotation**: How are `GROQ_API_KEY`, `ANTHROPIC_API_KEY` rotated?
+   → Managed via SOPS (ADR-045), rotated quarterly, stored in org-level secrets.
+
+## Implementation Plan
+
+| Phase | Deliverable | Effort |
+|-------|-------------|--------|
+| 1 (done) | CLI adapters + bridge + services + tests | ✅ complete |
+| 2 | aifw core extraction (DB-independent engine) | 4h |
+| 3 | aifw CLI mode (`python -m aifw complete`) | 2h |
+| 4 | Groq provider in aifw routing | 1h |
+| 5 | Agent Loop + scope-aware tools | 6h |
+| 6 | Integration: bridge dispatches to loop vs. CLI | 2h |
+| 7 | Nightly sweep cron + Discord reporting | 3h |
+
+## Glossary
+
+- **action_code**: aifw routing key mapping task → model + provider + budget
+- **Agent Loop**: Own tool-use loop built on aifw — full control, no external CLI
+- **aifw**: Platform-internes LLM-Gateway (Python import, CLI, HTTP) — zentrale Schnittstelle für alle LLM-Aufrufe
+- **CLI**: Command-Line Interface — Kommandozeilenprogramm
+- **content_hash**: SHA256 aus Identitätsfeldern eines Findings zur Deduplizierung
+- **HARD_DENY**: Frozenset von Umgebungsvariablen die niemals an Subprozesse weitergegeben werden dürfen
+- **LLM**: Large Language Model — KI-Sprachmodell (z.B. Claude, GPT, Llama)
+- **MCP**: Model Context Protocol — Orchestrator-Protokoll für Tool-Aufrufe und Kontext-Management
+- **ORM**: Object-Relational Mapping — Abstraktion für Datenbankzugriffe (hier: SQLAlchemy)
+- **ScopeLock**: ADR-081 Mechanismus zur Einschränkung erlaubter Dateimodifikationen (inline bei jedem Tool-Call)
+- **SOPS**: Secrets OPerationS — Verschlüsselungstool für Secrets in Repositories (ADR-045)
+- **Worktree**: Git-Feature für parallele Arbeitsverzeichnisse (isolierte Sandbox)
+
+## More Information
+
+- **catalog-info.yaml**: The `headless` component will be registered in mcp-hub's
+  `catalog-info.yaml` once Phase 5 (Agent Loop) is complete (ADR-077 compliance).
+- **aifw extension**: Phases 2–4 affect aifw package — a separate ADR-187 will be
+  created when that work starts (scope separation).
+- **Nightly sweep**: Triggered via GitHub Actions scheduled workflow (ADR-075: write-ops
+  via Actions, not MCP). Agent Loop runs synchronously, no Temporal in Phase 1.
+
+## References
+
+- ADR-045: Secrets Management (SOPS)
+- ADR-059: Drift-Detector
+- ADR-066: AI Engineering Squad (Gate-System, Agent-Rollen)
+- ADR-068: Audit Trail
+- ADR-075: infra-deploy (write-ops via GitHub Actions)
+- ADR-077: Service Catalog (catalog-info.yaml)
+- ADR-081: ScopeLock
+- ADR-116: Budget Tracking
+- ADR-138: Implementation Tracking
+- ADR-141: Discord → Agentic Coding Bridge (amended: Execution via Agent Loop statt Custom-StepExecutor)
+- ADR-177: Agent Role Specialization / Model Tiers
+- External Review: `mcp-hub/docs/ADR-186-PLAYBOOK.md` + Review-Historie (33 findings, 7 blockers fixed)
+- aifw: `github.com/achimdehnert/aifw`

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -189,7 +189,7 @@
 | 156 | Adopt Server-Side Deploy Scripts with Short-Trigger Pattern for Reliable Pipeline | `Accepted` | ✅ | [ADR-156](ADR-156-reliable-deployment-pipeline.md) |
 | 157 | Adopt same-port staging on Dev Desktop with automated port governance and onboarding | `Accepted` | ✅ | [ADR-157](ADR-157-staging-production-split-and-port-governance.md) |
 | 158 | Adopt dev-hub as Unified Documentation Portal with Audience Navigator and AI-Generated Reference Docs | `Accepted` | ✅ | [ADR-158](ADR-158-unified-documentation-architecture.md) |
-| 160 | Adopt Standardized Two-File CI/CD Pipeline for All Hub Repositories | `Accepted` | 🔶 | [ADR-160](../../mcp-hub/docs/ADR-160-standardized-hub-deployment.md) |
+| 160 | Adopt LLM-Powered Query-Expansion and Relevance Scoring for researchfw | `Accepted` | ✅ | [ADR-160](ADR-160-llm-powered-research-pipeline.md) |
 | 161 | Adopt Two-Layer-Schema with Hybrid-RLS for Tenant-Spanning SDS Data | `Proposed` | ⬜ | [ADR-161](ADR-161-shared-sds-library.md) |
 | 162 | Adopt REFLEX as Standard Methodology for Evidence-based UI Development | `Accepted` | 🔶 | [ADR-162](ADR-162-reflex-ui-testing-and-scraping.md) |
 | 163 | Adopt Three-Tier REFLEX Quality Standard for All Platform Repositories | `Accepted` | 🔶 | [ADR-163](ADR-163-reflex-tiering-platform-quality-standard.md) |
@@ -204,7 +204,7 @@
 | 175 | Adopt selective modularization for .windsurf/workflows/ files | `Accepted` | ✅ | [ADR-175](ADR-175-workflow-modularization-pattern.md) |
 | 177 | Agent Role Specialization — Split Developer into 5 specialized agents (DocBot, TestBot, FeatureBot, ReEngineerBot, ArchitectBot) | `Proposed` | ⬜ | [ADR-177](ADR-177-agent-role-specialization.md) |
 | 185 | Adopt Gate-controlled Deploy-Agent for automated Staging→Prod deployments | `Proposed` | ⬜ | [ADR-185](ADR-185-deploy-agent-pattern.md) |
-| 186 | Adopt Headless Agent-Coding Pipeline via Devin CLI + Orchestrator Bridge for Polyrepo Automation | `Proposed` | ⬜ | [ADR-186](ADR-186-headless-agent-coding-pipeline.md) |
+| 186 | Use Unified Agent Loop on aifw for Headless Coding Pipeline (v1.3) | `Proposed` | 🔶 | [ADR-186](ADR-186-headless-agent-coding-pipeline.md) |
 | 187 | Document Intelligence Pipeline — iil-ingest erweitern um VectorStore, Multi-Tool Ensemble & RAG | `Accepted` | 🔶 | [ADR-187](ADR-187-document-intelligence-pipeline.md) |
 | 188 | Adopt ADR-171 Schema with multilingual-e5-large as Platform-Wide Unified Vector Store | `Proposed` | ⬜ | [ADR-188](ADR-188-unified-vector-store.md) |
 | 194 | Universal LLM-Call Logging via Gateway | `Proposed` | ⬜ | [ADR-194](ADR-194-universal-llm-call-logging-via-gateway.md) |


### PR DESCRIPTION
## Was

Ersetzt platform ADR-186 (v1.2, **Devin CLI + Orchestrator-Bridge**) durch die in mcp-hub weiterentwickelte **v1.3** (**Unified Agent Loop auf aifw**, CLI-Adapter nur Fallback) und fixt zwei INDEX.md-Drifts.

## Warum

Der ADR-Fork wurde in der 3-Repo-ADR-Analyse (2026-06-10) gefunden: mcp-hub entwickelte ADR-186 zu v1.3 weiter (Commit `1e6ce04`), spielte sie aber nie nach platform zurück. Der produktive Code (`mcp-hub/orchestrator_mcp/headless/`, 44 Tests) und mcp-hub CORE_CONTEXT folgen v1.3 — die kanonische platform-Fassung widersprach damit der realen Architektur. Das war der einzige Fall, in dem die kanonische ADR-Quelle inhaltlich *falsch* war (Entscheidung E1 der Enterprise-Basis-Optimierung).

## Änderungen

- `docs/adr/ADR-186-…`: Body = v1.3-Inhalt; Frontmatter platform-schema-konform (validate lokal grün: 186/186); Versionshistorie + Provenienz-Hinweis; `implementation_status: partial` + Evidence; Devin-Re-Eval-Trigger aufgelöst (v1.3 ist vendor-unabhängig)
- `INDEX.md:192`: Nr. 160 zeigte auf die **mcp-hub-Datei** (Nummernraum-Kollision) statt auf platforms eigene accepted `ADR-160-llm-powered-research-pipeline.md` — repointet
- `INDEX.md:207`: ADR-186-Titel auf v1.3 aktualisiert

## Folge-PR

Banner auf den mcp-hub-lokalen ADRs (non-canonical) + tote Artefakte folgt separat in mcp-hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)