### PR TITLE
feat(ci): Aggregat-Job 'gate' in _ci-python.yml — required-check-Basis für ADR-242-Rollout

### DIFF
--- a/.github/workflows/_ci-python.yml
+++ b/.github/workflows/_ci-python.yml
@@ -499,3 +499,22 @@ jobs:
               print('platform_context.checks not available -- skipping guardian check')
               sys.exit(0)
           GUARDIAN_EOF
+
+  gate:
+    name: "gate"
+    runs-on: ${{ inputs.runs_on }}
+    needs: [qm-gate, lint, secrets-scan, security, test-unit, test-integration, coverage-report, test-contract, architecture-guardian]
+    if: always()
+    steps:
+      - name: "All CI jobs passed or skipped"
+        run: |
+          STATUS_LIST='${{ toJSON(needs) }}'
+          echo "$STATUS_LIST" | python3 -c "
+          import json, sys
+          needs = json.load(sys.stdin)
+          failures = [name for name, job in needs.items() if job['result'] not in ('success', 'skipped')]
+          if failures:
+              print('::error::Failed or cancelled jobs:', failures)
+              sys.exit(1)
+          print('All jobs passed or were skipped.')
+          "


### PR DESCRIPTION
## Summary

- Fügt stabilen `ci / gate` Check-Namen hinzu (aggregiert alle CI-Jobs via `needs:` über alle 9 Jobs)
- Erzwingt bei Erfolg aller Jobs grünen Status; bei einem fehlgeschlagenen Job roten Status
- Basis für branch-protection required-status-checks (ADR-242)
- `if: always()` + python-Check-Logik: `success`+`skipped`=grün, `failure`/`cancelled`=rot

## Details

Der neue `gate`-Job läuft nach allen anderen Jobs (`qm-gate`, `lint`, `secrets-scan`, `security`, `test-unit`, `test-integration`, `coverage-report`, `test-contract`, `architecture-guardian`). Da viele dieser Jobs bedingte `if:`-Conditions haben (z. B. `skip_tests`, `run_contract_tests`, `enable_qm_gate`), können sie geskippt werden — `skipped` wird in der gate-Logik als grün gewertet.

Der Check-Name in GitHub-PRs lautet `ci / gate` (reusable workflow `ci` + job name `gate`), was direkt als required status check in branch-protection konfiguriert werden kann (ADR-242).

## Test plan

- [ ] PR in einem Consumer-Repo (z. B. dev-hub) öffnen und prüfen, dass `ci / gate` als Check erscheint
- [ ] Alle Jobs grün → `ci / gate` grün
- [ ] Einen Job zum Scheitern bringen → `ci / gate` rot mit Fehlerausgabe

🤖 Generated with [Claude Code](https://claude.com/claude-code)