### PR TITLE
feat(registry): Org-Mapping + App-Anzeigenamen in canonical-Meta

### DIFF
--- a/registry/canonical.yaml
+++ b/registry/canonical.yaml
@@ -22,6 +22,27 @@ meta:
     iil-fieldprefill: iilgmbh
     iil-relaunch: iilgmbh
     illustration-fw: iilgmbh
+    iil-klickdummy: iilgmbh
+    iil-testkit: iilgmbh
+  owner_prefix_rules:
+  - prefix: meiki-
+    owner: meiki-lra
+  - prefix: ttz-
+    owner: ttz-lif
+  - prefix: sqf-
+    owner: bahn-sqf
+  - prefix: pg-
+    owner: bahn-sqf
+  - prefix: bahn-
+    owner: bahn-sqf
+  app_display_names:
+    meiki-hub: MEiKI · LRA-Plattform
+    ausschreibungs-hub: Bieterpilot
+    writing-hub: Writing-Hub
+    risk-hub: Risk-Hub
+    ttz-hub: TTZ-Hub
+    sqf-hub: SQF-Hub
+    pg-hub: PG-Hub
   _note: GENERATED-CANDIDATE (ADR-234 P0). Union aus scripts/repo-registry.yaml + registry/repos.yaml.
     Noch NICHT kanonisch geschaltet — Konsumenten unverändert.
 repos:

--- a/tools/registry-canonical.py
+++ b/tools/registry-canonical.py
@@ -88,6 +88,33 @@ def build() -> dict:
                 "iil-fieldprefill": "iilgmbh",
                 "iil-relaunch": "iilgmbh",
                 "illustration-fw": "iilgmbh",
+                # Org-Mapping-Externalisierung (Konsument: iil-klickdummy detect_org,
+                # 2026-06-12) — Werte identisch zu dessen bisheriger Code-Heuristik.
+                "iil-klickdummy": "iilgmbh",
+                "iil-testkit": "iilgmbh",
+            },
+            # Geordnete Präfix-Heuristik für Repos OHNE repo_owner-Eintrag. Konsument:
+            # iil-klickdummy genesor (detect_org) — ersetzt dessen hartkodierte Heuristik.
+            # Gleicher Stopgap-Status wie repo_owner (REC-11: gehört langfristig als
+            # owner_team-Feld ins Datenmodell). Default für Nicht-Treffer: server.github_org.
+            "owner_prefix_rules": [
+                {"prefix": "meiki-", "owner": "meiki-lra"},
+                {"prefix": "ttz-", "owner": "ttz-lif"},
+                {"prefix": "sqf-", "owner": "bahn-sqf"},
+                {"prefix": "pg-", "owner": "bahn-sqf"},
+                {"prefix": "bahn-", "owner": "bahn-sqf"},
+            ],
+            # App-Anzeigenamen (Konsument: iil-klickdummy genesor render_fallback) —
+            # externalisiert aus dessen app_name_map (2026-06-12). Fallback dort:
+            # Titel-Heuristik aus dem Repo-Namen.
+            "app_display_names": {
+                "meiki-hub": "MEiKI · LRA-Plattform",
+                "ausschreibungs-hub": "Bieterpilot",
+                "writing-hub": "Writing-Hub",
+                "risk-hub": "Risk-Hub",
+                "ttz-hub": "TTZ-Hub",
+                "sqf-hub": "SQF-Hub",
+                "pg-hub": "PG-Hub",
             },
             "_note": "GENERATED-CANDIDATE (ADR-234 P0). Union aus scripts/repo-registry.yaml + "
                      "registry/repos.yaml. Noch NICHT kanonisch geschaltet — Konsumenten unverändert.",


### PR DESCRIPTION
## Was

Externalisierung der in `iil-klickdummy` hartkodierten Org-Zuordnung (KONZ-003-Beifang, Codebase-Analyse 2026-06) in die Registry-SSoT — **nicht** als separate `orgs.yaml` (wäre eine konkurrierende Quelle zu ADR-234), sondern im dokumentierten Stopgap-Muster als Generator-Literal in `tools/registry-canonical.py` (gleicher Ort/Status wie `repo_owner`, REC-11):

- `owner_prefix_rules` — geordnete Präfix-Heuristik (`meiki-`→meiki-lra, `ttz-`→ttz-lif, `sqf-`/`pg-`/`bahn-`→bahn-sqf); Default für Nicht-Treffer: `server.github_org`
- `repo_owner` += `iil-klickdummy`, `iil-testkit` (→ iilgmbh)
- `app_display_names` — die 7 genesor-Anzeigenamen aus `app_name_map`

Alle Werte **identisch** zur bisherigen Code-Heuristik — kein Verhaltens-Delta beim Konsumenten.

## Verifikation

- `registry-canonical.py build` regeneriert, `verify` grün (flat- und rich-View semantisch identisch)
- CI-Drift-Gate (`registry-consistency.yml`) unverändert anwendbar

## Folge-PR

`iil-klickdummy`: `detect_org`/`app_name_map` lesen `platform/registry/canonical.yaml` (unter `--repos-root`), Code-Heuristik bleibt Fallback für Installationen ohne platform-Checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)