### PR TITLE
fix(skill): session-ende 3.1c Reaper-Loop härten (3 Increment-Retro-Befunde)

### DIFF
--- a/.windsurf/workflows/session-ende.md
+++ b/.windsurf/workflows/session-ende.md
@@ -318,9 +318,11 @@ find ${GITHUB_DIR:-$HOME/github}/ -maxdepth 4 -name "*.fixed" -o -name "*.update
 # Jedes Repo mit Session-Worktrees abräumen. --apply, aber tool-interne Guards
 # lassen dirty / offene-PR-Worktrees absichtlich stehen. Restore-Manifest je Repo.
 for repo in ${GITHUB_DIR:-$HOME/github}/*/; do
-  [ -e "$repo/.git" ] || continue
-  out=$(cd "$repo" && python3 ${GITHUB_DIR:-$HOME/github}/platform/tools/worktree-reaper.py --apply 2>/dev/null | grep -E "entfernt$|[0-9]+ entfernt")
-  [ -n "$out" ] && echo "$(basename "$repo"): $out"
+  # NUR Haupt-Checkouts: .git ist ein Verzeichnis. Linked-Worktrees (z.B.
+  # *-pinned) haben .git als DATEI → überspringen, sonst Doppel-Durchlauf.
+  [ -d "$repo/.git" ] || continue
+  summary=$(cd "$repo" && python3 ${GITHUB_DIR:-$HOME/github}/platform/tools/worktree-reaper.py --apply 2>/dev/null | grep -oE "[0-9]+ entfernt")
+  [ -n "$summary" ] && [ "${summary%% *}" != "0" ] && echo "$(basename "$repo"): $summary"
 done
 echo "✅ Worktree-Reaper durchgelaufen (ADR-233)"
 ```


### PR DESCRIPTION
## Was
Härtet den in #567 hinzugefügten Reaper-Loop. Increment-Retro fand drei Bugs im eigenen Gate:
1. **toter grep-Arm** `entfernt$` — die Reaper-Per-Removal-Zeile endet auf `)`, matcht nie → nur `[0-9]+ entfernt` behalten.
2. **`[ -e .git ]` matchte Linked-Worktrees** (deren `.git` eine DATEI ist, z.B. `platform-pinned`) → Platform wurde doppelt verarbeitet. Jetzt **`[ -d .git ]`** = nur Haupt-Checkouts.
3. **nie ausgeführt vor Merge** (#567) → diesmal **real getestet**: dry-run über alle Repos, 0 Fehler, `bin`/`genesor` + `platform-pinned` korrekt übersprungen.

Kein Verhaltens-Change am Reaper selbst (Guards unverändert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)