### PR TITLE
feat(drift-check): shared-ci-Tag-Drift-Regeln (🌀 Tag≠main)

### DIFF
--- a/scripts/drift_check.py
+++ b/scripts/drift_check.py
@@ -355,6 +355,124 @@ def check_python_version(repo: str, token: str) -> list[DriftItem]:
     return drifts
 
 
+# ── shared-ci Tag-Drift (🌀 Drift-Klasse „Tag ≠ main") ───────────────────────
+#
+# Dreimal passiert (zuletzt 2026-06-12, ADR-242 Phase 3): ein shared-ci-Tag
+# wurde VOR einem Fix in der kanonischen platform-Quelle geschnitten bzw.
+# Consumer pinnen veraltete Tags — Doku behauptet dann einen Stand, den die
+# Flotte real nicht hat (deploy_runs_on-Regression #461; gate-Job fehlte in
+# v1.0.2 trotz #548-Behauptung). Zwei Regeln:
+#   shared-ci-tag-outdated (warn):  Consumer pinnt nicht-neuesten Tag
+#   shared-ci-tag-stale    (error): neuester Tag ≠ platform-main-Kanon
+
+SHARED_CI_REPO = "iilgmbh/shared-ci"
+SHARED_CI_PIN_RE = re.compile(
+    r"iilgmbh/shared-ci/\.github/workflows/([\w.-]+\.ya?ml)@([\w./-]+)"
+)
+_SHARED_CI_STATE: dict | None = None
+
+
+def parse_shared_ci_pins(content: str) -> list[tuple[str, str]]:
+    """Extrahiert (workflow-datei, ref) aller shared-ci-Pins aus YAML-Text."""
+    return [(m.group(1), m.group(2)) for m in SHARED_CI_PIN_RE.finditer(content)]
+
+
+def _semver_key(tag: str) -> tuple[int, ...] | None:
+    m = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)", tag)
+    return tuple(int(x) for x in m.groups()) if m else None
+
+
+def latest_shared_ci_tag(tags: list[str]) -> str | None:
+    """Höchster vX.Y.Z-Tag nach Semver (API-Reihenfolge ist nicht verlässlich)."""
+    versioned = [(k, t) for t in tags if (k := _semver_key(t)) is not None]
+    return max(versioned)[1] if versioned else None
+
+
+def _get_content_at(owner_repo: str, path: str, ref: str, token: str) -> str | None:
+    data = _api_get(f"/repos/{owner_repo}/contents/{path}?ref={ref}", token)
+    if not isinstance(data, dict) or "content" not in data:
+        return None
+    try:
+        return base64.b64decode(data["content"]).decode(errors="replace")
+    except Exception:
+        return None
+
+
+def _shared_ci_state(token: str) -> dict:
+    """Einmal pro Lauf: neuester Tag + Abgleich Tag-Inhalt vs platform-Kanon."""
+    global _SHARED_CI_STATE
+    if _SHARED_CI_STATE is not None:
+        return _SHARED_CI_STATE
+    tags_data = _api_get(f"/repos/{SHARED_CI_REPO}/tags", token) or []
+    tags = [t.get("name", "") for t in tags_data if isinstance(t, dict)]
+    latest = latest_shared_ci_tag(tags)
+    stale_files: list[str] = []
+    if latest:
+        listing = _api_get(
+            f"/repos/{SHARED_CI_REPO}/contents/.github/workflows?ref={latest}", token
+        ) or []
+        for item in listing:
+            if not isinstance(item, dict) or not item.get("name", "").endswith((".yml", ".yaml")):
+                continue
+            name = item["name"]
+            canonical = _get_content_at(
+                f"{GITHUB_ORG}/platform", f".github/workflows/{name}", "main", token
+            )
+            if canonical is None:
+                continue  # existiert nur in shared-ci — kein Kanon-Abgleich
+            tagged = _get_content_at(
+                SHARED_CI_REPO, f".github/workflows/{name}", latest, token
+            )
+            # Port-Transformation normalisieren: der Mirror schreibt nur die
+            # Repo-Pfade um (Header + interne Action-Refs) — das ist kein Drift.
+            if tagged is not None:
+                normalized = tagged.replace(SHARED_CI_REPO, f"{GITHUB_ORG}/platform")
+                if normalized != canonical:
+                    stale_files.append(name)
+    _SHARED_CI_STATE = {"latest_tag": latest, "stale_files": stale_files}
+    return _SHARED_CI_STATE
+
+
+def check_shared_ci_tag_drift(repo: str, token: str,
+                               state: dict | None = None) -> list[DriftItem]:
+    """Prüft shared-ci-Pins des Repos gegen neuesten Tag + platform-Kanon."""
+    drifts = []
+    pins: list[tuple[str, str, str]] = []  # (wf_file, pinned_file, ref)
+    for wf_file in _get_dir_files(repo, ".github/workflows", token):
+        content = _get_file_content(repo, f".github/workflows/{wf_file}", token)
+        if not content:
+            continue
+        for pinned_file, ref in parse_shared_ci_pins(content):
+            pins.append((wf_file, pinned_file, ref))
+    if not pins:
+        return drifts
+
+    if state is None:
+        state = _shared_ci_state(token)
+    latest = state.get("latest_tag")
+    stale_files = state.get("stale_files", [])
+
+    for wf_file, pinned_file, ref in pins:
+        if latest and ref != latest and _semver_key(ref) is not None:
+            drifts.append(DriftItem(
+                rule="shared-ci-tag-outdated",
+                severity="warn",
+                file=f".github/workflows/{wf_file}",
+                message=f"shared-ci/{pinned_file}@{ref} — neuester Tag: {latest}",
+                fix_hint=f"sed -i 's#{pinned_file}@{ref}#{pinned_file}@{latest}#' .github/workflows/{wf_file}",
+            ))
+        if pinned_file in stale_files:
+            drifts.append(DriftItem(
+                rule="shared-ci-tag-stale",
+                severity="error",
+                file=f".github/workflows/{wf_file}",
+                message=(f"shared-ci@{latest}/{pinned_file} ≠ platform-main-Kanon — "
+                         "Tag ist stale, neuen Tag schneiden (🌀 Tag≠main)"),
+                fix_hint="platform .github/workflows nach shared-ci portieren + neuen Tag schneiden",
+            ))
+    return drifts
+
+
 # ── Haupt-Scan ────────────────────────────────────────────────────────────────
 
 SCAFFOLD_TYPES: frozenset[str] = frozenset({"django", "agent", "bot"})
