### PR TITLE
ci(adr): Citation-Lint + INDEX-Checker als SUGGEST-Step

### DIFF
--- a/.github/workflows/adr-validate.yml
+++ b/.github/workflows/adr-validate.yml
@@ -3,10 +3,14 @@ name: ADR Schema Validation
 on:
   push:
     paths:
-      - "docs/adr/ADR-*.md"
+      - "docs/adr/**"
+      - "tools/adr_citation_lint.py"
+      - "tools/adr_index_check.py"
   pull_request:
     paths:
-      - "docs/adr/ADR-*.md"
+      - "docs/adr/**"
+      - "tools/adr_citation_lint.py"
+      - "tools/adr_index_check.py"
   schedule:
     - cron: "0 6 * * 1"  # Weekly Monday 06:00 UTC
 
@@ -40,4 +44,19 @@ jobs:
           else
             echo "✓ No ADR reference drift."
           fi
+          exit 0
+
+      # ADR citation lint + INDEX consistency — SUGGEST / non-gating
+      # (repo-health-rule-discipline: neue Regeln starten als SUGGEST, deterministisch-
+      # strukturell, kein LLM). Ergaenzt den staleness-Step (nur depends_on-Frontmatter)
+      # um Body-Zitate (dead_ref/stale_filename/external_target) und INDEX.md-Drift
+      # (missing_row/ghost_row/status_drift/broken_link/stale_next_free).
+      # Promotion-Pfad zu gating: erst die Alt-Funde bereinigen bzw. via
+      # docs/adr/.adr-lint-ignore parken, dann hier `--gate` setzen und das
+      # `exit 0` entfernen. Skripte selbst exiten im SUGGEST-Modus IMMER 0.
+      - name: ADR citation lint + INDEX consistency (SUGGEST, non-gating)
+        run: |
+          set +e
+          python3 tools/adr_citation_lint.py --format github
+          python3 tools/adr_index_check.py --format github
           exit 0

