### PR TITLE
feat(adr): doc_profile_check.sh --detect-profile-change + reusable GHA (ADR-218 OQ-4)

### DIFF
--- a/.github/workflows/doc-profile-guard.yml
+++ b/.github/workflows/doc-profile-guard.yml
@@ -1,0 +1,54 @@
+name: Doc-Profile-Change-Guard
+
+# ADR-218 OQ-4 — Profil-Wechsel-Enforcement.
+# Erkennt profile:-Wert-Änderungen in docs/doc-profile.yaml und erzwingt
+# einen ADR-Link im PR-Body. Override: Label 'adr-exempt-profile-change'.
+#
+# Einbindung im Repo-CI:
+#   jobs:
+#     doc-profile-guard:
+#       uses: achimdehnert/platform/.github/workflows/doc-profile-guard.yml@main
+#       with:
+#         labels: ${{ toJson(github.event.pull_request.labels.*.name) }}
+
+on:
+  workflow_call:
+    inputs:
+      labels:
+        description: "JSON array of PR label names (pass github.event.pull_request.labels.*.name)"
+        type: string
+        default: "[]"
+
+permissions:
+  contents: read
+
+jobs:
+  doc-profile-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout caller repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout platform (check script)
+        uses: actions/checkout@v4
+        with:
+          repository: achimdehnert/platform
+          ref: main
+          path: _platform
+
+      - name: Check for profile-change exemption label
+        id: exempt
+        run: |
+          labels='${{ inputs.labels }}'
+          if echo "$labels" | python3 -c "import sys,json; sys.exit(0 if 'adr-exempt-profile-change' in json.load(sys.stdin) else 1)" 2>/dev/null; then
+            echo "exempt=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "exempt=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Detect profile-value change (ADR-218 OQ-4)
+        env:
+          PROFILE_CHANGE_EXEMPT: ${{ steps.exempt.outputs.exempt }}
+        run: bash _platform/scripts/checks/doc_profile_check.sh --detect-profile-change

--- a/scripts/checks/doc_profile_check.sh
+++ b/scripts/checks/doc_profile_check.sh
@@ -23,21 +23,50 @@ SCHEMA="$REPO_ROOT/docs/conventions/doc-profile-schema.yaml"
 STRICT=0
 USE_REMOTE_MAIN=0
 SINGLE_REPO=""
+DETECT_CHANGE=0
 for arg in "$@"; do
   case "$arg" in
-    --strict) STRICT=1 ;;
-    --main)   USE_REMOTE_MAIN=1 ;;
-    --repo=*) SINGLE_REPO="${arg#--repo=}" ;;
+    --strict)               STRICT=1 ;;
+    --main)                 USE_REMOTE_MAIN=1 ;;
+    --repo=*)               SINGLE_REPO="${arg#--repo=}" ;;
+    --detect-profile-change) DETECT_CHANGE=1 ;;
     -h|--help)
       cat <<EOF
-Usage: $0 [--strict] [--main] [--repo=<name>]
-  --strict   Repos ohne doc-profile.yaml als FAIL (Default: WARN).
-  --main     Quelle origin/main statt Working-Tree (CI-Sicht).
-  --repo=X   Nur Repo X prüfen statt alle aus registry/repos.yaml.
+Usage: $0 [--strict] [--main] [--repo=<name>] [--detect-profile-change]
+  --strict                Repos ohne doc-profile.yaml als FAIL (Default: WARN).
+  --main                  Quelle origin/main statt Working-Tree (CI-Sicht).
+  --repo=X                Nur Repo X prüfen statt alle aus registry/repos.yaml.
+  --detect-profile-change Prüft git diff origin/main..HEAD -- docs/doc-profile.yaml
+                          auf Profil-Wert-Wechsel (ADR-218 OQ-4). FAIL wenn geändert,
+                          es sei denn PROFILE_CHANGE_EXEMPT=1 ist gesetzt.
 EOF
       exit 0 ;;
   esac
 done
+
+# --- --detect-profile-change: ADR-218 OQ-4 Profil-Wechsel-Gate -------------------
+if [[ $DETECT_CHANGE -eq 1 ]]; then
+  if [[ "${PROFILE_CHANGE_EXEMPT:-0}" == "1" ]]; then
+    echo "✓ PROFILE_CHANGE_EXEMPT=1 — ADR-Pflicht-Gate übersprungen (Label adr-exempt-profile-change)."
+    exit 0
+  fi
+  diff_out=$(git diff "origin/main...HEAD" -- "docs/doc-profile.yaml" 2>/dev/null || true)
+  if [[ -z "$diff_out" ]]; then
+    echo "✓ docs/doc-profile.yaml unverändert — kein Profil-Wechsel."
+    exit 0
+  fi
+  old_val=$(printf '%s\n' "$diff_out" | grep '^-profile:' | sed 's/^-profile:[[:space:]]*//' | tr -d '"'"'" | head -1)
+  new_val=$(printf '%s\n' "$diff_out" | grep '^+profile:' | sed 's/^+profile:[[:space:]]*//' | tr -d '"'"'" | head -1)
+  if [[ -z "$old_val" && -z "$new_val" ]]; then
+    echo "✓ docs/doc-profile.yaml geändert, aber kein profile:-Wert-Wechsel — OK."
+    exit 0
+  fi
+  echo "FAIL: Profil-Wechsel erkannt: '${old_val:-?}' → '${new_val:-?}'"
+  echo "ADR-Pflicht (ADR-218 §Confirmation Schritt 4): Profil-Wechsel erfordert ADR."
+  echo "Bitte ADR-NNN-Link im PR-Body verlinken."
+  echo "Tippfehler-Korrektur? Label 'adr-exempt-profile-change' am PR setzen."
+  exit 1
+fi
 
 [[ -f "$REGISTRY" ]] || { echo "FATAL: $REGISTRY fehlt"; exit 2; }
 [[ -f "$SCHEMA" ]]   || { echo "FATAL: $SCHEMA fehlt"; exit 2; }


### PR DESCRIPTION
## Summary

- Adds `--detect-profile-change` mode to `scripts/checks/doc_profile_check.sh`
- Detects `profile:` value changes via `git diff origin/main...HEAD -- docs/doc-profile.yaml`
- FAIL with ADR-Pflicht message; override via env `PROFILE_CHANGE_EXEMPT=1`
- New reusable workflow `doc-profile-guard.yml` (pattern: `deploy-config-lint.yml`): checks PR label `adr-exempt-profile-change`, sets exempt env var, runs the script

## Test plan

- [ ] `bash scripts/checks/doc_profile_check.sh --detect-profile-change` exits 0 on clean diff
- [ ] `PROFILE_CHANGE_EXEMPT=1 bash scripts/checks/doc_profile_check.sh --detect-profile-change` exits 0 with exempt message
- [ ] Workflow callable with `uses: achimdehnert/platform/.github/workflows/doc-profile-guard.yml@main`

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)