### PR TITLE
ci(_ci-python): Runner-Label-Check org-weit (tote self-hosted-Pins blockieren)

### DIFF
--- a/.github/workflows/_ci-python.yml
+++ b/.github/workflows/_ci-python.yml
@@ -523,10 +523,67 @@ jobs:
               sys.exit(0)
           GUARDIAN_EOF
 
+  runner-label-check:
+    name: "Runner-Label-Check"
+    # Bewusst GitHub-hosted: ein Gate gegen tote self-hosted-Runner-Label-Pins darf
+    # NICHT selbst von einem self-hosted-Runner abhängen (sonst hängt es genauso).
+    # Hintergrund: 2026-06-17 hing complete-check.yml 13h, weil auf [self-hosted,
+    # hetzner] gepinnt (hetzner trug nur ein verwaister offline-Runner) → blockierte
+    # ALLE risk-hub-Merges. Konvention/SoT: platform/infra/hosts.yaml.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python_version }}
+      - name: Install PyYAML
+        run: pip install pyyaml
+      - name: "Keine toten self-hosted-Label-Pins"
+        run: |
+          python3 - <<'PY'
+          import sys, glob, yaml
+          # Labels, die jeder self-hosted Runner automatisch trägt:
+          AUTO = {"self-hosted", "linux", "x64"}
+          # Erlaubte Zusatz-Labels (leer = nur plain self-hosted). Bei neuem dedizierten
+          # Runner: hier UND in platform/infra/hosts.yaml (status: online) ergänzen.
+          ALLOWED_EXTRA = set()
+          HOSTED = ("ubuntu", "windows", "macos")
+          issues = []
+          for wf in sorted(glob.glob(".github/workflows/*.yml") + glob.glob(".github/workflows/*.yaml")):
+              try:
+                  doc = yaml.safe_load(open(wf).read()) or {}
+              except yaml.YAMLError as e:
+                  issues.append(f"{wf}: YAML nicht parsebar ({e})")
+                  continue
+              for job_id, job in (doc.get("jobs", {}) or {}).items():
+                  if not isinstance(job, dict):
+                      continue
+                  ro = job.get("runs-on")
+                  labels = [ro] if isinstance(ro, str) else (ro or [])
+                  low = {str(x).lower() for x in labels}
+                  if any(any(l.startswith(h) for h in HOSTED) for l in low):
+                      continue
+                  if "self-hosted" not in low:
+                      continue
+                  extra = {str(x) for x in labels if str(x).lower() not in AUTO and str(x) not in ALLOWED_EXTRA}
+                  if extra:
+                      issues.append(
+                          f"{wf}: job '{job_id}' runs-on {labels} — Zusatz-Label {sorted(extra)} "
+                          f"ist nicht garantiert von einem Online-Runner gedeckt (toter-Pin-Risiko, "
+                          f"blockiert Merges). Fix: runs-on: self-hosted (SoT: platform/infra/hosts.yaml)."
+                      )
+          if issues:
+              print(f"::error::Runner-Label-Check: {len(issues)} Finding(s)")
+              for i in issues:
+                  print(f"  - {i}")
+              sys.exit(1)
+          print("OK — kein self-hosted-Workflow nutzt ein ungedecktes Runner-Label.")
+          PY
+
   gate:
     name: "gate"
     runs-on: ${{ inputs.runs_on }}
-    needs: [qm-gate, lint, secrets-scan, security, test-unit, test-integration, coverage-report, test-contract, architecture-guardian]
+    needs: [qm-gate, lint, secrets-scan, security, test-unit, test-integration, coverage-report, test-contract, architecture-guardian, runner-label-check]
     if: always()
     steps:
       - name: "All CI jobs passed or skipped"


### PR DESCRIPTION
Org-weiter Rollout des Runner-Label-Gates (Folge aus session-retro Infra-Transparenz).

## Mechanismus
Statt 21 Per-Repo-Dateien: ein `runner-label-check`-Job im **near-universalen** reusable `_ci-python.yml` (callen ~20 Repos) + Aufnahme in `gate.needs` → **org-weit blockierend ohne Per-Repo-Branch-Protection-Änderung** (Repos requiren `gate` bereits).

- Läuft auf **`ubuntu-latest`** — ein Gate gegen tote *self-hosted*-Labels darf nicht selbst von self-hosted abhängen.
- Schlägt fehl, sobald ein self-hosted-Job ein Zusatz-Label über `{self-hosted, Linux, X64}` hinaus verlangt, das kein Online-Runner deckt.

## Blast-Radius (vorab auditiert mit hosts_audit.py)
Nur **dev-hub** + **mcp-hub** hatten weitere tote Pins → separat gefixt (dev-hub #94, mcp-hub #117). Alle übrigen 18 Repos sauber. Getestet: FAIL gegen `[self-hosted, hetzner]`, OK gegen risk-hub/origin-main.

## gaeb-toolkit
Callt `_ci-python` nicht (0) → nicht abgedeckt; ist aber sauber (keine self-hosted-Pins). Follow-up: thin caller, falls gewünscht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)