### PR TITLE
fix(ci): Postgres-Service auf ephemeren Host-Port (shared-ci#8)

### DIFF
--- a/.github/workflows/_ci-python.yml
+++ b/.github/workflows/_ci-python.yml
@@ -245,7 +245,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports:
-          - 5432:5432
+          - 5432  # ephemer: Docker wählt freien Host-Port (shared-ci#8)
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python
@@ -265,6 +265,7 @@ jobs:
           DJANGO_SETTINGS_MODULE: ${{ inputs.django_settings_module }}
           SECRET_KEY: test-secret-key-for-ci
           POSTGRES_HOST: localhost
+          POSTGRES_PORT: ${{ job.services.postgres.ports['5432'] }}
         run: |
           WORKERS=${{ inputs.pytest_workers }}
           # django-tenants-Repos brauchen echte Migrationen (Tenant-Schema-Tabellen
@@ -309,7 +310,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports:
-          - 5432:5432
+          - 5432  # ephemer: Docker wählt freien Host-Port (shared-ci#8)
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python
@@ -329,6 +330,7 @@ jobs:
           DJANGO_SETTINGS_MODULE: ${{ inputs.django_settings_module }}
           SECRET_KEY: test-secret-key-for-ci
           POSTGRES_HOST: localhost
+          POSTGRES_PORT: ${{ job.services.postgres.ports['5432'] }}
         run: |
           set -euo pipefail
           python manage.py migrate 2>&1 && echo "OK: Migration graph consistent — all migrations applied" || {
@@ -343,6 +345,7 @@ jobs:
           DJANGO_SETTINGS_MODULE: ${{ inputs.django_settings_module }}
           SECRET_KEY: test-secret-key-for-ci
           POSTGRES_HOST: localhost
+          POSTGRES_PORT: ${{ job.services.postgres.ports['5432'] }}
         run: |
           set -euo pipefail
           python manage.py check --deploy --fail-level ERROR 2>&1 || {
@@ -357,6 +360,7 @@ jobs:
           DJANGO_SETTINGS_MODULE: ${{ inputs.django_settings_module }}
           SECRET_KEY: test-secret-key-for-ci
           POSTGRES_HOST: localhost
+          POSTGRES_PORT: ${{ job.services.postgres.ports['5432'] }}
           REDIS_URL: redis://localhost:6379/0
         run: |
           WORKERS=${{ inputs.pytest_workers }}
@@ -428,7 +432,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports:
-          - 5432:5432
+          - 5432  # ephemer: Docker wählt freien Host-Port (shared-ci#8)
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python
@@ -450,6 +454,7 @@ jobs:
           DJANGO_SETTINGS_MODULE: ${{ inputs.django_settings_module }}
           SECRET_KEY: test-secret-key-for-ci
           POSTGRES_HOST: localhost
+          POSTGRES_PORT: ${{ job.services.postgres.ports['5432'] }}
         run: pytest -m "contract" -v || ([ $? -eq 5 ] && echo "No contract tests found, skipping." && exit 0)
 
   architecture-guardian:


### PR DESCRIPTION
## Problem

`_ci-python.yml` mappte den Postgres-Service in 3 Jobs hart auf `5432:5432` — auf einem self-hosted Runner kollidiert jedes parallele Job-Paar (cad-hub#26 + dev-hub#90 fielen 2026-06-12 zeitgleich mit `port is already allocated`). Mit required `ci / gate` (ADR-242) blockiert so ein Transient-Fail Merges bis zum Hand-Rerun. → shared-ci#8

## Fix

`ports: - 5432` (Docker wählt freien Host-Port) + `POSTGRES_PORT: ${{ job.services.postgres.ports['5432'] }}` in allen 5 Test-Step-Envs.

## Kontrakt-Änderung (für Consumer)

Test-Settings müssen `POSTGRES_PORT` aus dem Env lesen (Default 5432 bleibt korrekt für lokal). Kompatibilität geprüft: **dev-hub** ✅ liest es · **billing-hub/coach-hub** skippen DB-Tests · **cad-hub** Fix nötig (test.py las nur TEST_DB_PORT) — kommt mit dem v1.0.5-Bump-PR.

## Evidenz (Validierungs-Draft cad-hub#27 gegen diesen Branch)

- Lauf 1 rot → bewies die Kontrakt-Lücke (POSTGRES_PORT=1024/32768 gesetzt, Django verband trotzdem zu 5432)
- Lauf 2 **grün** ([27443219506](https://github.com/achimdehnert/cad-hub/actions/runs/27443219506)) mit test.py-Fallback: Unit auf Port **32769**, Integration auf **1025** — gleichzeitig, kollisionsfrei

## Nach Merge

Port nach shared-ci spiegeln + **v1.0.5** taggen (zusammen mit dem dort stale gewordenen `deploy-config-lint.yml` — Fund des neuen Tag-Drift-Meters #561), dann Consumer-Bumps inkl. `deploy.yml`-Pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)