### PR TITLE
fix(governance): ADR-242 Ruleset-Template — integration_id:null entfernen (API 422)

### DIFF
--- a/governance/rulesets/main-required-checks-template.json
+++ b/governance/rulesets/main-required-checks-template.json
@@ -15,8 +15,7 @@
       "parameters": {
         "required_status_checks": [
           {
-            "context": "__REQUIRED_CHECK__",
-            "integration_id": null
+            "context": "__REQUIRED_CHECK__"
           }
         ],
         "strict_required_status_checks_policy": false


### PR DESCRIPTION
## Problem

Das Ruleset-Template aus #541 war nie live gegen die Rulesets-API getestet: `"integration_id": null` führt zu **HTTP 422** (`Invalid property /rules/0: data matches no possible input`) — die API erwartet einen Integer oder das Fehlen des Felds.

## Fix

Feld entfernt. Verifiziert durch erfolgreichen Live-Apply (Phase-3-Pilot, 2026-06-12):

| Repo | Ruleset-ID | required check |
|---|---|---|
| platform | 17621471 | `guardian` |
| risk-hub | 17621472 | `Deploy-Config-Lint / deploy-config-lint` |
| mcp-hub | 17621473 | `🚦 Quality Gate` |

Alle 3: `enforcement=active`, Target `refs/heads/main`, Bypass-Liste leer (ADR-242 Option B).

## Kontext Phase 3

billing-hub/cad-hub/dev-hub deferred: pinnen `shared-ci@v1.0.2`/`@v1.0.1` ohne `gate`-Job (erst in v1.0.4) — Ruleset jetzt würde Merges deadlocken. coach-hub deferred: main-CI rot (Deploy-failures seit 2026-05-31). Hinweis: #548-Behauptung „billing/cad via @v1.0.4" war falsch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)