### PR TITLE
docs(infra): SoT für Hosts + CI-Runner-Topologie (hosts.yaml)

### DIFF
--- a/infra/hosts.yaml
+++ b/infra/hosts.yaml
@@ -1,0 +1,98 @@
+# platform/infra/hosts.yaml
+# ═══════════════════════════════════════════════════════════════════════════════
+# Single Source of Truth für PHYSISCHE HOSTS + CI-RUNNER-TOPOLOGIE
+#
+# Warum diese Datei existiert:
+#   Wiederkehrendes Problem (User-Kritik 2026-06-17): der Agent hat keine
+#   Transparenz über die TATSÄCHLICHE Infrastruktur — welche Server existieren,
+#   wo sie liegen, welche GitHub-Actions-Runner mit welchen Labels laufen. Das war
+#   2026-06-15 die Outage-Wurzel (137-hub COMPOSE-Kollision auf Multi-Hub-Host) und
+#   2026-06-17 der Merge-Blocker (toter `hetzner`-Runner-Pin in complete-check.yml).
+#
+# WICHTIG: Diese Datei MUSS den realen Server-Zustand abbilden.
+#   Hosts prüfen:   python infra/scripts/server_probe.py --host <ip>
+#   Runner prüfen:  gh api repos/<owner>/<repo>/actions/runners
+#   Ports:          siehe infra/ports.yaml (eigene SoT)
+#
+# Ground-Truth-Stand: 2026-06-17 (verifiziert per SSH + gh api; siehe `verified`).
+# ═══════════════════════════════════════════════════════════════════════════════
+
+hosts:
+  prod:
+    ip: 88.198.191.108
+    ssh: root@88.198.191.108
+    ssh_alias: hetzner-prod            # ~/.ssh/config
+    hostname: ubuntu-8gb-nbg1-1
+    os: Ubuntu 24.04.3 LTS
+    provider: Hetzner (nbg1)
+    role: >
+      Produktions-Multi-Hub-Host. Trägt ALLE Prod-Container aller Hubs
+      (risk-hub→schutztat.de, billing-hub, trading-hub, …) als getrennte
+      docker-compose-Projekte auf EINER Engine. Multi-Hub-Host → COMPOSE_PROJECT_NAME
+      pro Hub pinnen (ADR-248), sonst Cross-Projekt-Orphan-Removal.
+    hosts_runners: [prod-server]
+    verified: 2026-06-17
+
+  staging:
+    ip: 88.99.38.75
+    ssh: root@88.99.38.75
+    hostname: dev-desktop              # "Dev-Desktop / Staging" in infra-Skripten
+    provider: Hetzner
+    role: >
+      Staging-/Dev-Host. Trägt Staging-Container (risk_hub_staging_*,
+      cad_hub_staging_web, …) + diverse *_local_*-Dev-Stacks + ib_gateway.
+      Staging-Ingress via eigenem cloudflared (staging-riskhub.iil.pet).
+      KEIN GitHub-Actions-Runner installiert (Stand 2026-06-17).
+    hosts_runners: []
+    verified: 2026-06-17
+
+  odoo:
+    ip: 46.225.127.211
+    ssh_alias: hetzner-odoo            # ~/.ssh/config
+    role: "Odoo-Host (Details nicht in dieser Session verifiziert)."
+    hosts_runners: []
+    verified: false                    # nur aus ~/.ssh/config, nicht geprüft
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GitHub-Actions Self-Hosted Runner
+# ─────────────────────────────────────────────────────────────────────────────
+# Label-Konvention (verbindlich): Workflows nutzen `runs-on: self-hosted` (plain).
+# Den erfüllt der prod-server-Runner. Die Labels `hetzner` und `dev` sind TOT
+# (nur der verwaiste, offline dev-hetzner-2 trägt sie) — NICHT mehr verwenden.
+runners:
+  prod-server:
+    host: prod                         # 88.198.191.108
+    status: online                     # Stand 2026-06-17
+    labels: [self-hosted, Linux, X64, prod, prod-server]
+    scope: per-repo
+    install: /opt/actions-runner-<repo>
+    service: actions.runner.achimdehnert-<repo>.prod-server.service
+    note: >
+      Ein dedizierter Runner pro Repo (risk-hub, billing-hub, trading-hub,
+      platform, … alle 23 Repos). Verarbeitet alles mit `runs-on: self-hosted`.
+      Ein Runner pro Repo → Jobs eines PRs laufen sequenziell.
+    verified: 2026-06-17
+
+  dev-hetzner-2:
+    host: UNKNOWN                       # auf keinem erreichbaren Host installiert
+    status: offline-orphaned           # >13h offline am 2026-06-17, blockierte Merges
+    labels: [self-hosted, Linux, X64, hetzner, dev]
+    note: >
+      VERWAISTE Registrierung: in GitHub als Runner geführt, aber auf KEINEM
+      erreichbaren Host gefunden (nicht prod, nicht staging/dev-desktop; nicht in
+      ssh-config/known_hosts/infra-configs). Die Labels `hetzner`/`dev` zeigen nur
+      auf ihn → jeder Workflow, der sie verlangt, hängt unbegrenzt in der Queue.
+      Cleanup-Kandidat: `gh api -X DELETE repos/<owner>/<repo>/actions/runners/<id>`
+      (erst sicherstellen, dass kein Workflow mehr die toten Labels verlangt).
+    verified: 2026-06-17
+
+# Workflows, die (noch) tote Labels verlangen — beim Auftauchen auf self-hosted angleichen:
+dead_label_refs:
+  - repo: risk-hub
+    file: .github/workflows/complete-check.yml
+    was: "[self-hosted, hetzner]"
+    fixed_in: "PR #209 (→ self-hosted)"
+  - repo: risk-hub
+    file: .github/workflows/runner-diag.yml
+    requires: "[self-hosted, dev]"
+    status: "offen — Diagnose-Workflow, kein Merge-Gate; bei Bedarf auf self-hosted"


### PR DESCRIPTION
## Warum
Wiederkehrendes, vom User als **schwerwiegend** benanntes Problem (2026-06-17): der Agent hat keine Transparenz über die **tatsächliche** Infrastruktur — welche Hosts existieren, welche CI-Runner mit welchen Labels laufen. Das war:
- **2026-06-15** die Outage-Wurzel (137-hub COMPOSE-Kollision auf dem Multi-Hub-Host),
- **2026-06-17** der Merge-Blocker (toter `hetzner`-Runner-Pin → siehe risk-hub #209).

Es gab SoT für Ports (`ports.yaml`), Secrets, Tunnel — **keine** für Hosts + Runner.

## Inhalt (`infra/hosts.yaml`)
Verifizierte Ground Truth (SSH + `gh api`, 2026-06-17):
- **prod** `88.198.191.108` (`ubuntu-8gb-nbg1-1`): Multi-Hub-Prod-Host; `prod-server`-Runner pro Repo (`/opt/actions-runner-<repo>`).
- **staging/dev-desktop** `88.99.38.75`: Staging-Container + Dev-Stacks; **kein** Runner.
- **odoo** `46.225.127.211`: aus ssh-config, nicht verifiziert.
- **Runner:** `prod-server` (online, Labels inkl. `prod-server`) vs. **`dev-hetzner-2`** (offline, **verwaist**, kein Host — `hetzner`/`dev`-Labels sind tot).
- **Label-Konvention:** `runs-on: self-hosted`; tote-Label-Workflow-Referenzen gelistet.

Format/Disziplin wie `ports.yaml` (Ground-Truth-Datum + Validierungs-Befehle im Header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)