### PR TITLE
fix(skill): frontend-ui-test — reverse() statt hardcodierter /projects/-Pfade

### DIFF
--- a/.windsurf/workflows/frontend-ui-test.md
+++ b/.windsurf/workflows/frontend-ui-test.md
@@ -89,6 +89,7 @@ print(f'=== {len(routes) - len(errors)}/{len(routes)} URL-Reverses OK ===')
 ```bash
 cd ${GITHUB_DIR:-$HOME/github}/writing-hub && python manage.py shell -c "
 from django.test import Client
+from django.urls import reverse, NoReverseMatch
 from apps.projects.models import BookProject
 
 p = BookProject.objects.get(title='__UI_TEST_PROJECT__')
@@ -97,41 +98,49 @@ pk = str(p.pk)
 c = Client()
 c.login(username='ui_testuser', password='uitest123')
 
-urls = [
-    f'/projects/{pk}/',
-    f'/projects/{pk}/drama/',
-    f'/projects/{pk}/health/',
-    f'/projects/{pk}/pitch/',
-    f'/projects/{pk}/analysis/',
-    f'/projects/{pk}/budget/',
-    f'/projects/{pk}/research/',
-    f'/projects/{pk}/beta/',
-    f'/projects/{pk}/lektorat/',
-    f'/projects/{pk}/manuscript/',
+# URLs IMMER via reverse() bauen — NIE hardcoden. Der Pfad-Prefix ist /projekte/
+# (deutsch), nicht /projects/; hardcodierte Pfade liefen still in 404 (Drift 2026-06-13).
+routes = [
+    ('projects:detail',             {'pk': pk}),
+    ('projects:chapter_writer',     {'pk': pk}),
+    ('projects:drama_dashboard',    {'pk': pk}),
+    ('projects:health',             {'pk': pk}),
+    ('projects:pitch_dashboard',    {'pk': pk}),
+    ('projects:analysis',           {'pk': pk}),
+    ('projects:budget',             {'pk': pk}),
+    ('projects:research_dashboard', {'pk': pk}),
+    ('projects:beta_dashboard',     {'pk': pk}),
+    ('projects:lektorat',           {'pk': pk}),
+    ('projects:manuscript',         {'pk': pk}),
 ]
 
 ok_count = 0
 errors = []
-for url in urls:
+for name, kwargs in routes:
+    try:
+        url = reverse(name, kwargs=kwargs)
+    except NoReverseMatch as e:
+        msg = f'NOREV     {name}: {e}'
+        print(msg); errors.append(msg); continue
     try:
         r = c.get(url)
         if r.status_code == 200:
-            print(f'OK  200  {url}')
+            print(f'OK  200  {url}  [{name}]')
             ok_count += 1
         elif r.status_code == 302:
-            print(f'OK  302  {url}  -> {r.get(\"Location\",\"\")}')
+            print(f'OK  302  {url}  -> {r.get(\"Location\",\"\")}  [{name}]')
             ok_count += 1
         else:
-            msg = f'ERR {r.status_code}  {url}'
+            msg = f'ERR {r.status_code}  {url}  [{name}]'
             print(msg)
             errors.append(msg)
     except Exception as e:
-        msg = f'EXC       {url}: {e}'
+        msg = f'EXC       {url}  [{name}]: {e}'
         print(msg)
         errors.append(msg)
 
 print()
-print(f'=== {ok_count}/{len(urls)} Views OK ===')
+print(f'=== {ok_count}/{len(routes)} Views OK ===')
 if errors:
     print('FEHLER:')
     for e in errors:
@@ -149,29 +158,31 @@ else:
 ```bash
 cd ${GITHUB_DIR:-$HOME/github}/writing-hub && python manage.py shell -c "
 from django.test import Client
+from django.urls import reverse
 from apps.projects.models import BookProject, ResearchNote
 
 p = BookProject.objects.get(title='__UI_TEST_PROJECT__')
 pk = str(p.pk)
+research_url = reverse('projects:research_dashboard', kwargs={'pk': pk})  # NIE hardcoden (/projekte/, nicht /projects/)
 
 c = Client(enforce_csrf_checks=True)
 c.login(username='ui_testuser', password='uitest123')
 
-r_get = c.get(f'/projects/{pk}/research/')
+r_get = c.get(research_url)
 csrf_token = r_get.cookies.get('csrftoken')
 if not csrf_token:
     print('WARN: kein csrftoken Cookie')
 else:
     print(f'OK   CSRF-Cookie vorhanden: {str(csrf_token)[:12]}...')
 
