### PR TITLE
feat(governance): ADR-242 Phase 4 — branch-protection-meter + deferred-Semantik

### DIFF
--- a/.github/workflows/apply-branch-protection.yml
+++ b/.github/workflows/apply-branch-protection.yml
@@ -112,16 +112,23 @@ jobs:
               echo "❌ Repo '$TARGET_REPO' nicht in wave1-repos.json"
               exit 1
             fi
+            deferred=$(echo "$entry" | jq -r '.deferred // empty')
+            if [ -n "$deferred" ]; then
+              echo "❌ Repo '$TARGET_REPO' ist deferred: $deferred"
+              echo "   Zum Anwenden 'deferred'-Feld in wave1-repos.json entfernen (Rollout-Gate prüfen!)."
+              exit 1
+            fi
             owner=$(echo "$entry" | jq -r '.owner')
             check=$(echo "$entry" | jq -r '.required_check')
             run_one "$owner" "$TARGET_REPO" "$check"
           else
+            jq -r '.[] | select(.deferred != null) | "⏸ \(.repo) übersprungen (deferred): \(.deferred)"' "$WAVE1"
             while IFS= read -r entry; do
               repo=$(echo "$entry"  | jq -r '.repo')
               owner=$(echo "$entry" | jq -r '.owner')
               check=$(echo "$entry" | jq -r '.required_check')
               run_one "$owner" "$repo" "$check"
-            done < <(jq -c '.[]' "$WAVE1")
+            done < <(jq -c '.[] | select(.deferred == null)' "$WAVE1")
           fi
 
           echo ""