--- a/tools/adr_citation_lint.py
+++ b/tools/adr_citation_lint.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""adr_citation_lint.py — deterministischer Lint fuer ADR-Querverweise (Body-Zitate).
+
+Ergaenzt den bestehenden `iil-adrfw staleness`-Step (der nur depends_on-Frontmatter
+prueft) um Body-Zitate und Markdown-Links. Hintergrund: ADR-Full-Scan 2026-06-06
+fand ~30 tote/falsch betitelte ADR-Querverweise (Zitat auf Nummer, die archiviert
+oder anders belegt ist) — der dominante, CI-fangbare Defekt-Typ.
+
+Finding-Kategorien (deterministisch-strukturell, kein LLM):
+  dead_ref        Referenz auf eine ADR-Nummer ohne aktive Datei in docs/adr/
+                  (mit Hinweis auf den Archiv-Pfad, falls die Nummer dort liegt)
+  stale_filename  Markdown-Link, dessen Ziel-Slug nicht dem realen Dateinamen
+                  der aktiven Nummer entspricht (z.B. nach Rename/Renumbering)
+  external_target Markdown-Link mit ADR-Bezug, dessen Ziel ausserhalb docs/adr/
+                  liegt (z.B. ../../mcp-hub/...)
+
+Whitelist fuer bekannte Alt-Funde:
+  - Inline-Marker `<!-- adr-lint: ignore-next-line -->` (unterdrueckt die
+    Folgezeile komplett)
+  - docs/adr/.adr-lint-ignore — eine Referenz pro Zeile, Format:
+        ADR-054 in ADR-101
+    (unterdrueckt alle Findings fuer Referenz ADR-054 innerhalb von ADR-101;
+    `#`-Kommentare und Leerzeilen erlaubt)
+
+SUGGEST-Modus (Default, repo-health-rule-discipline): Exit-Code IMMER 0.
+`--gate` ist fuer die spaetere Promotion vorgesehen (Exit 1 bei Findings),
+erst nach Bereinigung der Alt-Funde aktivieren.
+
+Usage:
+    python3 tools/adr_citation_lint.py [--adr-dir docs/adr] [--format human|github] [--gate]
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+from dataclasses import dataclass
+
+ADR_FILE_RE = re.compile(r"^ADR-(\d{3})\b")
+ADR_REF_RE = re.compile(r"ADR-(\d{3})")
+# Markdown-Link: [text](target) — target ohne Whitespace, optionaler "title"
+MD_LINK_RE = re.compile(r"\[([^\]]*)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+IGNORE_MARKER = "<!-- adr-lint: ignore-next-line -->"
+IGNORE_FILE_LINE_RE = re.compile(r"^(ADR-\d{3})\s+in\s+(ADR-\d{3})\s*$")
+
+
+@dataclass
+class Finding:
+    path: str  # repo-relativer Pfad der Quelldatei
+    line: int  # 1-basiert
+    category: str  # dead_ref | stale_filename | external_target
+    message: str
+
+
+def build_maps(
+    adr_dir: pathlib.Path,
+) -> tuple[dict[str, pathlib.Path], dict[str, list[pathlib.Path]]]:
+    """Nummer→Datei-Maps: aktiv (docs/adr/ flach) und archiviert (archive/ + _archive/)."""
+    active: dict[str, pathlib.Path] = {}
+    for f in sorted(adr_dir.glob("ADR-*.md")):
+        m = ADR_FILE_RE.match(f.name)
+        if m:
+            active[m.group(1)] = f
+    archived: dict[str, list[pathlib.Path]] = {}
+    for sub in ("archive", "_archive"):
+        d = adr_dir / sub
+        if not d.is_dir():
+            continue
+        for f in sorted(d.rglob("ADR-*.md")):
+            m = ADR_FILE_RE.match(f.name)
+            if m:
+                archived.setdefault(m.group(1), []).append(f)
+    return active, archived
+
+
+def load_ignore_pairs(adr_dir: pathlib.Path) -> set[tuple[str, str]]:
+    """Liest .adr-lint-ignore: {(referenzierte Nummer, Quell-Nummer), ...}."""
+    pairs: set[tuple[str, str]] = set()
+    ignore_file = adr_dir / ".adr-lint-ignore"
+    if not ignore_file.is_file():
+        return pairs
+    for raw in ignore_file.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        m = IGNORE_FILE_LINE_RE.match(line)
+        if m:
+            pairs.add((m.group(1)[4:], m.group(2)[4:]))  # nur die Nummern
+    return pairs
+
+
+def _rel(path: pathlib.Path, root: pathlib.Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def lint_file(
+    src: pathlib.Path,
+    adr_dir: pathlib.Path,
+    active: dict[str, pathlib.Path],
+    archived: dict[str, list[pathlib.Path]],
+    ignore_pairs: set[tuple[str, str]],
+    repo_root: pathlib.Path,
+) -> list[Finding]:
+    """Lintet eine aktive ADR-Datei (Body + Frontmatter, zeilenweise)."""
+    findings: list[Finding] = []
+    src_rel = _rel(src, repo_root)
+    own_m = ADR_FILE_RE.match(src.name)
+    own_num = own_m.group(1) if own_m else ""
+    adr_dir_resolved = adr_dir.resolve()
+    seen: set[tuple[int, str, str]] = set()  # (line, category, num/target) dedupe
+
+    def add(line_no: int, category: str, num: str, message: str) -> None:
+        if num and (num, own_num) in ignore_pairs:
+            return
+        key = (line_no, category, num or message)
+        if key in seen:
+            return
+        seen.add(key)
+        findings.append(Finding(src_rel, line_no, category, message))
+
+    def check_number(line_no: int, num: str) -> None:
+        """dead_ref-Check fuer eine bare Nummern-Referenz."""
+        if num == own_num or num in active:
+            return
+        if num in archived:
+            hint = ", ".join(_rel(p, repo_root) for p in archived[num])
+            add(line_no, "dead_ref", num, f"ADR-{num} hat keine aktive Datei (archiviert: {hint})")
+        else:
+            add(line_no, "dead_ref", num, f"ADR-{num} existiert weder aktiv noch archiviert")
+
+    lines = src.read_text(encoding="utf-8", errors="ignore").splitlines()
+    skip_next = False
+    for i, line in enumerate(lines, start=1):
+        if skip_next:
+            skip_next = False
+            continue
+        if IGNORE_MARKER in line:
+            skip_next = True
+            continue
+
+        rest = line
+        for m in MD_LINK_RE.finditer(line):
+            text, target = m.group(1), m.group(2)
+            rest = rest.replace(m.group(0), " ", 1)
+            target_path = target.split("#", 1)[0]
+            has_adr = bool(ADR_REF_RE.search(text) or ADR_REF_RE.search(target))
+            if "://" in target or target.startswith("mailto:"):
+                # URL-Ziele: nur die Nummern im Link-Text pruefen
+                for num in ADR_REF_RE.findall(text):
+                    check_number(i, num)
+                continue
+            if not has_adr:
+                continue
+            # relativer Pfad: gegen das Verzeichnis der Quelldatei aufloesen
+            resolved = (src.parent / target_path).resolve() if target_path else src.resolve()
+            if not str(resolved).startswith(str(adr_dir_resolved) + "/") and resolved != adr_dir_resolved:
+                nums = ADR_REF_RE.findall(target) or ADR_REF_RE.findall(text)
+                num = nums[0] if nums else ""
+                add(
+                    i,
+                    "external_target",
+                    num,
+                    f"Link-Ziel ausserhalb docs/adr/: {target}",
+                )
+                continue
+            fm = ADR_REF_RE.search(pathlib.Path(target_path).name)
+            if fm and target_path.endswith(".md"):
+                num = fm.group(1)
+                if num == own_num:
+                    continue
+                if num in active:
+                    if resolved != active[num].resolve():
+                        add(
+                            i,
+                            "stale_filename",
+                            num,
+                            f"Link-Slug '{target_path}' entspricht nicht der aktiven Datei "
+                            f"{active[num].name} fuer ADR-{num}",
+                        )
+                else:
+                    check_number(i, num)
+            else:
+                # Link auf Nicht-ADR-Datei innerhalb docs/adr mit ADR-Nummer im Text
+                for num in ADR_REF_RE.findall(text):
+                    check_number(i, num)
+
+        # bare Referenzen ausserhalb von Links
+        for num in ADR_REF_RE.findall(rest):
+            check_number(i, num)
+
+    return findings
+
+
+def run(adr_dir: pathlib.Path, repo_root: pathlib.Path) -> list[Finding]:
+    active, archived = build_maps(adr_dir)
+    ignore_pairs = load_ignore_pairs(adr_dir)
+    findings: list[Finding] = []
+    for num in sorted(active):
+        findings.extend(
+            lint_file(active[num], adr_dir, active, archived, ignore_pairs, repo_root)
+        )
+    return findings
+
+
+def emit(findings: list[Finding], fmt: str) -> None:
+    counts: dict[str, int] = {}
+    for f in findings:
+        counts[f.category] = counts.get(f.category, 0) + 1
+        if fmt == "github":
+            print(
+                f"::warning file={f.path},line={f.line},"
+                f"title=adr-citation-lint {f.category}::{f.message}"
+            )
+        else:
+            print(f"{f.path}:{f.line}: [{f.category}] {f.message}")
+    summary = ", ".join(f"{k}={v}" for k, v in sorted(counts.items())) or "0 Findings"
+    if fmt == "github":
+        print(f"::warning title=adr-citation-lint summary::{len(findings)} Finding(s): {summary}")
+    print(f"adr-citation-lint: {len(findings)} Finding(s) ({summary})")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--adr-dir", default="docs/adr", help="ADR-Verzeichnis (Default docs/adr)")
+    ap.add_argument("--format", choices=["human", "github"], default="human")
+    ap.add_argument(
+        "--gate",
+        action="store_true",
+        help="Exit 1 bei Findings (Promotion-Pfad; Default ist SUGGEST = Exit 0)",
+    )
+    args = ap.parse_args(argv)
+
+    adr_dir = pathlib.Path(args.adr_dir)
+    if not adr_dir.is_dir():
+        print(f"adr-citation-lint: Verzeichnis {adr_dir} nicht gefunden — nichts zu pruefen.")
+        return 0
+    repo_root = adr_dir.resolve().parent.parent  # docs/adr → repo root
+    findings = run(adr_dir.resolve(), repo_root)
+    emit(findings, args.format)
+    if args.gate and findings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/adr_index_check.py
+++ b/tools/adr_index_check.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""adr_index_check.py — Konsistenz-Check INDEX.md ↔ ADR-Dateibestand.
+
+docs/adr/INDEX.md ist handgepflegt und driftet (stale "Next free ADR number",
+fehlende Zeilen fuer neue ADRs, Geister-Eintraege, Status-Drift). Dieser Check
+vergleicht die INDEX-Tabelle (| # | Title | Status | Impl | Link |) deterministisch
+gegen den Dateibestand in docs/adr/ (aktiv) + archive/ + _archive/ (archiviert).
+
+Finding-Kategorien:
+  missing_row     aktive ADR-Datei ohne INDEX-Eintrag
+  ghost_row       INDEX-Eintrag, fuer den weder aktive noch archivierte Datei existiert
+  status_drift    INDEX-Status ≠ Frontmatter `status:` (case-insensitive;
+                  INDEX `Archived` matcht Dateien unter _archive/)
+  broken_link     INDEX-Link-Ziel existiert nicht im Filesystem
+  stale_next_free Kopfzeile "Next free ADR number" ≠ max(aktive Nummer)+1
+
+SUGGEST-Modus (Default, repo-health-rule-discipline): Exit-Code IMMER 0.
+`--gate` fuer spaetere Promotion (Exit 1 bei Findings) nach Bereinigung der Alt-Funde.
+
+Usage:
+    python3 tools/adr_index_check.py [--adr-dir docs/adr] [--format human|github] [--gate]
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+from dataclasses import dataclass
+
+ADR_FILE_RE = re.compile(r"^ADR-(\d{3})\b")
+NEXT_FREE_RE = re.compile(r"Next free ADR number:\*{0,2}\s*(\d+)")
+ROW_RE = re.compile(r"^\|\s*(\d{3})\s*\|")
+LINK_RE = re.compile(r"\[([^\]]*)\]\(([^)\s]+)\)")
+FRONTMATTER_STATUS_RE = re.compile(r"^status:\s*(.+?)\s*$", re.MULTILINE)
+
+
+@dataclass
+class Finding:
+    path: str
+    line: int
+    category: str
+    message: str
+
+
+@dataclass
+class IndexRow:
+    line: int
+    number: str
+    title: str
+    status: str  # normalisiert (lowercase, ohne Backticks)
+    link_target: str  # leer wenn kein Link geparst
+
+
+def build_maps(
+    adr_dir: pathlib.Path,
+) -> tuple[dict[str, pathlib.Path], dict[str, list[pathlib.Path]]]:
+    """Nummer→Datei-Maps: aktiv (flach) und archiviert (archive/ + _archive/, rekursiv)."""
+    active: dict[str, pathlib.Path] = {}
+    for f in sorted(adr_dir.glob("ADR-*.md")):
+        m = ADR_FILE_RE.match(f.name)
+        if m:
+            active[m.group(1)] = f
+    archived: dict[str, list[pathlib.Path]] = {}
+    for sub in ("archive", "_archive"):
+        d = adr_dir / sub
+        if not d.is_dir():
+            continue
+        for f in sorted(d.rglob("ADR-*.md")):
+            m = ADR_FILE_RE.match(f.name)
+            if m:
+                archived.setdefault(m.group(1), []).append(f)
+    return active, archived
+
+
+def _norm_status(raw: str) -> str:
+    """Normalisiert Status: Backticks/Quotes weg, lowercase, erstes Wort."""
+    s = raw.strip().strip("`'\"").strip()
+    return s.split()[0].lower() if s else ""
+
+
+def frontmatter_status(path: pathlib.Path) -> str:
+    """Liest `status:` aus dem YAML-Frontmatter; leer wenn nicht vorhanden."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return ""
+    if not text.startswith("---"):
+        return ""
+    end = text.find("\n---", 3)
+    if end == -1:
+        return ""
+    m = FRONTMATTER_STATUS_RE.search(text[3:end])
+    return _norm_status(m.group(1)) if m else ""
+
+
+def parse_index(index_path: pathlib.Path) -> tuple[list[IndexRow], int | None, int]:
+    """Parst INDEX.md → (Tabellenzeilen mit 3-stelliger Nummer, next-free-Wert, dessen Zeile)."""
+    rows: list[IndexRow] = []
+    next_free: int | None = None
+    next_free_line = 0
+    for i, line in enumerate(index_path.read_text(encoding="utf-8").splitlines(), start=1):
+        nf = NEXT_FREE_RE.search(line)
+        if nf and next_free is None:
+            next_free = int(nf.group(1))
+            next_free_line = i
+        m = ROW_RE.match(line)
+        if not m:
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) < 5:
+            continue
+        link_m = LINK_RE.search(cells[4])
+        rows.append(
+            IndexRow(
+                line=i,
+                number=m.group(1),
+                title=cells[1],
+                status=_norm_status(cells[2]),
+                link_target=link_m.group(2) if link_m else "",
+            )
+        )
+    return rows, next_free, next_free_line
+
+
+def _rel(path: pathlib.Path, root: pathlib.Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def run(adr_dir: pathlib.Path, repo_root: pathlib.Path) -> list[Finding]:
+    findings: list[Finding] = []
+    index_path = adr_dir / "INDEX.md"
+    index_rel = _rel(index_path, repo_root)
+    if not index_path.is_file():
+        findings.append(Finding(index_rel, 1, "ghost_row", "INDEX.md fehlt"))
+        return findings
+
+    active, archived = build_maps(adr_dir)
+    rows, next_free, next_free_line = parse_index(index_path)
+    indexed = {r.number for r in rows}
+
+    # missing_row: aktive Datei ohne INDEX-Eintrag
+    for num in sorted(active):
+        if num not in indexed:
+            findings.append(
+                Finding(
+                    index_rel,
+                    1,
+                    "missing_row",
+                    f"ADR-{num} ({active[num].name}) hat keinen INDEX-Eintrag",
+                )
+            )
+
+    for row in rows:
+        num = row.number
+        # ghost_row: Eintrag ohne Datei (weder aktiv noch archiviert)
+        if num not in active and num not in archived:
+            findings.append(
+                Finding(
+                    index_rel,
+                    row.line,
+                    "ghost_row",
+                    f"INDEX-Eintrag ADR-{num} ohne Datei (weder aktiv noch archiviert)",
+                )
+            )
+            continue
+
+        # broken_link: Link-Ziel existiert nicht
+        if row.link_target:
+            target = (adr_dir / row.link_target.split("#", 1)[0]).resolve()
+            if not target.is_file():
+                findings.append(
+                    Finding(
+                        index_rel,
+                        row.line,
+                        "broken_link",
+                        f"ADR-{num}: Link-Ziel {row.link_target} existiert nicht",
+                    )
+                )
+
+        # status_drift
+        if row.status == "archived":
+            # INDEX `Archived` matcht Dateien unter _archive/ — egal welcher Frontmatter-Status
+            under_underscore_archive = any(
+                "_archive" in p.parts for p in archived.get(num, [])
+            )
+            if num in active:
+                findings.append(
+                    Finding(
+                        index_rel,
+                        row.line,
+                        "status_drift",
+                        f"ADR-{num}: INDEX sagt Archived, aber aktive Datei existiert "
+                        f"({active[num].name})",
+                    )
+                )
+            elif not under_underscore_archive:
+                findings.append(
+                    Finding(
+                        index_rel,
+                        row.line,
+                        "status_drift",
+                        f"ADR-{num}: INDEX sagt Archived, aber keine Datei unter _archive/",
+                    )
+                )
+            continue
+        # Vergleich gegen Frontmatter der massgeblichen Datei (aktiv bevorzugt)
+        path = active.get(num) or archived.get(num, [None])[0]
+        if path is None:
+            continue
+        fm = frontmatter_status(path)
+        if fm and row.status and fm != row.status:
+            findings.append(
+                Finding(
+                    index_rel,
+                    row.line,
+                    "status_drift",
+                    f"ADR-{num}: INDEX-Status '{row.status}' ≠ Frontmatter-Status '{fm}' "
+                    f"({_rel(path, repo_root)})",
+                )
+            )
+
+    # stale_next_free
+    if active:
+        expected = max(int(n) for n in active) + 1
+        if next_free is None:
+            findings.append(
+                Finding(
+                    index_rel,
+                    1,
+                    "stale_next_free",
+                    f"Kopfzeile 'Next free ADR number' fehlt (Soll: {expected})",
+                )
+            )
+        elif next_free != expected:
+            findings.append(
+                Finding(
+                    index_rel,
+                    next_free_line,
+                    "stale_next_free",
+                    f"'Next free ADR number: {next_free}' ist stale — "
+                    f"Soll: {expected} (max aktive Nummer + 1)",
+                )
+            )
+
+    return findings
+
+
+def emit(findings: list[Finding], fmt: str) -> None:
+    counts: dict[str, int] = {}
+    for f in findings:
+        counts[f.category] = counts.get(f.category, 0) + 1
+        if fmt == "github":
+            print(
+                f"::warning file={f.path},line={f.line},"
+                f"title=adr-index-check {f.category}::{f.message}"
+            )
+        else:
+            print(f"{f.path}:{f.line}: [{f.category}] {f.message}")
+    summary = ", ".join(f"{k}={v}" for k, v in sorted(counts.items())) or "0 Findings"
+    if fmt == "github":
+        print(f"::warning title=adr-index-check summary::{len(findings)} Finding(s): {summary}")
+    print(f"adr-index-check: {len(findings)} Finding(s) ({summary})")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--adr-dir", default="docs/adr", help="ADR-Verzeichnis (Default docs/adr)")
+    ap.add_argument("--format", choices=["human", "github"], default="human")
+    ap.add_argument(
+        "--gate",
+        action="store_true",
+        help="Exit 1 bei Findings (Promotion-Pfad; Default ist SUGGEST = Exit 0)",
+    )
+    args = ap.parse_args(argv)
+
+    adr_dir = pathlib.Path(args.adr_dir)
+    if not adr_dir.is_dir():
+        print(f"adr-index-check: Verzeichnis {adr_dir} nicht gefunden — nichts zu pruefen.")
+        return 0
+    repo_root = adr_dir.resolve().parent.parent
+    findings = run(adr_dir.resolve(), repo_root)
+    emit(findings, args.format)
+    if args.gate and findings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_adr_citation_lint.py
+++ b/tools/tests/test_adr_citation_lint.py
@@ -1,0 +1,160 @@
+"""Tests fuer tools/adr_citation_lint.py — ADR-Body-Zitate-Lint (SUGGEST)."""
+
+import importlib.util
+import pathlib
+import sys
+
+_SPEC = importlib.util.spec_from_file_location(
+    "adr_citation_lint",
+    pathlib.Path(__file__).resolve().parents[1] / "adr_citation_lint.py",
+)
+acl = importlib.util.module_from_spec(_SPEC)
+sys.modules["adr_citation_lint"] = acl  # noetig fuer @dataclass-Aufloesung
+_SPEC.loader.exec_module(acl)
+
+
+def _mk_corpus(tmp_path):
+    """Mini-Korpus: 2 aktive ADRs, 1 archive/, 1 _archive/superseded/."""
+    adr_dir = tmp_path / "docs" / "adr"
+    adr_dir.mkdir(parents=True)
+    (adr_dir / "archive").mkdir()
+    (adr_dir / "_archive" / "superseded").mkdir(parents=True)
+
+    (adr_dir / "ADR-100-foo-service.md").write_text(
+        "---\nstatus: accepted\n---\n\n# ADR-100 Foo\n\nBody.\n", encoding="utf-8"
+    )
+    (adr_dir / "ADR-101-bar-pattern.md").write_text(
+        "---\nstatus: accepted\n---\n\n# ADR-101 Bar\n\nBody.\n", encoding="utf-8"
+    )
+    (adr_dir / "archive" / "ADR-050-old-thing.md").write_text(
+        "---\nstatus: superseded\n---\n\n# ADR-050 Old\n", encoding="utf-8"
+    )
+    (adr_dir / "_archive" / "superseded" / "ADR-040-ancient.md").write_text(
+        "# ADR-040 Ancient\n", encoding="utf-8"
+    )
+    return adr_dir
+
+
+def _lint(tmp_path, body):
+    """Schreibt body in ADR-100 und lintet den Korpus."""
+    adr_dir = _mk_corpus(tmp_path)
+    (adr_dir / "ADR-100-foo-service.md").write_text(body, encoding="utf-8")
+    return acl.run(adr_dir, tmp_path)
+
+
+def test_should_pass_clean_reference_to_active_adr(tmp_path):
+    findings = _lint(tmp_path, "# ADR-100\n\nSiehe ADR-101 und [ADR-101](ADR-101-bar-pattern.md).\n")
+    assert findings == []
+
+
+def test_should_skip_self_reference(tmp_path):
+    findings = _lint(tmp_path, "# ADR-100\n\nDieses ADR-100 referenziert sich selbst.\n")
+    assert findings == []
+
+
+def test_should_flag_dead_ref_with_archive_hint(tmp_path):
+    findings = _lint(tmp_path, "# ADR-100\n\nBasiert auf ADR-050.\n")
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.category == "dead_ref"
+    assert "ADR-050" in f.message
+    assert "archive" in f.message  # Archiv-Pfad als Hinweis
+    assert f.line == 3
+
+
+def test_should_flag_dead_ref_for_nonexistent_number(tmp_path):
+    findings = _lint(tmp_path, "# ADR-100\n\nSiehe ADR-999.\n")
+    assert [f.category for f in findings] == ["dead_ref"]
+    assert "weder aktiv noch archiviert" in findings[0].message
+
+
+def test_should_flag_stale_filename_link_slug(tmp_path):
+    findings = _lint(
+        tmp_path, "# ADR-100\n\nSiehe [ADR-101](ADR-101-wrong-old-slug.md).\n"
+    )
+    assert [f.category for f in findings] == ["stale_filename"]
+    assert "ADR-101-bar-pattern.md" in findings[0].message
+
+
+def test_should_flag_external_target_outside_adr_dir(tmp_path):
+    findings = _lint(
+        tmp_path,
+        "# ADR-100\n\nSiehe [ADR-160](../../mcp-hub/docs/ADR-160-standardized-hub-deployment.md).\n",
+    )
+    assert [f.category for f in findings] == ["external_target"]
+    assert "mcp-hub" in findings[0].message
+
+
+def test_should_not_flag_non_adr_links(tmp_path):
+    findings = _lint(tmp_path, "# ADR-100\n\nSiehe [Readme](../../README.md).\n")
+    assert findings == []
+
+
+def test_should_honor_inline_ignore_marker(tmp_path):
+    body = (
+        "# ADR-100\n\n"
+        "<!-- adr-lint: ignore-next-line -->\n"
+        "Bekannter Alt-Fund: ADR-050.\n"
+        "Aber dieser hier zaehlt: ADR-999.\n"
+    )
+    findings = _lint(tmp_path, body)
+    assert len(findings) == 1
+    assert "ADR-999" in findings[0].message
+
+
+def test_should_honor_ignore_file(tmp_path):
+    adr_dir = _mk_corpus(tmp_path)
+    (adr_dir / "ADR-100-foo-service.md").write_text(
+        "# ADR-100\n\nSiehe ADR-050 und ADR-999.\n", encoding="utf-8"
+    )
+    (adr_dir / ".adr-lint-ignore").write_text(
+        "# geparkte Alt-Funde\nADR-050 in ADR-100\n", encoding="utf-8"
+    )
+    findings = acl.run(adr_dir, tmp_path)
+    assert len(findings) == 1
+    assert "ADR-999" in findings[0].message
+
+
+def test_should_check_link_text_numbers_for_url_targets(tmp_path):
+    findings = _lint(
+        tmp_path,
+        "# ADR-100\n\nSiehe [ADR-999](https://github.com/x/y/blob/main/docs/adr/INDEX.md).\n",
+    )
+    assert [f.category for f in findings] == ["dead_ref"]
+
+
+def test_should_dedupe_same_finding_per_line(tmp_path):
+    findings = _lint(tmp_path, "# ADR-100\n\nADR-999 und nochmal ADR-999.\n")
+    assert len(findings) == 1
+
+
+def test_should_exit_zero_in_suggest_mode_despite_findings(tmp_path, monkeypatch, capsys):
+    adr_dir = _mk_corpus(tmp_path)
+    (adr_dir / "ADR-100-foo-service.md").write_text(
+        "# ADR-100\n\nSiehe ADR-999.\n", encoding="utf-8"
+    )
+    rc = acl.main(["--adr-dir", str(adr_dir)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "dead_ref=1" in out
+
+
+def test_should_exit_one_with_gate_flag_on_findings(tmp_path, capsys):
+    adr_dir = _mk_corpus(tmp_path)
+    (adr_dir / "ADR-100-foo-service.md").write_text(
+        "# ADR-100\n\nSiehe ADR-999.\n", encoding="utf-8"
+    )
+    assert acl.main(["--adr-dir", str(adr_dir), "--gate"]) == 1
+
+
+def test_should_emit_github_annotations(tmp_path, capsys):
+    adr_dir = _mk_corpus(tmp_path)
+    (adr_dir / "ADR-100-foo-service.md").write_text(
+        "# ADR-100\n\nSiehe ADR-999.\n", encoding="utf-8"
+    )
+    rc = acl.main(["--adr-dir", str(adr_dir), "--format", "github"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "::warning file=" in out
+    assert "title=adr-citation-lint dead_ref" in out
+    assert "::warning title=adr-citation-lint summary" in out

--- a/tools/tests/test_adr_index_check.py
+++ b/tools/tests/test_adr_index_check.py
@@ -1,0 +1,143 @@
+"""Tests fuer tools/adr_index_check.py — INDEX.md ↔ Dateibestand-Konsistenz (SUGGEST)."""
+
+import importlib.util
+import pathlib
+import sys
+
+_SPEC = importlib.util.spec_from_file_location(
+    "adr_index_check",
+    pathlib.Path(__file__).resolve().parents[1] / "adr_index_check.py",
+)
+aic = importlib.util.module_from_spec(_SPEC)
+sys.modules["adr_index_check"] = aic  # noetig fuer @dataclass-Aufloesung
+_SPEC.loader.exec_module(aic)
+
+_TABLE_HEADER = "| # | Title | Status | Impl | Link |\n|---|-------|--------|------|------|\n"
+
+
+def _mk_corpus(tmp_path):
+    """Mini-Korpus: 2 aktive ADRs, 1 archive/, 1 _archive/superseded/."""
+    adr_dir = tmp_path / "docs" / "adr"
+    adr_dir.mkdir(parents=True)
+    (adr_dir / "archive").mkdir()
+    (adr_dir / "_archive" / "superseded").mkdir(parents=True)
+
+    (adr_dir / "ADR-100-foo-service.md").write_text(
+        "---\nstatus: accepted\n---\n\n# ADR-100 Foo\n", encoding="utf-8"
+    )
+    (adr_dir / "ADR-101-bar-pattern.md").write_text(
+        "---\nstatus: proposed\n---\n\n# ADR-101 Bar\n", encoding="utf-8"
+    )
+    (adr_dir / "archive" / "ADR-050-old-thing.md").write_text(
+        "---\nstatus: superseded\n---\n\n# ADR-050 Old\n", encoding="utf-8"
+    )
+    (adr_dir / "_archive" / "superseded" / "ADR-040-ancient.md").write_text(
+        "# ADR-040 Ancient (kein Frontmatter)\n", encoding="utf-8"
+    )
+    return adr_dir
+
+
+def _write_index(adr_dir, rows, next_free=102):
+    (adr_dir / "INDEX.md").write_text(
+        f"# Index\n\n> **Next free ADR number:** {next_free}\n\n"
+        + _TABLE_HEADER
+        + "".join(rows),
+        encoding="utf-8",
+    )
+
+
+_ROW_040 = "| 040 | Ancient | `Archived` | — | [ADR-040](_archive/superseded/ADR-040-ancient.md) |\n"
+_ROW_050 = "| 050 | Old Thing | `Superseded` | — | [ADR-050](archive/ADR-050-old-thing.md) |\n"
+_ROW_100 = "| 100 | Foo Service | `Accepted` | ✅ | [ADR-100](ADR-100-foo-service.md) |\n"
+_ROW_101 = "| 101 | Bar Pattern | `Proposed` | ⬜ | [ADR-101](ADR-101-bar-pattern.md) |\n"
+
+
+def test_should_pass_consistent_index(tmp_path):
+    adr_dir = _mk_corpus(tmp_path)
+    _write_index(adr_dir, [_ROW_040, _ROW_050, _ROW_100, _ROW_101], next_free=102)
+    assert aic.run(adr_dir, tmp_path) == []
+
+
+def test_should_flag_missing_row_for_active_file(tmp_path):
+    adr_dir = _mk_corpus(tmp_path)
+    _write_index(adr_dir, [_ROW_040, _ROW_050, _ROW_100], next_free=102)  # 101 fehlt
+    findings = aic.run(adr_dir, tmp_path)
+    assert [f.category for f in findings] == ["missing_row"]
+    assert "ADR-101" in findings[0].message
+
+
+def test_should_flag_ghost_row_without_any_file(tmp_path):
+    adr_dir = _mk_corpus(tmp_path)
+    ghost = "| 666 | Phantom | `Accepted` | ✅ | [ADR-666](ADR-666-phantom.md) |\n"
+    _write_index(adr_dir, [_ROW_040, _ROW_050, _ROW_100, _ROW_101, ghost], next_free=102)
+    findings = aic.run(adr_dir, tmp_path)
+    assert [f.category for f in findings] == ["ghost_row"]
+    assert "ADR-666" in findings[0].message
+
+
+def test_should_flag_status_drift_case_insensitive(tmp_path):
+    adr_dir = _mk_corpus(tmp_path)
+    drifted = "| 101 | Bar Pattern | `Accepted` | ⬜ | [ADR-101](ADR-101-bar-pattern.md) |\n"
+    _write_index(adr_dir, [_ROW_040, _ROW_050, _ROW_100, drifted], next_free=102)
+    findings = aic.run(adr_dir, tmp_path)
+    assert [f.category for f in findings] == ["status_drift"]
+    assert "'accepted'" in findings[0].message and "'proposed'" in findings[0].message
+
+
+def test_should_accept_archived_status_for_underscore_archive_file(tmp_path):
+    # INDEX `Archived` matcht _archive/ — auch ohne Frontmatter-Status (Zeile _ROW_040)
+    adr_dir = _mk_corpus(tmp_path)
+    _write_index(adr_dir, [_ROW_040, _ROW_050, _ROW_100, _ROW_101], next_free=102)
+    assert [f for f in aic.run(adr_dir, tmp_path) if f.category == "status_drift"] == []
+
+
+def test_should_flag_archived_status_when_file_is_active(tmp_path):
+    adr_dir = _mk_corpus(tmp_path)
+    wrong = "| 100 | Foo Service | `Archived` | — | [ADR-100](ADR-100-foo-service.md) |\n"
+    _write_index(adr_dir, [_ROW_040, _ROW_050, wrong, _ROW_101], next_free=102)
+    findings = aic.run(adr_dir, tmp_path)
+    assert [f.category for f in findings] == ["status_drift"]
+    assert "aktive Datei existiert" in findings[0].message
+
+
+def test_should_flag_broken_link_target(tmp_path):
+    adr_dir = _mk_corpus(tmp_path)
+    broken = "| 100 | Foo Service | `Accepted` | ✅ | [ADR-100](ADR-100-renamed-elsewhere.md) |\n"
+    _write_index(adr_dir, [_ROW_040, _ROW_050, broken, _ROW_101], next_free=102)
+    findings = aic.run(adr_dir, tmp_path)
+    assert [f.category for f in findings] == ["broken_link"]
+    assert "ADR-100-renamed-elsewhere.md" in findings[0].message
+
+
+def test_should_flag_stale_next_free_number(tmp_path):
+    adr_dir = _mk_corpus(tmp_path)
+    _write_index(adr_dir, [_ROW_040, _ROW_050, _ROW_100, _ROW_101], next_free=99)
+    findings = aic.run(adr_dir, tmp_path)
+    assert [f.category for f in findings] == ["stale_next_free"]
+    assert "Soll: 102" in findings[0].message
+
+
+def test_should_exit_zero_in_suggest_mode_despite_findings(tmp_path, capsys):
+    adr_dir = _mk_corpus(tmp_path)
+    _write_index(adr_dir, [_ROW_040, _ROW_050, _ROW_100], next_free=99)
+    rc = aic.main(["--adr-dir", str(adr_dir)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "missing_row=1" in out and "stale_next_free=1" in out
+
+
+def test_should_exit_one_with_gate_flag_on_findings(tmp_path, capsys):
+    adr_dir = _mk_corpus(tmp_path)
+    _write_index(adr_dir, [_ROW_040, _ROW_050, _ROW_100], next_free=99)
+    assert aic.main(["--adr-dir", str(adr_dir), "--gate"]) == 1
+
+
+def test_should_emit_github_annotations(tmp_path, capsys):
+    adr_dir = _mk_corpus(tmp_path)
+    _write_index(adr_dir, [_ROW_040, _ROW_050, _ROW_100, _ROW_101], next_free=99)
+    rc = aic.main(["--adr-dir", str(adr_dir), "--format", "github"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "::warning file=" in out
+    assert "title=adr-index-check stale_next_free" in out
+    assert "::warning title=adr-index-check summary" in out


### PR DESCRIPTION
## Was

Zwei neue deterministische, stdlib-only Checks (Python 3.12, kein LLM), als **non-gating SUGGEST-Step** in `adr-validate.yml` verdrahtet — nach dem bestehenden `iil-adrfw staleness`-Step, der nur `depends_on`-Frontmatter abdeckt:

- **`tools/adr_citation_lint.py`** — scannt alle aktiven ADRs (Body + Frontmatter) nach `ADR-NNN`-Referenzen und Markdown-Links:
  - `dead_ref`: Referenz auf Nummer ohne aktive Datei (mit Archiv-Pfad-Hinweis)
  - `stale_filename`: Link-Slug ≠ realer Dateiname der Nummer
  - `external_target`: ADR-Link-Ziel außerhalb `docs/adr/` (z.B. `../../mcp-hub/...`)
  - Whitelist: `<!-- adr-lint: ignore-next-line -->` + optionale `docs/adr/.adr-lint-ignore` (`ADR-054 in ADR-101`)
- **`tools/adr_index_check.py`** — INDEX.md-Tabelle vs. Dateibestand:
  - `missing_row` / `ghost_row` / `status_drift` (case-insensitive; INDEX `Archived` matcht `_archive/`) / `broken_link` / `stale_next_free` (Soll = max(aktive Nummer)+1)

Beide: `--format github` (::warning-Annotations), **Exit-Code immer 0 im SUGGEST-Modus**, `--gate`-Flag für die spätere Promotion.

## Warum

Dominanter Defekt-Typ aus dem ADR-Full-Scan 2026-06-06: tote/falsch betitelte ADR-Querverweise. INDEX.md ist handgepflegt und stale. Disziplin-Regel: neue Regeln starten als SUGGEST, deterministisch-strukturell — Promotion zu gating erst nach Bereinigung der Alt-Funde.

## Messung (origin/main, 186 aktive ADRs — reine Mess-PR, KEINE Alt-Funde gefixt)

| Check | Kategorie | Vorkommen |
|---|---|---|
| citation lint | `dead_ref` | **329** (= 125 distinkte Quelle→Ziel-Paare in 77 Dateien) |
| citation lint | `external_target` | 7 |
| citation lint | `stale_filename` | 6 |
| index check | `missing_row` | **56** (u.a. 092, 101–105, 139–147, 171–184, 200–219, 229/230, 237–240) |
| index check | `status_drift` | 8 |
| index check | `broken_link` | 2 (ADR-155, ADR-160 → `../../mcp-hub/...`) |
| index check | `stale_next_free` | 1 (Kopfzeile sagt 237, Soll 241) |

Hinweis: Der ADR-160/Zeile-160-INDEX-Drift wird in PR #532 separat gefixt — hier nur gemessen, INDEX.md/ADRs unverändert.

## Promotion-Pfad zu gating

1. Alt-Funde bereinigen bzw. bewusst in `docs/adr/.adr-lint-ignore` parken
2. Im CI-Step `--gate` setzen und das `exit 0` entfernen (Kommentar im YAML markiert die Stelle)

## Tests / Qualität

- 25 pytest-Tests (`tools/tests/test_adr_citation_lint.py`, `test_adr_index_check.py`, tmp_path-Mini-Korpus) — laufen automatisch als blockierender Gate via `tools-tests.yml`; volle Suite lokal grün (94 passed)
- ruff (Default-Config, im Repo ist keine konfiguriert): clean
- Trigger-Paths von `docs/adr/ADR-*.md` auf `docs/adr/**` + die beiden Tools erweitert, damit INDEX.md-/Archiv-Änderungen den Check auslösen

🤖 Generated with [Claude Code](https://claude.com/claude-code)