### PR TITLE
fix(registry): bfagent in canonical archivieren (Drift-Gate rot, blockt alle PRs)

### DIFF
--- a/registry/canonical.yaml
+++ b/registry/canonical.yaml
@@ -144,9 +144,7 @@ repos:
     in_rich: true
     flat:
       type: agent
-      prod_url: bfagent.iil.pet
-      port: 8091
-      health: /livez/
+      archived: true   # 2026-06-17 archiviert (Funktionsspeicher/import-only) — kein Live-Prod/Monitoring
     domain: Content & Publishing
     rich:
       name: bfagent


### PR DESCRIPTION
## Problem
Das Drift-Gate „Views == canonical" (ADR-234 P0) ist auf main **rot** und blockt **alle** offenen Platform-PRs (#590 ADR-251, #588, …):
```
🔴 flat-View weicht ab: bfagent — committed 'archived', generiert 'health/port/prod_url'
```

## Ursache
`scripts/repo-registry.yaml` (flat-View) wurde 2026-06-17 **von Hand** auf `archived: true` gesetzt (bfagent = Funktionsspeicher/import-only, raus aus Prod/Monitoring), aber `canonical.yaml` (SSoT) hatte bfagent noch aktiv → halb-fertige Archivierung.

## Fix
`canonical.flat.bfagent` an die flat-View angeglichen (`archived: true`, prod_url/port/health raus). **`verify` ✅✅ ohne `flip`** → keine ungewollte Kommentar-Strippung der anderen Repos. rich-View unverändert (bfagent bleibt im Katalog; entspricht Memory „bfagent eingefroren trotz Registry-Status production").

## Wirkung
Drift-Gate grün → entsperrt ADR-251 (#590) + die anderen blockierten PRs.