### PR TITLE
chore(infra): bfagent archivieren + 3 recovered Hubs in den Canary

### DIFF
--- a/.github/workflows/prod-uptime-canary.yml
+++ b/.github/workflows/prod-uptime-canary.yml
@@ -48,6 +48,9 @@ jobs:
           https://trading-hub.iil.pet/livez/
           https://wedding-hub.iil.pet/livez/
           https://weltenforger.com/livez/
+          https://writing-hub.iil.pet/livez/
+          https://travel-beat.iil.pet/livez/
+          https://research.iil.pet/healthz/
           "
           down=""
           for u in $URLS; do

--- a/scripts/repo-registry.yaml
+++ b/scripts/repo-registry.yaml
@@ -31,9 +31,10 @@ repos:
     pypi: authoringfw
   bfagent:
     type: agent
-    prod_url: bfagent.iil.pet
-    port: 8091
-    health: /livez/
+    archived: true   # 2026-06-17 archiviert, nicht mehr aktiv — kein Live-Prod
+    # prod_url: bfagent.iil.pet   # archiviert (war :8091); aus Monitoring/Prod-Listen raus
+    # port: 8091
+    # health: /livez/
   billing-hub:
     type: django
     prod_url: billing.iil.pet


### PR DESCRIPTION
Reconciliation nach dem Prod-Hub-Triage (2026-06-17).

- **bfagent** (archiviert, nicht mehr aktiv): `archived: true`, `prod_url` entfernt → kein Tooling behandelt es mehr als Live-Prod.
- **3 recovered Hubs in den Canary** (extern verifiziert 200): writing-hub + travel-beat (`/livez/`), research (`/healthz/` — eigene Health-Route). Ihre Prod-Edge-Defekte wurden gefixt: writing/research = nginx-Port-Drift; travel-beat = fehlender DNS-Record (via cloudflared route dns angelegt) + neuer nginx-vhost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)