--- a/.github/workflows/branch-protection-meter.yml
+++ b/.github/workflows/branch-protection-meter.yml
@@ -1,0 +1,80 @@
+name: "ADR-242: Branch-Protection Meter"
+
+# Enforcement der Enforcement (ADR-242 §Rollout 5 / §Confirmation 1):
+# wöchentlich prüfen, ob jedes Soll-Repo ein aktives Ruleset mit dem
+# erwarteten required check trägt. Verletzung/disabled (Break-Glass offen)
+# → Issue (Label protection-violation) + Discord.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # montags 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  meter:
+    name: "Soll/Ist-Abgleich Rulesets (Wave 1)"
+    runs-on: self-hosted
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Meter ausführen"
+        id: meter
+        continue-on-error: true
+        env:
+          # PROJECT_PAT = cross-repo PAT (GITHUB_TOKEN liest fremde Repo-Rulesets nicht)
+          TOKEN: ${{ secrets.PROJECT_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          python3 tools/branch_protection_meter.py \
+            --expected governance/rulesets/wave1-repos.json \
+            --report /tmp/meter-report.md
+
+      - name: "Issue bei Verletzung (Label protection-violation)"
+        if: steps.meter.outputs.violations != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Label idempotent sicherstellen (422 = existiert schon)
+          gh api "repos/${GITHUB_REPOSITORY}/labels" \
+            -f name="protection-violation" -f color="b60205" \
+            -f description="ADR-242 Meter: Branch-Protection-Soll verletzt" \
+            >/dev/null 2>&1 || true
+
+          existing=$(gh issue list --label protection-violation --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file /tmp/meter-report.md
+            echo "Kommentar an bestehendes Issue #$existing"
+          else
+            gh issue create \
+              --title "[protection-violation] branch-protection-meter: Soll-Zustand verletzt ($(date -u +%Y-%m-%d))" \
+              --label protection-violation \
+              --body-file /tmp/meter-report.md
+          fi
+
+      - name: "Discord-Alert bei Verletzung"
+        if: steps.meter.outputs.violations != '0'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DISCORD_WEBHOOK}" ]; then
+            echo "⚠️ DISCORD_WEBHOOK nicht gesetzt — Alert übersprungen"
+            exit 0
+          fi
+          count="${{ steps.meter.outputs.violations }}"
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          payload=$(python3 -c "import json,sys; print(json.dumps({'content': sys.argv[1]}))" \
+            "🚨 **branch-protection-meter (ADR-242)**: ${count} Verletzung(en) — ${run_url}")
+          curl -sf -X POST -H "Content-Type: application/json" \
+            -d "$payload" "$DISCORD_WEBHOOK" > /dev/null
+
+      - name: "Gate: Meter-Ergebnis durchreichen"
+        if: steps.meter.outcome == 'failure'
+        run: |
+          echo "❌ Meter meldet Verletzungen (Report siehe Step 'Meter ausführen')"
+          exit 1

--- a/governance/rulesets/wave1-repos.json
+++ b/governance/rulesets/wave1-repos.json
@@ -39,7 +39,8 @@
     "owner": "achimdehnert",
     "required_check": "ci / gate",
     "wave": 1,
-    "reason": "auto-prod-deploy"
+    "reason": "auto-prod-deploy",
+    "deferred": "main-Deploy rot seit 2026-05-31 (F4) — Ruleset erst nach gruener main-CI (ADR-242 Rollout-Gate)"
   },
   {
     "repo": "dev-hub",

--- a/tools/apply-branch-protection.sh
+++ b/tools/apply-branch-protection.sh
@@ -77,8 +77,15 @@ if [ -n "$FILTER_REPO" ]; then
     echo "❌ Repo '$FILTER_REPO' nicht in wave1-repos.json gefunden." >&2
     exit 1
   fi
+  DEFERRED_REASON=$(echo "$ENTRIES" | jq -r '.[0].deferred // empty')
+  if [ -n "$DEFERRED_REASON" ]; then
+    echo "❌ Repo '$FILTER_REPO' ist deferred: $DEFERRED_REASON" >&2
+    echo "   Zum Anwenden 'deferred'-Feld in wave1-repos.json entfernen (Rollout-Gate prüfen!)." >&2
+    exit 1
+  fi
 else
-  ENTRIES=$(jq '.' "$REPOS_JSON")
+  jq -r '.[] | select(.deferred != null) | "⏸ \(.repo) übersprungen (deferred): \(.deferred)"' "$REPOS_JSON"
+  ENTRIES=$(jq '[.[] | select(.deferred == null)]' "$REPOS_JSON")
 fi
 
 TOTAL=$(echo "$ENTRIES" | jq 'length')

--- a/tools/branch_protection_meter.py
+++ b/tools/branch_protection_meter.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""ADR-242 §Rollout 4: branch-protection-meter — Enforcement der Enforcement.
+
+Prüft für jedes Soll-Repo aus governance/rulesets/*-repos.json, ob das
+Branch-Protection-Ruleset 'main-required-checks' real existiert, aktiv ist
+und den erwarteten required check trägt. Break-Glass (enforcement=disabled)
+ist per ADR-242 ausdrücklich meldepflichtig.
+
+Einträge mit "deferred"-Feld werden nicht als Verletzung gewertet, aber im
+Report gelistet (Rollout-Gate: erst grüne main-CI, dann Ruleset).
+
+Exit-Codes: 0 = alle Soll-Repos konform · 1 = mindestens eine Verletzung
+            2 = Konfigurations-/Aufruffehler
+
+Usage:
+    TOKEN=<pat> python3 tools/branch_protection_meter.py \
+        --expected governance/rulesets/wave1-repos.json \
+        --report /tmp/meter-report.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+API = "https://api.github.com"
+RULESET_NAME = "main-required-checks"
+
+
+def evaluate_repo(entry: dict, rulesets: list) -> dict:
+    """Bewertet ein Soll-Repo gegen seine live Rulesets (pure, testbar).
+
+    Returns dict mit status: 'ok' | 'deferred' | 'violation' und reasons.
+    """
+    repo = entry["repo"]
+    if entry.get("deferred"):
+        return {"repo": repo, "status": "deferred", "reasons": [str(entry["deferred"])]}
+
+    expected_check = entry["required_check"]
+    matching = [r for r in rulesets if r.get("name") == RULESET_NAME]
+    if not matching:
+        return {
+            "repo": repo,
+            "status": "violation",
+            "reasons": [f"Ruleset '{RULESET_NAME}' fehlt"],
+        }
+
+    reasons = []
+    ruleset = matching[0]
+    if ruleset.get("enforcement") != "active":
+        reasons.append(
+            f"enforcement='{ruleset.get('enforcement')}' (Break-Glass offen? ADR-242 verlangt Re-Aktivierung)"
+        )
+
+    contexts = [
+        c.get("context")
+        for rule in ruleset.get("rules", [])
+        if rule.get("type") == "required_status_checks"
+        for c in rule.get("parameters", {}).get("required_status_checks", [])
+    ]
+    if expected_check not in contexts:
+        reasons.append(
+            f"required check '{expected_check}' nicht konfiguriert (gefunden: {contexts or 'keine'})"
+        )
+
+    if reasons:
+        return {"repo": repo, "status": "violation", "reasons": reasons}
+    return {"repo": repo, "status": "ok", "reasons": []}
+
+
+def _api_get(path: str, token: str):
+    req = urllib.request.Request(
+        f"{API}{path}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.load(resp)
+
+
+def fetch_rulesets(owner: str, repo: str, token: str) -> list:
+    """Liefert Rulesets MIT rules-Array.
+
+    Gotcha: der List-Endpoint (/rulesets) liefert nur Summaries ohne 'rules';
+    die Regel-Details gibt es nur per GET /rulesets/{id} — daher zweistufig.
+    """
+    summaries = _api_get(f"/repos/{owner}/{repo}/rulesets", token)
+    return [
+        _api_get(f"/repos/{owner}/{repo}/rulesets/{s['id']}", token)
+        for s in summaries
+        if s.get("name") == RULESET_NAME
+    ]
+
+
+def render_report(results: list) -> str:
+    """Markdown-Report für Issue/Discord."""
+    ok = [r for r in results if r["status"] == "ok"]
+    deferred = [r for r in results if r["status"] == "deferred"]
+    violations = [r for r in results if r["status"] == "violation"]
+
+    lines = ["# branch-protection-meter (ADR-242)", ""]
+    lines.append(
+        f"**{len(ok)} konform · {len(violations)} Verletzungen · {len(deferred)} deferred**"
+    )
+    if violations:
+        lines += ["", "## ❌ Verletzungen", ""]
+        for r in violations:
+            for reason in r["reasons"]:
+                lines.append(f"- **{r['repo']}**: {reason}")
+    if deferred:
+        lines += ["", "## ⏸ Deferred (kein Alarm)", ""]
+        for r in deferred:
+            lines.append(f"- {r['repo']}: {r['reasons'][0]}")
+    if ok:
+        lines += ["", "## ✅ Konform", ""]
+        for r in ok:
+            lines.append(f"- {r['repo']}")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--expected", required=True, help="Pfad zur Soll-Repo-Liste (JSON)")
+    parser.add_argument("--report", help="Markdown-Report in Datei schreiben")
+    args = parser.parse_args()
+
+    token = os.environ.get("TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        print("❌ TOKEN (oder GH_TOKEN) nicht gesetzt", file=sys.stderr)
+        return 2
+
+    try:
+        with open(args.expected) as fh:
+            expected = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"❌ Soll-Liste nicht lesbar: {exc}", file=sys.stderr)
+        return 2
+
+    results = []
+    for entry in expected:
+        if entry.get("deferred"):
+            results.append(evaluate_repo(entry, []))
+            continue
+        try:
+            rulesets = fetch_rulesets(entry["owner"], entry["repo"], token)
+        except urllib.error.HTTPError as exc:
+            # Nicht-prüfbar = Verletzung (Schweigen wäre Schein-Grün)
+            results.append(
+                {
+                    "repo": entry["repo"],
+                    "status": "violation",
+                    "reasons": [f"Rulesets-API nicht lesbar (HTTP {exc.code})"],
+                }
+            )
+            continue
+        results.append(evaluate_repo(entry, rulesets))
+
+    report = render_report(results)
+    print(report)
+    if args.report:
+        with open(args.report, "w") as fh:
+            fh.write(report)
+
+    violations = sum(1 for r in results if r["status"] == "violation")
+    gh_output = os.environ.get("GITHUB_OUTPUT")
+    if gh_output:
+        with open(gh_output, "a") as fh:
+            fh.write(f"violations={violations}\n")
+
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_branch_protection_meter.py
+++ b/tools/tests/test_branch_protection_meter.py
@@ -1,0 +1,79 @@
+"""Tests für tools/branch_protection_meter.py (ADR-242 §Rollout 4)."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from branch_protection_meter import evaluate_repo, render_report  # noqa: E402
+
+
+def _ruleset(enforcement="active", check="ci / gate", name="main-required-checks"):
+    return {
+        "name": name,
+        "enforcement": enforcement,
+        "rules": [
+            {
+                "type": "required_status_checks",
+                "parameters": {"required_status_checks": [{"context": check}]},
+            }
+        ],
+    }
+
+
+ENTRY = {"repo": "demo-hub", "owner": "achimdehnert", "required_check": "ci / gate"}
+
+
+def test_should_pass_when_active_ruleset_with_matching_check():
+    result = evaluate_repo(ENTRY, [_ruleset()])
+    assert result["status"] == "ok"
+    assert result["reasons"] == []
+
+
+def test_should_flag_missing_ruleset():
+    result = evaluate_repo(ENTRY, [])
+    assert result["status"] == "violation"
+    assert "fehlt" in result["reasons"][0]
+
+
+def test_should_flag_foreign_ruleset_name_as_missing():
+    result = evaluate_repo(ENTRY, [_ruleset(name="andere-regel")])
+    assert result["status"] == "violation"
+
+
+def test_should_flag_disabled_enforcement_as_break_glass():
+    result = evaluate_repo(ENTRY, [_ruleset(enforcement="disabled")])
+    assert result["status"] == "violation"
+    assert any("disabled" in r for r in result["reasons"])
+
+
+def test_should_flag_wrong_check_context():
+    result = evaluate_repo(ENTRY, [_ruleset(check="guardian")])
+    assert result["status"] == "violation"
+    assert any("ci / gate" in r for r in result["reasons"])
+
+
+def test_should_collect_both_reasons_when_disabled_and_wrong_check():
+    result = evaluate_repo(ENTRY, [_ruleset(enforcement="evaluate", check="falsch")])
+    assert result["status"] == "violation"
+    assert len(result["reasons"]) == 2
+
+
+def test_should_skip_deferred_entries_without_violation():
+    entry = dict(ENTRY, deferred="main-CI rot — erst F4-Fix")
+    result = evaluate_repo(entry, [])
+    assert result["status"] == "deferred"
+    assert "F4" in result["reasons"][0]
+
+
+def test_should_render_report_with_all_sections():
+    results = [
+        {"repo": "a-hub", "status": "ok", "reasons": []},
+        {"repo": "b-hub", "status": "violation", "reasons": ["Ruleset fehlt"]},
+        {"repo": "c-hub", "status": "deferred", "reasons": ["main-CI rot"]},
+    ]
+    report = render_report(results)
+    assert "1 konform · 1 Verletzungen · 1 deferred" in report
+    assert "**b-hub**: Ruleset fehlt" in report
+    assert "c-hub: main-CI rot" in report
+    assert "- a-hub" in report


### PR DESCRIPTION
## Was

ADR-242 §Rollout 5 / §Confirmation 1 — der Meter, der prüft, dass die Branch-Protection real existiert (Enforcement der Enforcement):

1. **`tools/branch_protection_meter.py`** — Soll/Ist-Abgleich gegen `governance/rulesets/wave1-repos.json`. Meldet: fehlendes Ruleset, `enforcement != active` (= offenes Break-Glass, per ADR meldepflichtig), falschen/fehlenden required check, nicht-lesbare API (Schweigen wäre Schein-Grün). **API-Gotcha gefunden:** der List-Endpoint liefert Rulesets ohne `rules`-Array — Details nur per GET by-id, daher zweistufiger Fetch.
2. **`.github/workflows/branch-protection-meter.yml`** — wöchentlich (Mo 06:00 UTC) + `workflow_dispatch`. Bei Verletzung: Issue mit Label `protection-violation` (Kommentar statt Duplikat wenn schon offen) + Discord-Alert (`DISCORD_WEBHOOK`), Job rot. Cross-Repo-Reads via `PROJECT_PAT` (Konvention wie apply-branch-protection.yml).
3. **`deferred`-Semantik in der SSoT-Liste** — coach-hub trägt jetzt `deferred` (main-Deploy rot seit 2026-05-31, F4): Meter listet ohne Alarm, Apply-Script und Apply-Workflow überspringen konsistent. Das ADR-Rollout-Gate („erst grüne main-CI") steht damit als Code in der Liste statt als Tribal Knowledge.
4. **8 Unit-Tests** in `tools/tests/test_branch_protection_meter.py` — CI-wirksam via `tools-tests.yml` (pytest läuft in diesem PR, siehe Checks).

## Evidenz

Live-Smoke gegen die echten Rulesets (nach Phase-3-Rollout heute):

```
6 konform · 0 Verletzungen · 1 deferred (coach-hub), exit=0
```

Negativ-Pfade per Unit-Tests abgedeckt (fehlendes Ruleset, disabled, falscher Check, beides).

**Nicht lokal verifiziert:** die jq-Ausdrücke der deferred-Skips in `.sh`/Apply-Workflow (jq lokal nicht installiert) — Syntax ist Standard-jq; erster Dispatch-Lauf des Apply-Workflows zeigt es.

## Nach Merge

`workflow_dispatch` des Meters = Confirmation-1-Nachweis (grüner wöchentlicher Lauf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)