### PR TITLE
fix(governance): ADR-242 Wave-1 required-check-Namen (mcp-hub, risk-hub)

### DIFF
--- a/governance/rulesets/wave1-repos.json
+++ b/governance/rulesets/wave1-repos.json
@@ -9,14 +9,14 @@
   {
     "repo": "risk-hub",
     "owner": "achimdehnert",
-    "required_check": "deploy-config-lint",
+    "required_check": "Deploy-Config-Lint / deploy-config-lint",
     "wave": 1,
     "reason": "live-customer-product"
   },
   {
     "repo": "mcp-hub",
     "owner": "achimdehnert",
-    "required_check": "ci / gate",
+    "required_check": "🚦 Quality Gate",
     "wave": 1,
     "reason": "mcp-infrastruktur"
   },


### PR DESCRIPTION
## Was
Korrigiert die `required_check`-Namen für **mcp-hub** und **risk-hub** in `governance/rulesets/wave1-repos.json`.

## Warum (Triage 5c, verifiziert via check-runs API)
Beide hatten Namen, die nicht den real emittierten Check-runs entsprechen → ein Branch-Protection-Apply hätte dort **alle Merges blockiert** (required Check bleibt ewig „pending").

| Repo | vorher | nachher | Beleg |
|---|---|---|---|
| mcp-hub | `ci / gate` | `🚦 Quality Gate` | nutzt keinen `_ci-python`-Caller; Aggregat in `mcp-quality.yml` (`needs:[static-analysis,mcp-checks,tests]`, jeder PR) |
| risk-hub | `deploy-config-lint` | `Deploy-Config-Lint / deploy-config-lint` | realer check-run-Name (Workflow / Job), success auf #168 |

## Unverändert (verifiziert korrekt)
- **platform** `guardian` — `guardian.yml` feuert auf jedem PR (`types:[opened,synchronize,reopened]`, kein Path-Filter), skippt nur Bot-PRs (skip=pass).
- **dev-hub/billing-hub/cad-hub/coach-hub** `ci / gate` — kommt aus `_ci-python` `@v1.0.4` (shared-ci#7) bzw. `platform@main` (coach-hub).

## Hinweise (nicht-blockierend)
- mcp-hub `🚦 Quality Gate` hat kein `if: always()` → fails-as-skip (Härtungs-Kandidat).
- coach-hub ist durch #28 (privater Dep) ohnehin rot, unabhängig vom gate-Check.

Teil der ADR-242-Phase-3-Strecke (shared-ci#7 → v1.0.4 → Re-points → Live-Apply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)