### PR TITLE
feat(session-retro): v2.2 — retro_kpis.py + 6 Methoden-Fixes aus 2 realen Läufen

### DIFF
--- a/.windsurf/workflows/session-retro.md
+++ b/.windsurf/workflows/session-retro.md
@@ -44,6 +44,22 @@ Survivors strukturell selten → kleiner skalieren (sonst verbrennt die Falsifik
 Kein Multi-Agent unter `lean`. Falsifikation **nie** 1 Agent pro Befund (explodiert linear) —
 gebündelt je Dimension.
 
+**Trigger-Konflikt (Rule B feuert, Dichte-Regel dämpft) — Auflösung (Lehre 2026-06-14):**
+Der `deep`-Trigger „Prod-Schritt" und die Dichte-Regel „reversibel+transparent+freigegeben →
+kleiner skalieren" widersprechen sich bei einem **sauberen, freigegebenen, reversiblen**
+Prod-Deploy. Regel: starte beim Rule-B-Level (`deep`); **eine** Stufe runter (→ `full`) nur wenn
+**alle drei** zutreffen — (a) Prod-Schritt war menschlich explizit freigegeben (Artefakt-Beleg:
+PR-Body-Warnung oder `AskUserQuestion`), (b) voll rollback-fähig (gleiche Bereitstellung, **keine**
+DB-Migration), (c) findings_total-Schätzung ≤10. Bei Prod-Schritt **nie** auf `lean`. Reduktion +
+die drei Begründungen im Frontmatter (`footprint_reduction_reason`) festhalten.
+
+**Increment-Retro (Anchor am selben Tag):** Läuft eine zweite Retro auf dem Abarbeiten der
+Action-Items der vorigen Retro: (1) `session_id`-Suffix `-incr` (kollisionssicherer Pfad);
+(2) **nur die neuen Artefakte** sind in-scope — Vor-Retro NICHT re-litigieren; (3) Parent-Retro-
+Slugs zählen als Vorkommen-1 → taucht ein Slug im Increment erneut auf, ist das Vorkommen-2 ⇒
+**Gate-Pflicht, auch same-day** (siehe `retro_kpis.py`); (4) Right-Sizing-Minimum mit Prod-Schritt:
+`full` (nie `lean`), weil ein Anchor per Definition neue Fixes auf bekannte Muster deployt.
+
 ## Modell-Routing je Phase (Kosten-Disziplin)
 Die Trennung Richter≠Angeklagter kommt vom **frischen Kontext**, NICHT vom teuren Opus →
 Subagenten laufen auf dem **billigsten Modell, das die Phase trägt** (`agent(..., model: …)`):
@@ -86,6 +102,17 @@ Je Dimension ein **eigener** Subagent (kennt die Session-Erzählung nicht), geer
 
 Je Befund: Schweregrad (kritisch/hoch/mittel/niedrig) + Root Cause (5-Why) + Kategorie
 (Wissenslücke / Prozesslücke / Kommunikation / verfrühte Festlegung / fehlende Validierung / Werkzeug).
+
+## Phase 2.5 — Finder-Konflikt-Erkennung (in-context, 0 Agenten — Lehre 2026-06-14)
+Bevor Phase 3 startet: die Finder-Outputs auf **zwei Finder mit widersprüchlichen Fakt-Behauptungen
+über dasselbe Artefakt** (gleiche Datei/PR/Status) scannen. Jeden Widerspruch explizit als Paar
+markieren. **NICHT in Phase 4 selbst auflösen** — das wäre verstecktes Verify aus dem Haupt-Kontext
+(Regel-1-Bruch). Stattdessen den Widerspruch als **zusätzlichen Skeptiker-Task** routen: der Phase-3-
+Skeptiker zieht das umstrittene Artefakt **unabhängig aus `origin/main`** (nicht aus dem lokalen
+Working-Tree) und entscheidet binär. Nur die skeptiker-verifizierte Version geht in den Report — mit
+eigener Befund-Nummer + Kategorie/Severity (keine nummernlosen Tabellenzeilen). (Realfall: zwei Finder
+widersprachen sich über `pptx-hub origin/main`; **ein Finder verfiel selbst in den stale-local-Fehler,
+den er anklagte** — genau dafür existiert Richter≠Angeklagter.)
 
 ## Phase 3 — Verify (Falsifikation)
 Skeptiker-Subagent **je Dimension** (nicht je Befund — Budget, s. Phase 0). **Binär: SURVIVES
@@ -130,7 +157,9 @@ session_id: <kurz>
 footprint: lean|full|deep
 findings_total: <n>
 findings_survived: <n>
-refuted_rate: <(refuted)/total, 0–1>     # Skill-KPI, s. Phase 5
+refuted_rate: <(phase3_refuted + pre_refuted)/findings_total, 0–1>  # Skill-KPI, s. Phase 5
+phase3_refuted: <n>   # vom UNABHÄNGIGEN Phase-3-Skeptiker mit frischem Artefakt-Check verworfen
+pre_refuted: <n>      # schon VOR Phase 3 als trivial-falsch erkannt (Finder-Stroh); NICHT die Skeptiker-Schärfe
 scores:                                   # ganzzahlig 1–5, KEINE Halbwerte
   zielerreichung: <1-5>
   architektur_design: <1-5>
@@ -151,13 +180,22 @@ Danach in fester Reihenfolge:
   mit Rework · `3`=teilweise erreicht, signifikante Abweichung begründet · `4`=erreicht, kleine Mängel ·
   `5`=erreicht, vorbildlich.
 - **4. Soll-Ablauf** (aus Phase 3.5, Ist→Soll→eliminiert-#).
-- **5. Längsschnitt — der eigentliche Hebel:** gegen `<auto-memory>/MEMORY.md` abgleichen.
-  Wiederholung (gleiche Kategorie mehrfach in dieser Session ODER schon als Drift-Memory **belegt
-  vorhanden** — Existenz per `grep` prüfen, Phase 3) → **HARTES GATE** (Hook/CI), nicht der N-te Notizzettel.
+- **5. Längsschnitt — der eigentliche Hebel:** **PFLICHT** `python3 tools/retro_kpis.py` laufen lassen
+  (zählt `recurring_findings`-Slugs maschinell über ALLE `~/shared/session-retro-*.md`). Jeder Slug mit
+  Zähler **≥2 ⇒ GATE-PFLICHT** (Hook/CI/Skill-Edit), nicht der N-te Notizzettel. Zusätzlich gegen
+  `<auto-memory>/MEMORY.md` abgleichen (gleiche Kategorie mehrfach in dieser Session ODER schon als
+  Drift-Memory **belegt vorhanden** — Existenz per `grep` prüfen). Der maschinelle Zähler ersetzt das
+  manuelle Erinnern (Realfall 2026-06-14: `worktree-orphan-accumulation` ×2 erst vom Tool gefangen).
 - **6. Verankerung:** kopierfertige `memory_candidates` + `adr_candidates` (du schreibst sie NICHT selbst).
 - **7. Maßnahmen als Action-Board** (Org-Standard: Buckets 🟢 dein Zug / 🔵 ich sofort / 🟡-⛔ wip / ✅ done;
   Lean-Spalten `# | Item | Repo | PR/Issue/ADR | Status | Next Step`), **abgeleitet aus dem Soll-Ablauf**.
 - **8. Nicht verifiziert (Restlücken)** — Pflicht-Sektion: was offen blieb + billigster Check.
+
+**Synthesizer-Grenze (Lehre 2026-06-14):** Phase 4 ist **nur Zusammenführen** — der Haupt-Kontext führt
+hier **keine** neuen `gh`/`git`-Befehle aus. Stellt er einen Finder-Widerspruch oder ein ungedecktes
+Faktum fest → zurück nach Phase 2.5/3 (Skeptiker) ODER als Lücke in §8 (Nicht verifiziert), **nicht**
+still selbst-verifizieren. Befunde, die nur durch Session-Gedächtnis gedeckt sind (kein per `gh run
+view` erreichbares Artefakt), werden als **Hypothese** geführt, nicht als SURVIVES mit „Beleg=Session-Log".
 
 **Report-Pfad — kollisionsfrei bei Parallel-Sessions (Pflicht):**
 `~/shared/session-retro-<datum>-<repo>-<session-id-kurz>.md`. **Jede Session schreibt ihre eigene Datei.**
@@ -174,13 +212,20 @@ Er sieht nur den Report + diese Skill. Checkliste:
 - Scores ganzzahlig 1–5, je an Befund verankert? (fängt erfundene Halbwerte wie `2.5`)
 - **Invariante** `|Soll-Schritte| == |überlebende Befunde|` erfüllt?
 - Frontmatter schema-valide (alle Pflichtfelder)? Report-Pfad kollisionsfrei (repo+session-id)?
-- `refuted_rate` plausibel? **Interpretation als Skill-KPI** (kein Session-Urteil): dauerhaft
-  **>0,8** über mehrere Retros → Finder zu lasch (produzieren widerlegbares Stroh); **<0,2** →
-  Falsifikation ist Theater (widerlegt nie). Auffälligkeit als `## Self-Review`-Block im Report notieren.
+- `refuted_rate` plausibel? Der Meta-Reviewer kommentiert sie **ausschließlich numerisch** als
+  Band-Vergleich (aktueller Wert vs. die vorangehenden Retros via `retro_kpis.py`) — er beurteilt
+  **NICHT**, ob einzelne SURVIVES/REFUTED-Entscheide inhaltlich korrekt sind (das wäre Session-Urteil).
+  Band-KPI: dauerhaft **>0,8** → Finder zu lasch (widerlegbares Stroh); **<0,2** → Falsifikation ist
+  Theater. **Nur `phase3_refuted/(findings_total − pre_refuted)` ist die echte Falsifikations-Quote**
+  (hohes `pre_refuted` = schwache Finder, nicht scharfer Skeptiker). Auffälligkeit als `## Self-Review`.
 
-> **Längsschnitt der Skill selbst (optional):** `retro-kpis.py` (falls vorhanden) liest die Frontmatter
-> aller `~/shared/session-retro-*.md`, trendet `refuted_rate`/Scores und eskaliert jeden
-> `recurring_finding` mit Zähler **≥2 über Retros** automatisch zum Gate-PR-Pflicht-Item.
+> **Längsschnitt der Skill selbst (PFLICHT in Phase 4, nicht optional):** `python3 tools/retro_kpis.py`
+> liest die Frontmatter aller `~/shared/session-retro-*.md`, trendet `refuted_rate`/Scores und eskaliert
+> jeden `recurring_finding` mit Zähler **≥2 über Retros** zum Gate-PR-Pflicht-Item. Stdlib-only, kein Setup.
+
+**Agenten-Budget-Hinweis:** ein `full`-Lauf mit Phase 5 braucht den 6. Subagenten (Meta) — das `≤5` in der
+Phase-0-Tabelle gilt für die Find/Verify-Pipeline; der Meta-Reviewer kommt **obendrauf** (also `full` ≤6,
+`deep` zzgl. Phase-6-Extern).
 
 ## Phase 6 — Extern-Handoff (optional, nur `deep`)
 Stärkste Stufe der Selbstverbesserung: eine **anbieter-fremde** Zweitmeinung (nicht nur frischer
@@ -216,6 +261,10 @@ genau wie die Skill ursprünglich aus einem Diabolus-Review entstand.
 - ❌ Find/Verify durch **„du"/Haupt-Session** „zum Sparen" — das ist Self-Review (Regel-1-Bruch). Kosten-Fix = **Sonnet-Subagent**, nicht **kein** Subagent.
 - ❌ **Opus-Subagenten** als Default — Sonnet trägt Find/Verify/Meta; Opus nur bei nachgewiesenem Nuance-Fail.
 - ❌ Extern-Handoff (Phase 6) **Evidenz-Fakten** behaupten lassen — extern hat kein gh/git, nur Methoden-Kritik.
+- ❌ **Finder-vs-Finder-Widerspruch durch die Haupt-Session (Phase 4) per neuem git/gh auflösen** — verstecktes Verify (Regel-1-Bruch); Widersprüche gehören als Skeptiker-Task nach Phase 2.5/3.
+- ❌ **Nummernlose Befund-Zeile** (Finder-Konflikt-Funde ohne `#`/Kategorie/Severity) — bricht die eingefrorenen Spalten + den `findings_total`-Zähler.
+- ❌ **`recurring_finding` im Frontmatter ohne `retro_kpis.py`-Zähler-Check** — Längsschnitt ist dann Dekoration, kein Hebel (genau das Anti-Pattern, das die Skill predigt, auf sich selbst angewandt).
+- ❌ **`refuted_rate` ohne `pre_refuted`-Trennung** — trivial-falsche Finder-Behauptungen (vom Haupt-Kontext vor-widerlegt) blähen die Quote und verfälschen das Skill-KPI.
 
 ## Changelog
 - 2026-06-04: Initial. Aus einem Advocatus-Diabolus-Review des Paste-Prompt-Retros
@@ -238,3 +287,16 @@ genau wie die Skill ursprünglich aus einem Diabolus-Review entstand.
   **Phase 6 Extern-Handoff** (optional, deep) — anbieter-fremde Methoden-Zweitmeinung (Muster
   `adr-handoff-extern`); harte Grenze: extern kritisiert Methode, prüft KEINE Evidenz (kein gh/git);
   wiederkehrende Kritik fließt zurück in die Skill (Self-Improvement-Loop mit externem Falsifikator).
+- 2026-06-14 (v2.2): **Self-Improvement aus zwei realen Läufen am selben Tag** (Richter≠Angeklagter:
+  frischer Skill-Kritiker gegen die zwei erzeugten Reports). **Fixes:** (1) **`tools/retro_kpis.py`
+  gebaut** (war nur „falls vorhanden" referenziert → Längsschnitt-Hebel war fiktiv; 15 Reports lagen
+  ungelesen). Stdlib-only, zählt `recurring_findings` über Retros, eskaliert ≥2 → GATE-PFLICHT; fing
+  beim ersten Lauf `worktree-orphan-accumulation ×2`. Phase-4-Pflichtaufruf, „falls vorhanden"-Hedge
+  entfernt. (2) **Phase 2.5 Finder-Konflikt-Erkennung** — widersprechen sich zwei Finder über einen
+  Fakt, war die Auflösung still in Phase 4 (Haupt-Session zieht neues git/gh = Regel-1-Bruch; Realfall:
+  ein Finder verfiel selbst in den stale-local-Fehler, den er anklagte). Jetzt: als Skeptiker-Task nach
+  Phase 3, Synthesizer führt KEINE neuen Befehle aus. (3) **`refuted_rate` 3-Feld-Split** (`phase3_refuted`
+  + `pre_refuted`) — Vor-Widerlegungen durch den Haupt-Kontext verfälschten das KPI. (4) **Trigger-Konflikt-
+  Auflösung** (deep „Prod-Schritt" vs. Dichte-Downscale) + **Increment-Retro-Regeln** (same-day Anchor).
+  (5) **Phase-5-Budget** geklärt (`full` ≤6 mit Meta) + Meta-Reviewer nur **numerisch** (kein Einzel-Befund-
+  Urteil). Quelle: `~/shared/session-retro-2026-06-14-coach-hub-2d7cd9*.md` + adversarialer Skill-Kritiker.

--- a/tools/retro_kpis.py
+++ b/tools/retro_kpis.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""retro-kpis.py — Längsschnitt-Hebel für /session-retro (ADR-light, kein Dep).
+
+Liest die YAML-Frontmatter aller `~/shared/session-retro-*.md` (außer den
+`-extern-`-Briefings), zählt `recurring_findings`-Slugs ÜBER Retros hinweg und
+eskaliert jeden Slug mit **Zähler ≥2 → GATE-PFLICHT**. Trendet zusätzlich
+`refuted_rate` gegen das Skill-KPI-Band (>0.8 Finder zu lasch · <0.2 Falsifikation
+Theater) und die 6 Score-Dimensionen.
+
+Bewusst stdlib-only (Frontmatter-Mini-Parser statt PyYAML) — das Tool muss in
+jeder session-retro-Phase-4 ohne Setup laufen.
+
+Aufruf:
+    python3 tools/retro_kpis.py                 # Default-Glob ~/shared/session-retro-*.md
+    python3 tools/retro_kpis.py --dir <pfad>    # anderes Verzeichnis
+    python3 tools/retro_kpis.py --min-band 3    # refuted_rate-Band erst ab N Retros werten
+
+Exit-Code 0 immer (Report-Tool, kein Gate-Enforcer — das Gate ist der gemeldete
+GATE-PFLICHT-Block, den der Mensch in einen PR überführt).
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import re
+from collections import Counter, defaultdict
+
+LIST_KEYS = {"recurring_findings", "gate_candidates", "repo_scope"}
+SCALAR_KEYS = {"date", "session_id", "footprint", "refuted_rate",
+               "findings_total", "findings_survived",
+               "phase3_refuted", "pre_refuted"}
+SCORE_KEYS = ["zielerreichung", "architektur_design", "code_konventionstreue",
+              "risiko_debt", "prozess_effizienz", "entscheidungsqualitaet"]
+
+
+def parse_frontmatter(text: str) -> dict | None:
+    """Minimaler Frontmatter-Parser: erstes ---...----Block, flache keys + scores-Block."""
+    m = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    if not m:
+        return None
+    body = m.group(1)
+    out: dict = {"scores": {}}
+    in_scores = False
+    for raw in body.splitlines():
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        indented = raw[0] in " \t"
+        line = raw.strip()
+        if line.rstrip(":") == "scores" and line.endswith(":"):
+            in_scores = True
+            continue
+        if in_scores and indented and ":" in line:
+            k, v = line.split(":", 1)
+            k, v = k.strip(), v.strip()
+            if k in SCORE_KEYS:
+                try:
+                    out["scores"][k] = int(v)
+                except ValueError:
+                    pass
+            continue
+        in_scores = False
+        if ":" not in line:
+            continue
+        k, v = line.split(":", 1)
+        k, v = k.strip(), v.strip()
+        if k in LIST_KEYS:
+            v = v.strip("[]")
+            out[k] = [s.strip().strip("'\"") for s in v.split(",") if s.strip()]
+        elif k in SCALAR_KEYS:
+            out[k] = v.strip("'\"")
+    return out
+
+
+def load_reports(directory: str) -> list[dict]:
+    pattern = os.path.join(directory, "session-retro-*.md")
+    reports = []
+    for path in sorted(glob.glob(pattern)):
+        if "-extern-" in os.path.basename(path):
+            continue  # Phase-6-Briefings sind keine Retros
+        try:
+            fm = parse_frontmatter(open(path, encoding="utf-8").read())
+        except OSError:
+            continue
+        if fm is None:
+            continue
+        fm["_path"] = os.path.basename(path)
+        reports.append(fm)
+    return reports
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Längsschnitt-KPIs über session-retro-Reports")
+    ap.add_argument("--dir", default=os.path.expanduser("~/shared"),
+                    help="Verzeichnis mit session-retro-*.md (default ~/shared)")
+    ap.add_argument("--min-band", type=int, default=3,
+                    help="refuted_rate-Band erst ab N Retros bewerten (default 3)")
+    args = ap.parse_args()
+
+    reports = load_reports(args.dir)
+    if not reports:
+        print(f"Keine session-retro-Reports in {args.dir} gefunden.")
+        return 0
+
+    print(f"# Längsschnitt über {len(reports)} Retro-Reports ({args.dir})\n")
+
+    # --- Recurring-Findings-Zähler über Retros → Gate-Eskalation ---
+    slug_reports: dict[str, list[str]] = defaultdict(list)
+    for r in reports:
+        for slug in r.get("recurring_findings", []):
+            slug_reports[slug].append(r.get("session_id", r["_path"]))
+    gated = {s: v for s, v in slug_reports.items() if len(v) >= 2}
+
+    print("## recurring_findings (Zähler über Retros)")
+    if not slug_reports:
+        print("(keine recurring_findings deklariert)")
+    for slug, where in sorted(slug_reports.items(), key=lambda kv: -len(kv[1])):
+        mark = "🚨 GATE-PFLICHT" if len(where) >= 2 else "·"
+        print(f"  {mark}  {slug}  ×{len(where)}  [{', '.join(where)}]")
+    if gated:
+        print(f"\n→ {len(gated)} Slug(s) ≥2 ⇒ Gate-PR-Pflicht: "
+              f"{', '.join(sorted(gated))}. Als Gate (Hook/CI/Skill) verankern, "
+              f"nicht als N-tes Memo.")
+
+    # --- refuted_rate-Band ---
+    rates = []
+    for r in reports:
+        try:
+            rates.append((r.get("session_id", r["_path"]), float(r["refuted_rate"])))
+        except (KeyError, ValueError):
+            pass
+    print("\n## refuted_rate-Trend (Skill-KPI)")
+    if rates:
+        print("  " + " · ".join(f"{sid}:{val:.2f}" for sid, val in rates[-8:]))
+        n = len(rates)
+        if n >= args.min_band:
+            recent = [v for _, v in rates[-args.min_band:]]
+            if all(v > 0.8 for v in recent):
+                print(f"  ⚠️  letzte {args.min_band} >0.8 → Finder zu lasch (widerlegbares Stroh).")
+            elif all(v < 0.2 for v in recent):
+                print(f"  ⚠️  letzte {args.min_band} <0.2 → Falsifikation ist Theater (widerlegt nie).")
+            else:
+                print(f"  ✅ Band gesund (weder {args.min_band}× >0.8 noch <0.2).")
+        else:
+            print(f"  (erst ab {args.min_band} Retros als Band gewertet — bisher {n})")
+    else:
+        print("  (keine refuted_rate-Werte parsebar)")
+
+    # --- Score-Mittel je Dimension ---
+    print("\n## Score-Mittel je Dimension (1–5)")
+    sums: Counter = Counter()
+    cnts: Counter = Counter()
+    for r in reports:
+        for k, v in r.get("scores", {}).items():
+            sums[k] += v
+            cnts[k] += 1
+    for k in SCORE_KEYS:
+        if cnts[k]:
+            print(f"  {k:24} {sums[k]/cnts[k]:.2f}  (n={cnts[k]})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_retro_kpis.py
+++ b/tools/tests/test_retro_kpis.py
@@ -1,0 +1,63 @@
+"""Tests für tools/retro_kpis.py (session-retro Längsschnitt-Hebel, v2.2)."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from retro_kpis import load_reports, parse_frontmatter  # noqa: E402
+
+SAMPLE = """---
+retro_schema: 1
+date: 2026-06-14
+repo_scope: [coach-hub, platform]
+session_id: 2d7cd9
+footprint: deep
+findings_total: 12
+findings_survived: 8
+refuted_rate: 0.33
+phase3_refuted: 2
+pre_refuted: 2
+scores:
+  zielerreichung: 4
+  architektur_design: 3
+  risiko_debt: 2
+gate_candidates: [a-gate, b-gate]
+recurring_findings: [stale-local-vs-origin, worktree-orphan-accumulation]
+---
+
+# Body, darf NICHT geparst werden
+recurring_findings: [should-be-ignored]
+"""
+
+
+def test_should_parse_inline_list_and_scalars():
+    fm = parse_frontmatter(SAMPLE)
+    assert fm is not None
+    assert fm["session_id"] == "2d7cd9"
+    assert fm["refuted_rate"] == "0.33"
+    assert fm["recurring_findings"] == ["stale-local-vs-origin", "worktree-orphan-accumulation"]
+
+
+def test_should_parse_nested_scores_block_as_ints():
+    fm = parse_frontmatter(SAMPLE)
+    assert fm["scores"] == {"zielerreichung": 4, "architektur_design": 3, "risiko_debt": 2}
+
+
+def test_should_not_leak_body_keys_into_frontmatter():
+    # Der `recurring_findings`-Eintrag IM BODY darf den Frontmatter-Wert nicht überschreiben.
+    fm = parse_frontmatter(SAMPLE)
+    assert "should-be-ignored" not in fm["recurring_findings"]
+
+
+def test_should_return_none_without_frontmatter():
+    assert parse_frontmatter("kein Frontmatter hier\n") is None
+
+
+def test_should_skip_extern_briefings_and_load_real_reports(tmp_path):
+    (tmp_path / "session-retro-2026-06-14-x-aaa.md").write_text(SAMPLE, encoding="utf-8")
+    (tmp_path / "session-retro-extern-2026-06-14-x-aaa.md").write_text(SAMPLE, encoding="utf-8")
+    (tmp_path / "unrelated.md").write_text("nope", encoding="utf-8")
+    reports = load_reports(str(tmp_path))
+    assert len(reports) == 1  # -extern- + unrelated ausgeschlossen
+    assert reports[0]["_path"] == "session-retro-2026-06-14-x-aaa.md"


### PR DESCRIPTION
## Was
Optimiert die `session-retro`-Skill, **geerdet an zwei realen Läufen heute** (nicht abstrakt). Ein frischer adversarialer Skill-Kritiker (Richter≠Angeklagter — ich war der, der die Skill anwandte) fand 8 Gaps gegen die zwei erzeugten Reports; die 6 mit dem höchsten Hebel sind umgesetzt.

## Fixes
| # | Gap (real exponiert) | Fix |
|---|------|-----|
| 1 | `retro-kpis.py` war nur *'falls vorhanden'* → Längsschnitt-Hebel **fiktiv** (15 Reports ungelesen) | **`tools/retro_kpis.py` gebaut** + Phase-4-Pflichtaufruf + Test (5 grün). Fing sofort `worktree-orphan-accumulation ×2` |
| 2/6 | Finder-vs-Finder-Widerspruch (pptx-hub) wurde **still in Phase 4** aufgelöst = Regel-1-Bruch; ein Finder verfiel selbst in den stale-local-Fehler | **Phase 2.5** Konflikt→Skeptiker-Task; Synthesizer führt **keine** neuen gh/git aus |
| 3 | `refuted_rate` undefiniert für Vor-Widerlegungen | **3-Feld-Split** `phase3_refuted` + `pre_refuted` |
| 4 | `deep`-Trigger 'Prod-Schritt' **widerspricht** der Dichte-Downscale-Regel | explizite Auflösungs-Regel |
| 5 | keine **Increment-Retro**-Guidance (heute genau das gelaufen) | Subsection |
| 8 | Phase-5-Budget (`full` listet 5, Meta braucht 6.) | Cap geklärt + Meta nur numerisch |

`tools/retro_kpis.py`: stdlib-only (kein PyYAML-Dep), zählt `recurring_findings` über alle `~/shared/session-retro-*.md`, eskaliert ≥2 → GATE-PFLICHT, trendet `refuted_rate`/Scores. Live an 12 Reports getestet.

## Selbst-referenziell
Die Skill predigt 'recurring pattern → Gate, nicht N-tes Memo' — und beging das Anti-Pattern an sich selbst (der Gate-Mechanismus war nie gebaut). Dieser PR schließt das.

🤖 Generated with [Claude Code](https://claude.com/claude-code)