-r_bad = c.post(f'/projects/{pk}/research/', {'action': 'add_note', 'title': 'x', 'content': 'x'})
+r_bad = c.post(research_url, {'action': 'add_note', 'title': 'x', 'content': 'x'})
 if r_bad.status_code == 403:
     print('OK   POST ohne CSRF -> 403 (korrekt)')
 else:
     print(f'WARN POST ohne CSRF -> {r_bad.status_code} (sollte 403 sein!)')
 
 r_ok = c.post(
-    f'/projects/{pk}/research/',
+    research_url,
     {'action': 'add_note', 'title': 'CSRF-Test', 'content': 'Test',
      'csrfmiddlewaretoken': csrf_token.value},
     HTTP_X_CSRFTOKEN=csrf_token.value,
@@ -206,8 +217,32 @@ print('Test-Daten geloescht.')
 
 ## Erweiterung: Neue Views hinzufügen
 
-In Schritt 2 `routes`-Liste und in Schritt 3 `urls`-Liste erweitern.
+Die `routes`-Liste in **Schritt 2 und Schritt 3** erweitern (beide bauen URLs via
+`reverse()` — Routen-Name + kwargs, **nie** hardcodierte Pfade).
 
 - `200` = View rendert korrekt
 - `302` = Redirect nach POST — OK
 - `403/404/500` = Fehler → beheben
+
+---
+
+## Gegen Prod/Staging statt lokal testen (optional)
+
+Diese Skill läuft per Default gegen die **lokale** Instanz (Dev-Settings mit
+`ALLOWED_HOSTS=['*']`). Für einen Lauf gegen einen Remote-Host gilt:
+
+- Test-Client-Default-Host ist `testserver` → bei gehärtetem `ALLOWED_HOSTS`
+  (Prod/Staging) `DisallowedHost 400`. Pro Request `HTTP_HOST='<host>'` setzen,
+  z.B. `c.get(url, HTTP_HOST='writing.iil.pet', secure=True)`.
+- **Nicht** via `docker exec … manage.py shell` mit Template-Rendering im Prod-
+  `writing_hub_web`-Container (512M-Limit, läuft baseline ~75%) — eine zweite
+  Django-Instanz + Render kippt die cgroup → **OOM-Kill** (kann echte gunicorn-
+  Worker treffen). Stattdessen echtes HTTP durch gunicorn (curl mit Login-Session).
+
+## Changelog
+
+- 2026-06-13: Schritt 3 von hardcodierten `/projects/{pk}/…`-Pfaden auf `reverse()`
+  umgestellt — der echte Prefix ist `/projekte/` (deutsch), die hardcodierten
+  Pfade lieferten still 404. `projects:chapter_writer` (#39 Chapter-Writer)
+  ergänzt. Routen-Name wird jetzt im Output mitgeführt. Prod/Staging-Hinweis
+  (HTTP_HOST + OOM-Warnung) ergänzt. Dogfood: writing-hub #39/#40 Prod-Smoke-Test.


### PR DESCRIPTION
## Problem

Die Skill `.windsurf/workflows/frontend-ui-test.md` (kanonische Quelle in platform, per Symlink in writing-hub) hardcodierte in **Schritt 3** (HTTP-200-Test) und **Schritt 3b** (CSRF-Test) Pfade wie `/projects/{pk}/…`. Der echte URL-Prefix von writing-hub ist aber **`/projekte/`** (deutsch) → alle Checks liefen still in **404**, der Test war faktisch wirkungslos. Schritt 2 (Reverse-Test) nutzte bereits korrekt `reverse()`.

Entdeckt beim Prod-Smoke-Test von writing-hub #39/#40.

## Fix

- **Schritt 3**: URLs via `reverse()` aus Routen-Namen statt Pfad-Strings (robust gegen URL-Änderungen). `projects:chapter_writer` (#39 Chapter-Writer) ergänzt. Routen-Name wird im Output mitgeführt.
- **Schritt 3b**: `reverse('projects:research_dashboard', …)` statt hardcodiertem Pfad.
- Erweiterungs-Hinweis auf die gemeinsame `reverse()`-`routes`-Liste aktualisiert.
- Neue Sektion „Gegen Prod/Staging testen": `HTTP_HOST` setzen (sonst `DisallowedHost 400` bei gehärtetem `ALLOWED_HOSTS`) + Warnung gegen in-process `docker exec manage.py shell` mit Render im 512M-`writing_hub_web` (OOM-Risiko, kann gunicorn-Worker killen).
- Changelog-Sektion ergänzt (Skill-Policy).

## Dogfood (writing-hub #39/#40 Prod-Smoke-Test, 2026-06-13)

`reverse()` gegen die echten Routen-Namen, dann authentifiziertes HTTP durch gunicorn:

```
reverse('projects:detail')         -> /projekte/<uuid>/            GET 200
reverse('projects:chapter_writer') -> /projekte/<uuid>/write/      GET 200
reverse('projects:manuscript')     -> /projekte/<uuid>/manuscript/ GET 200
```

Gegenprobe — die **alten** hardcodierten Pfade:
```
GET /projects/<uuid>/            -> 404
GET /projects/<uuid>/write/      -> 404
GET /projects/<uuid>/manuscript/ -> 404
```

Alle 5 Python-Blöcke der Skill kompilieren (`compile(..., 'exec')`).

## Hinweis

`mode`/Anti-Patterns-Vollstruktur (Skill-Policy 2026-05-15) sind in dieser bestehenden Skill noch nicht nachgezogen — bewusst aus dem Scope dieses fokussierten Bugfixes gehalten; separat nachziehbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)