### PR TITLE
fix(adr): ADR-211 C5/I4 cross-repo-ref-check in CI verdrahten

### DIFF
--- a/.github/workflows/adr-validate.yml
+++ b/.github/workflows/adr-validate.yml
@@ -41,3 +41,8 @@ jobs:
             echo "✓ No ADR reference drift."
           fi
           exit 0
+
+      # ADR-211 C5/I4 — Cross-Repo-Ref-Format-Gate (gating).
+      # Qualifizierte Refs müssen ^[a-z][a-z0-9-]+:ADR-[0-9]{3}$ matchen.
+      - name: ADR cross-repo ref format (ADR-211 C5/I4, gating)
+        run: bash scripts/checks/adr_cross_repo_refs.sh docs/adr/


### PR DESCRIPTION
## Summary

- Adds gating step to `adr-validate.yml` that runs `scripts/checks/adr_cross_repo_refs.sh`
- Script existed since PR #234 but was never wired into CI — C5/I4 verification never ran automatically
- Baseline: 186 ADRs, 0 violations

## Test plan

- [ ] CI runs `adr_cross_repo_refs.sh docs/adr/` and exits 0

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)