### PR TITLE
feat(governance): ADR-242 — coach-hub Deferral aufgehoben (Wave 1 = 7/7)

### DIFF
--- a/governance/rulesets/wave1-repos.json
+++ b/governance/rulesets/wave1-repos.json
@@ -39,8 +39,7 @@
     "owner": "achimdehnert",
     "required_check": "ci / gate",
     "wave": 1,
-    "reason": "auto-prod-deploy",
-    "deferred": "main-Deploy rot seit 2026-05-31 (F4) — Ruleset erst nach gruener main-CI (ADR-242 Rollout-Gate)"
+    "reason": "auto-prod-deploy"
   },
   {
     "repo": "dev-hub",


### PR DESCRIPTION
## Was
coach-hub aus dem `deferred`-Zustand in `governance/rulesets/wave1-repos.json` entfernt.

## Warum
Das ADR-242-Rollout-Gate (Ruleset erst nach grüner main-CI) ist erfüllt:
- coach-hub main-Deploy **grün** (push @`312f7f6`, run 27493734106 success)
- `kiohnerisiko.de/livez/` → **200**, Container auf `main-312f7f6`, `/entrypoint.sh` gebacken
- Root-Cause behoben in coach-hub#31 (entrypoint-Bind-Mount-Antipattern + PROJECT_PAT-Org-Transfer)

## Folge
Nach Merge: `apply-branch-protection.yml` für coach-hub dispatchen → **Wave 1 = 7/7 geschützt**, 0 deferred. Meter sollte dann `7 konform · 0 Verletzungen · 0 deferred` zeigen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)