### PR TITLE
feat(governance): ADR-242 — Ruleset-Template, Wave-1-Liste und Rollout-Script

### DIFF
--- a/governance/rulesets/main-required-checks-template.json
+++ b/governance/rulesets/main-required-checks-template.json
@@ -1,0 +1,27 @@
+{
+  "_comment": "ADR-242: Branch-Protection Template. Wird per apply-branch-protection.sh auf Repos angewendet.",
+  "name": "main-required-checks",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "required_status_checks": [
+          {
+            "context": "__REQUIRED_CHECK__",
+            "integration_id": null
+          }
+        ],
+        "strict_required_status_checks_policy": false
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/governance/rulesets/wave1-repos.json
+++ b/governance/rulesets/wave1-repos.json
@@ -1,0 +1,51 @@
+[
+  {
+    "repo": "platform",
+    "owner": "achimdehnert",
+    "required_check": "guardian",
+    "wave": 1,
+    "reason": "already-protected-baseline"
+  },
+  {
+    "repo": "risk-hub",
+    "owner": "achimdehnert",
+    "required_check": "deploy-config-lint",
+    "wave": 1,
+    "reason": "live-customer-product"
+  },
+  {
+    "repo": "mcp-hub",
+    "owner": "achimdehnert",
+    "required_check": "ci / gate",
+    "wave": 1,
+    "reason": "mcp-infrastruktur"
+  },
+  {
+    "repo": "billing-hub",
+    "owner": "achimdehnert",
+    "required_check": "ci / gate",
+    "wave": 1,
+    "reason": "auto-prod-deploy"
+  },
+  {
+    "repo": "cad-hub",
+    "owner": "achimdehnert",
+    "required_check": "ci / gate",
+    "wave": 1,
+    "reason": "auto-prod-deploy"
+  },
+  {
+    "repo": "coach-hub",
+    "owner": "achimdehnert",
+    "required_check": "ci / gate",
+    "wave": 1,
+    "reason": "auto-prod-deploy"
+  },
+  {
+    "repo": "dev-hub",
+    "owner": "achimdehnert",
+    "required_check": "ci / gate",
+    "wave": 1,
+    "reason": "auto-prod-deploy"
+  }
+]

--- a/tools/apply-branch-protection.sh
+++ b/tools/apply-branch-protection.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# ADR-242: Idempotentes Script zum Anlegen/Aktualisieren von GitHub Rulesets
+# für Branch-Protection auf Wave-1-Repos.
+#
+# Usage:
+#   ./tools/apply-branch-protection.sh               # alle Wave-1-Repos
+#   ./tools/apply-branch-protection.sh --repo dev-hub # nur ein Repo
+#
+# Requirements: gh (GitHub CLI), jq, GH_TOKEN im ENV oder gh auth login
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE_FILE="$REPO_ROOT/governance/rulesets/main-required-checks-template.json"
+WAVE1_FILE="$REPO_ROOT/governance/rulesets/wave1-repos.json"
+
+# ---------------------------------------------------------------------------
+# Dependencies check
+# ---------------------------------------------------------------------------
+for cmd in gh jq; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "❌ Abhängigkeit fehlt: $cmd" >&2
+    exit 1
+  fi
+done
+
+if [ ! -f "$TEMPLATE_FILE" ]; then
+  echo "❌ Template nicht gefunden: $TEMPLATE_FILE" >&2
+  exit 1
+fi
+
+if [ ! -f "$WAVE1_FILE" ]; then
+  echo "❌ Wave-1-Liste nicht gefunden: $WAVE1_FILE" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# GH_TOKEN Fallback
+# ---------------------------------------------------------------------------
+if [ -z "${GH_TOKEN:-}" ]; then
+  GH_TOKEN="$(gh auth token 2>/dev/null || true)"
+  if [ -z "$GH_TOKEN" ]; then
+    echo "❌ GH_TOKEN nicht gesetzt und 'gh auth token' lieferte kein Token." >&2
+    echo "   Bitte 'gh auth login' ausführen oder GH_TOKEN setzen." >&2
+    exit 1
+  fi
+  export GH_TOKEN
+fi
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+FILTER_REPO=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      FILTER_REPO="$2"
+      shift 2
+      ;;
+    *)
+      echo "❌ Unbekanntes Argument: $1" >&2
+      echo "   Usage: $0 [--repo <repo-name>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Repo-Liste aus wave1-repos.json laden (optional nach --repo filtern)
+# ---------------------------------------------------------------------------
+REPOS_JSON="$WAVE1_FILE"
+if [ -n "$FILTER_REPO" ]; then
+  ENTRIES=$(jq --arg r "$FILTER_REPO" '[.[] | select(.repo == $r)]' "$REPOS_JSON")
+  COUNT=$(echo "$ENTRIES" | jq 'length')
+  if [ "$COUNT" -eq 0 ]; then
+    echo "❌ Repo '$FILTER_REPO' nicht in wave1-repos.json gefunden." >&2
+    exit 1
+  fi
+else
+  ENTRIES=$(jq '.' "$REPOS_JSON")
+fi
+
+TOTAL=$(echo "$ENTRIES" | jq 'length')
+SUCCESS=0
+FAIL=0
+
+# ---------------------------------------------------------------------------
+# Hilfsfunktion: Ruleset anlegen oder aktualisieren
+# ---------------------------------------------------------------------------
+apply_ruleset() {
+  local owner="$1"
+  local repo="$2"
+  local required_check="$3"
+
+  # Template befüllen: __REQUIRED_CHECK__ ersetzen
+  local ruleset_json
+  ruleset_json=$(jq --arg check "$required_check" \
+    '(.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[0].context) = $check' \
+    "$TEMPLATE_FILE")
+
+  # Prüfen ob Ruleset bereits existiert
+  local existing_id
+  existing_id=$(gh api "repos/$owner/$repo/rulesets" \
+    --jq '.[] | select(.name == "main-required-checks") | .id' 2>/dev/null || true)
+
+  if [ -n "$existing_id" ]; then
+    # Update via PATCH
+    echo "$ruleset_json" | gh api "repos/$owner/$repo/rulesets/$existing_id" \
+      -X PATCH --input - > /dev/null
+    echo "✅ $repo: Ruleset aktualisiert (ID $existing_id, check: $required_check)"
+  else
+    # Anlegen via POST
+    local new_id
+    new_id=$(echo "$ruleset_json" | gh api "repos/$owner/$repo/rulesets" \
+      -X POST --input - --jq '.id' 2>/dev/null)
+    echo "✅ $repo: Ruleset angelegt (ID $new_id, check: $required_check)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Hauptschleife
+# ---------------------------------------------------------------------------
+echo "ADR-242 Branch-Protection Rollout — Wave 1 ($TOTAL Repos)"
+echo "============================================================"
+
+for i in $(seq 0 $((TOTAL - 1))); do
+  entry=$(echo "$ENTRIES" | jq ".[$i]")
+  repo=$(echo "$entry"    | jq -r '.repo')
+  owner=$(echo "$entry"   | jq -r '.owner')
+  check=$(echo "$entry"   | jq -r '.required_check')
+
+  if apply_ruleset "$owner" "$repo" "$check"; then
+    SUCCESS=$((SUCCESS + 1))
+  else
+    echo "❌ $repo: Fehler beim Anlegen/Aktualisieren des Rulesets"
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+echo "============================================================"
+echo "$SUCCESS/$TOTAL Repos erfolgreich geschützt"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Neues Verzeichnis `governance/rulesets/` als SSoT für Branch-Protection-Konfiguration (ADR-242)
- Template `governance/rulesets/main-required-checks-template.json` — GitHub Rulesets API-kompatibel, `__REQUIRED_CHECK__` als Platzhalter für repo-spezifischen Check-Namen
- Wave-1-Liste `governance/rulesets/wave1-repos.json` — 7 Repos (auto-prod-deploy + mcp-hub + platform) mit owner, required_check und reason
- Idempotentes Script `tools/apply-branch-protection.sh` — legt Ruleset an oder aktualisiert (PATCH), 0 Fehler bei Wiederholung, `--repo <name>` für Einzelanwendung

## Context

Phase 3 des ADR-242-Rollouts (G1–G3 abgeräumt, ADR accepted). Wave-1-Repos decken alle Repos mit `on: push: [main]` deploy ohne Path-Filter (production target) sowie `mcp-hub` (Infrastruktur) und `platform` (Governance-Baseline).

Check-Namen aus echten CI-Workflows:
- `platform` → `guardian` (bestehende Protection)
- `risk-hub` → `deploy-config-lint` (Live-Kundenprodukt)
- Alle anderen → `ci / gate` (shared-CI-Pattern)

## Test plan

- [ ] `bash -n tools/apply-branch-protection.sh` — Syntax-Check grün
- [ ] `jq . governance/rulesets/wave1-repos.json` — valides JSON
- [ ] `jq . governance/rulesets/main-required-checks-template.json` — valides JSON
- [ ] Testlauf auf einem Dev-Repo mit `GH_TOKEN` gesetzt: `./tools/apply-branch-protection.sh --repo platform`
- [ ] Zweiter Lauf (Idempotenz): kein Fehler, PATCH statt POST

🤖 Generated with [Claude Code](https://claude.com/claude-code)