### PR TITLE
fix(drift-check): HEALTHCHECK-Regel auf ADR-078 nachgezogen (#549)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- `scripts/drift_check.py`: stale HEALTHCHECK-Regel auf **ADR-078** nachgezogen
+  (#549). Die alte Regel forderte `HEALTHCHECK` **im** Dockerfile (ADR-021 §2.3)
+  und widersprach damit der accepted ADR-078 *(„Healthcheck pro-Service in
+  docker-compose.prod.yml, nicht im image-globalen Dockerfile")* sowie dem REFLEX
+  `compose.healthcheck_in_dockerfile`. Regel entfernt und als `BANNED_PATTERN`
+  invertiert (HEALTHCHECK im Dockerfile = error). ADR-078-konforme Repos (z.B.
+  dev-hub) werden nicht mehr fälschlich rot geflaggt. Kein ADR (reiner
+  Tooling-Bugfix gegen accepted ADR).
+
+---
+
 ## [2026.05.18] — 2026-05-18
 
 ### Added

--- a/scripts/drift_check.py
+++ b/scripts/drift_check.py
@@ -60,8 +60,6 @@ REQUIRED_FILE_CONTENT_CHECKS = [
      "CI nutzt nicht platform/_ci-python.yml (reusable workflow)"),
     ("Dockerfile",                        r"python:3\.12",     "warn",
      "Dockerfile nutzt nicht Python 3.12"),
-    ("Dockerfile",                        r"HEALTHCHECK",      "error",
-     "Dockerfile ohne HEALTHCHECK (ADR-056)"),
     ("docker-compose.prod.yml",           r"env_file",         "error",
      "docker-compose.prod.yml ohne env_file (ADR-022 violation)"),
     ("docker-compose.prod.yml",           r"unless-stopped",   "warn",
@@ -81,6 +79,9 @@ BANNED_PATTERNS = [
      "docker-compose environment: mit ${VAR} (ADR-022 — env_file nutzen)"),
     (r"sqlite",                           "warn",
      "SQLite-Referenz gefunden — PostgreSQL ist Pflicht (ADR-009)"),
+    (r"^HEALTHCHECK\b",                   "error",
+     "HEALTHCHECK im Dockerfile (ADR-078 — Healthcheck gehört pro-Service in "
+     "docker-compose.prod.yml, nicht ins image-globale Dockerfile)"),
 ]
 
 ACTIONS_VERSION_MAP = {

--- a/tests/test_drift_check.py
+++ b/tests/test_drift_check.py
@@ -1,0 +1,65 @@
+"""Unit tests for scripts/drift_check.py HEALTHCHECK rule (ADR-078).
+
+ADR-078 (amends ADR-021 §2.3) reversed the old "HEALTHCHECK required in
+Dockerfile" convention: the healthcheck belongs per-service in
+docker-compose.prod.yml, never in the image-global Dockerfile. drift_check.py
+still enforced the *old* rule and thus contradicted accepted ADR-078 and the
+REFLEX plugin compose.healthcheck_in_dockerfile (issue #549). These tests pin
+the corrected behaviour. Pure (no GitHub API / token needed).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "drift_check.py"
+_spec = importlib.util.spec_from_file_location("drift_check", _SCRIPT)
+dc = importlib.util.module_from_spec(_spec)
+sys.modules["drift_check"] = dc  # let @dataclass resolve forward refs
+_spec.loader.exec_module(dc)
+
+
+def test_should_not_require_healthcheck_in_dockerfile():
+    """The stale ADR-021 rule (HEALTHCHECK *required* in Dockerfile) is gone."""
+    for filepath, pattern, _severity, _msg in dc.REQUIRED_FILE_CONTENT_CHECKS:
+        assert not (filepath == "Dockerfile" and "HEALTHCHECK" in pattern), (
+            "drift_check still requires HEALTHCHECK in the Dockerfile — "
+            "contradicts accepted ADR-078"
+        )
+
+
+def _healthcheck_banned_rule():
+    for pattern, severity, msg in dc.BANNED_PATTERNS:
+        if "HEALTHCHECK" in pattern:
+            return pattern, severity, msg
+    return None
+
+
+def test_should_ban_healthcheck_in_dockerfile():
+    """An inverted rule now flags HEALTHCHECK *in* the Dockerfile as an error."""
+    rule = _healthcheck_banned_rule()
+    assert rule is not None, "expected a banned-pattern rule for HEALTHCHECK"
+    pattern, severity, msg = rule
+    assert severity == "error"
+    assert "ADR-078" in msg
+    dockerfile = (
+        "FROM python:3.12-slim\n"
+        "HEALTHCHECK CMD curl -f http://localhost:8000/livez/ || exit 1\n"
+    )
+    assert re.search(pattern, dockerfile, re.MULTILINE)
+
+
+def test_should_not_flag_compose_healthcheck_key():
+    """The compose per-service `healthcheck:` key must NOT trip the rule."""
+    pattern, _severity, _msg = _healthcheck_banned_rule()
+    compose = (
+        "services:\n"
+        "  web:\n"
+        "    image: app:latest\n"
+        "    healthcheck:\n"
+        "      test: [\"CMD\", \"curl\", \"-f\", \"http://localhost:8000/livez/\"]\n"
+    )
+    assert not re.search(pattern, compose, re.MULTILINE)


### PR DESCRIPTION
## Problem
`scripts/drift_check.py` (Z.63-64) erzwang die **alte** ADR-021-§2.3-Konvention
(`HEALTHCHECK` **required im Dockerfile**). Diese wurde von **ADR-078 (accepted,
2026-02-24, amends ADR-021)** reversiert: Healthcheck gehört **pro-Service in
`docker-compose.prod.yml`**, nicht ins image-globale Dockerfile (Grund:
coach-hub Restart-Loop — `worker`/`beat` ohne HTTP-Server werden `unhealthy`).

Folge: jedes ADR-078-konforme Repo (z.B. dev-hub nach PR #82) wurde von
`drift_check --severity=error` fälschlich rot (Exit 1) geflaggt, obwohl REFLEX
(`compose.healthcheck_in_dockerfile`) korrekt grün war. drift_check ↔ REFLEX
divergierten — drift_check war falsch.

## Fix
- **`REQUIRED_FILE_CONTENT_CHECKS`**: stale Regel „Dockerfile ohne HEALTHCHECK" entfernt.
- **`BANNED_PATTERNS`**: invertiert — `^HEALTHCHECK` im Dockerfile = `error` (ADR-078),
  spiegelt REFLEX. Matcht **nicht** den compose `healthcheck:`-Key (lowercase/indented).
- **`tests/test_drift_check.py`**: 3 reine Unit-Tests (kein GitHub-API/Token):
  Regel weg · Dockerfile-HEALTHCHECK wird geflaggt · compose-Key wird **nicht** geflaggt.

## Akzeptanzkriterium (aus Issue)
ADR-078-konformes Repo → `drift_check --severity=error` kein Dockerfile-HEALTHCHECK-Error.
drift_check + REFLEX flaggen denselben Verstoß (HEALTHCHECK im Dockerfile) konsistent. ✅

Reiner Tooling-Bugfix gegen accepted ADR-078 → **kein ADR-Threshold** (PR + CHANGELOG genügen).

Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)