@@ -378,6 +496,7 @@ def check_repo(repo: str, repo_type: str, token: str,
     drift.drifts.extend(check_actions_versions(repo, token))
     drift.drifts.extend(check_iil_package_versions(repo, token, iil_latest))
     drift.drifts.extend(check_python_version(repo, token))
+    drift.drifts.extend(check_shared_ci_tag_drift(repo, token))
 
     return drift
 

--- a/tools/tests/test_shared_ci_tag_drift.py
+++ b/tools/tests/test_shared_ci_tag_drift.py
@@ -1,0 +1,127 @@
+"""Tests für die shared-ci-Tag-Drift-Regeln in scripts/drift_check.py.
+
+🌀 Drift-Klasse „Tag ≠ main" (3 Vorfälle, zuletzt 2026-06-12 ADR-242 Phase 3):
+shared-ci-Tags wurden vor Fixes in der kanonischen platform-Quelle geschnitten
+bzw. Consumer pinnen veraltete Tags. Zwei Regeln:
+  shared-ci-tag-outdated (warn)  — Consumer pinnt nicht-neuesten Tag
+  shared-ci-tag-stale    (error) — neuester Tag ≠ platform-main-Kanon
+
+Rein (kein Token nötig): GitHub-Zugriffe werden gemockt bzw. der State
+explizit injiziert.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "drift_check.py"
+_spec = importlib.util.spec_from_file_location("drift_check", _SCRIPT)
+dc = importlib.util.module_from_spec(_spec)
+sys.modules["drift_check"] = dc
+_spec.loader.exec_module(dc)
+
+
+CI_YML = "jobs:\n  ci:\n    uses: iilgmbh/shared-ci/.github/workflows/_ci-python.yml@{ref}\n"
+
+
+def _mock_repo_files(monkeypatch, content):
+    monkeypatch.setattr(dc, "_get_dir_files", lambda repo, path, token: ["ci.yml"])
+    monkeypatch.setattr(dc, "_get_file_content", lambda repo, path, token: content)
+
+
+def test_should_parse_pins_with_file_and_ref():
+    pins = dc.parse_shared_ci_pins(CI_YML.format(ref="v1.0.4"))
+    assert pins == [("_ci-python.yml", "v1.0.4")]
+
+
+def test_should_pick_latest_tag_by_semver_not_list_order():
+    assert dc.latest_shared_ci_tag(["v1.0.4", "v1.0.10", "v1.0.2"]) == "v1.0.10"
+    assert dc.latest_shared_ci_tag(["egal", "kein-semver"]) is None
+
+
+def test_should_warn_on_outdated_pin(monkeypatch):
+    _mock_repo_files(monkeypatch, CI_YML.format(ref="v1.0.2"))
+    state = {"latest_tag": "v1.0.5", "stale_files": []}
+    drifts = dc.check_shared_ci_tag_drift("demo-hub", "", state=state)
+    assert [d.rule for d in drifts] == ["shared-ci-tag-outdated"]
+    assert drifts[0].severity == "warn"
+    assert "v1.0.5" in drifts[0].message
+    assert "v1.0.2" in drifts[0].fix_hint
+
+
+def test_should_pass_when_pin_is_latest_and_tag_matches_canon(monkeypatch):
+    _mock_repo_files(monkeypatch, CI_YML.format(ref="v1.0.5"))
+    state = {"latest_tag": "v1.0.5", "stale_files": []}
+    assert dc.check_shared_ci_tag_drift("demo-hub", "", state=state) == []
+
+
+def test_should_error_when_latest_tag_is_stale_vs_canon(monkeypatch):
+    _mock_repo_files(monkeypatch, CI_YML.format(ref="v1.0.5"))
+    state = {"latest_tag": "v1.0.5", "stale_files": ["_ci-python.yml"]}
+    drifts = dc.check_shared_ci_tag_drift("demo-hub", "", state=state)
+    assert [d.rule for d in drifts] == ["shared-ci-tag-stale"]
+    assert drifts[0].severity == "error"
+    assert "Kanon" in drifts[0].message
+
+
+def test_should_not_warn_on_branch_refs_only_semver_tags(monkeypatch):
+    # @main-Pins sind kein Tag-Drift (eigene Konvention: Kanon direkt)
+    _mock_repo_files(monkeypatch, CI_YML.format(ref="main"))
+    state = {"latest_tag": "v1.0.5", "stale_files": []}
+    assert dc.check_shared_ci_tag_drift("demo-hub", "", state=state) == []
+
+
+def test_should_return_empty_for_repos_without_pins(monkeypatch):
+    _mock_repo_files(monkeypatch, "jobs:\n  test:\n    runs-on: ubuntu-latest\n")
+    called = {"n": 0}
+
+    def boom(token):
+        called["n"] += 1
+        raise AssertionError("state darf ohne Pins nicht berechnet werden")
+
+    monkeypatch.setattr(dc, "_shared_ci_state", boom)
+    assert dc.check_shared_ci_tag_drift("demo-hub", "") == []
+    assert called["n"] == 0
+
+
+def test_should_not_flag_mirror_path_rewrite_as_stale(monkeypatch):
+    """Der shared-ci-Mirror schreibt nur Repo-Pfade um — das ist kein Drift."""
+    canonical = "uses: achimdehnert/platform/.github/actions/x@main\n"
+    mirrored = "uses: iilgmbh/shared-ci/.github/actions/x@main\n"
+
+    def fake_api_get(path, token):
+        if path.endswith("/tags"):
+            return [{"name": "v1.0.4"}]
+        if "contents/.github/workflows?ref=" in path:
+            return [{"name": "_ci-python.yml", "type": "file"}]
+        return None
+
+    def fake_content_at(owner_repo, path, ref, token):
+        return canonical if owner_repo.endswith("/platform") else mirrored
+
+    monkeypatch.setattr(dc, "_api_get", fake_api_get)
+    monkeypatch.setattr(dc, "_get_content_at", fake_content_at)
+    monkeypatch.setattr(dc, "_SHARED_CI_STATE", None)
+    state = dc._shared_ci_state("")
+    assert state == {"latest_tag": "v1.0.4", "stale_files": []}
+
+
+def test_should_flag_genuine_content_difference_as_stale(monkeypatch):
+    def fake_api_get(path, token):
+        if path.endswith("/tags"):
+            return [{"name": "v1.0.4"}]
+        if "contents/.github/workflows?ref=" in path:
+            return [{"name": "_ci-python.yml", "type": "file"}]
+        return None
+
+    def fake_content_at(owner_repo, path, ref, token):
+        if owner_repo.endswith("/platform"):
+            return "jobs:\n  gate:\n    runs-on: x\n"
+        return "jobs: {}\n"
+
+    monkeypatch.setattr(dc, "_api_get", fake_api_get)
+    monkeypatch.setattr(dc, "_get_content_at", fake_content_at)
+    monkeypatch.setattr(dc, "_SHARED_CI_STATE", None)
+    assert dc._shared_ci_state("")["stale_files"] == ["_ci-python.yml"]


### PR DESCRIPTION
## Was

Codifiziert die 🌀-Drift-Klasse **„Tag ≠ main"** (3 Vorfälle: #461-Regression via v1.0.0/v1.0.1-Sweep; v1.0.2 ohne pg_isready-Fix; 2026-06-12 falsche #548-Behauptung „v1.0.4 in use" bei realen v1.0.2/v1.0.1-Pins) als zwei drift-check-Regeln:

| Regel | Severity | Bedeutung |
|---|---|---|
| `shared-ci-tag-outdated` | warn | Consumer pinnt nicht-neuesten Semver-Tag (Fix-Hint: sed-Bump) |
| `shared-ci-tag-stale` | error | neuester shared-ci-Tag ≠ platform-main-Kanon → neuen Tag schneiden |

**Normalisierung:** der shared-ci-Mirror schreibt nur Repo-Pfade um (`achimdehnert/platform` ↔ `iilgmbh/shared-ci`, Header + interne Action-Refs) — wird vor dem Kanon-Vergleich normalisiert, sonst wäre stale ein Dauer-False-Positive (im Live-Smoke verifiziert: vor Normalisierung 7/7 Dateien „stale", danach 1 echte).

`@main`-Pins sind bewusst kein Befund (= Kanon direkt). State (neuester Tag + Kanon-Abgleich) wird einmal pro Lauf berechnet und nur, wenn überhaupt Pins existieren.

## Live-Smoke (echte Flotte, 2026-06-12)

```
state: {'latest_tag': 'v1.0.4', 'stale_files': ['deploy-config-lint.yml']}
cad-hub:     deploy.yml pinnt _ci-python@v1.0.2 + _deploy-unified@v1.0.2  [warn]
billing-hub: deploy.yml pinnt _ci-python@v1.0.2 + _deploy-unified@v1.0.2  [warn]
dev-hub:     deploy.yml pinnt _ci-python@v1.0.1 + _deploy-unified@v1.0.1  [warn]
```

→ sofort 2 echte Befund-Typen: `deploy-config-lint.yml` ist in v1.0.4 stale (Tag vor #550/#556 geschnitten), und die heutigen v1.0.4-Bumps (#8/#26/#90) trafen nur `ci.yml` — `deploy.yml` pinnt weiter alte Tags. Beide werden beim v1.0.5-Schnitt (shared-ci#8-Portfix) mit abgeräumt.

## Tests

13 passed — inkl. Mirror-Normalisierung (kein False-Positive) und Echt-Diff (stale). CI-wirksam via `tools-tests.yml` (scripts/** + tools/**-Trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)