### PR TITLE
fix(ci): _ci-python Security-Scan — Git-Auth für private Deps (fleet-weit rot)

### DIFF
--- a/.github/workflows/_ci-python.yml
+++ b/.github/workflows/_ci-python.yml
@@ -178,6 +178,24 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python_version }}
+      - name: Git-Auth für private Deps (ephemer, self-hosted-safe)
+        env:
+          PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+        run: |
+          # pip / pip-audit müssen private git+https-Deps (z.B. iil-Org) klonen.
+          # Token in eine JOB-temporäre gitconfig schreiben statt ~/.gitconfig —
+          # self-hosted Runner persistieren das globale gitconfig sonst (Token-Leak).
+          # Via GIT_CONFIG_GLOBAL gilt sie für alle Folge-Steps und verschwindet
+          # mit RUNNER_TEMP.
+          if [ -n "$PROJECT_PAT" ]; then
+            cfg="${RUNNER_TEMP}/ci-git-auth.gitconfig"
+            git config --file "$cfg" \
+              url."https://x-access-token:${PROJECT_PAT}@github.com/".insteadOf "https://github.com/"
+            echo "GIT_CONFIG_GLOBAL=$cfg" >> "$GITHUB_ENV"
+            echo "✅ Git-Auth für private Deps aktiv (ephemer)"
+          else
+            echo "ℹ️  Kein PROJECT_PAT — private git-Deps werden ggf. nicht aufgelöst"
+          fi
       - name: Install dependencies
         run: |
           pip install pip-audit


### PR DESCRIPTION
## Problem
Der `security`-Job in `_ci-python.yml` (`pip install -r` + `pip-audit -r`) klont private `git+https`-Deps (z.B. `iil-Org`, django-lms-lite) **ohne Token** → `fatal: could not read Username for github.com` → Job rot. `continue-on-error: true` macht ihn non-blocking, aber das Dauer-Rot **verdeckt echte CVE/Konflikt-Funde** (Beispiel: coach-hub, jeder Deploy-Lauf).

Die Test-Jobs lösen das über die `install-iil-packages`-Action mit `PROJECT_PAT` — der security-Job nicht.

## Fix
PROJECT_PAT in eine **job-temporäre** gitconfig (`$RUNNER_TEMP`) schreiben und via `GIT_CONFIG_GLOBAL` an alle Folge-Steps reichen:
- **self-hosted-safe**: schreibt NICHT `~/.gitconfig` (self-hosted Runner persistieren das → Token-Leak), sondern eine ephemere Datei in RUNNER_TEMP.
- **guarded**: bei leerem `PROJECT_PAT` no-op (öffentliche Repos unverändert).
- gilt für `pip install` UND `pip-audit`.

## Blast radius
Reusable `@main`, alle Python-Consumer. Risiko minimal: Job ist `continue-on-error`, der Change fügt nur einen Step + Env-Var hinzu (keine Permissions/Inputs).

## Verify nach Merge
Nächster coach-hub-Lauf (oder ein `workflow_dispatch`): `ci / Security Scan` sollte grün statt rot sein.

🤖 Generated with [Claude Code](https://claude.com/claude-code)