### PR TITLE
chore(registry): bfagent im rich-Katalog als archiviert

### DIFF
--- a/registry/canonical.yaml
+++ b/registry/canonical.yaml
@@ -144,17 +144,18 @@ repos:
     in_rich: true
     flat:
       type: agent
-      archived: true   # 2026-06-17 archiviert (Funktionsspeicher/import-only) — kein Live-Prod/Monitoring
+      archived: true
     domain: Content & Publishing
     rich:
       name: bfagent
       repo: bfagent
       description: Book Factory Agent — AI-assisted book creation
       github: achimdehnert/bfagent
-      deployed: true
+      deployed: false
+      archived: true
       url: https://bfagent.iil.pet
       type: django
-      lifecycle: production
+      lifecycle: archived
       tenancy_mode: none
       dockerfile: Dockerfile
       compose: docker-compose.prod.yml

--- a/registry/repos.yaml
+++ b/registry/repos.yaml
@@ -127,10 +127,11 @@ domains:
     repo: bfagent
     description: Book Factory Agent — AI-assisted book creation
     github: achimdehnert/bfagent
-    deployed: true
+    deployed: false
+    archived: true   # 2026-06-17 archiviert (Funktionsspeicher/import-only) — kein Live-Prod/Monitoring
     url: https://bfagent.iil.pet
     type: django
-    lifecycle: production
+    lifecycle: archived
     tenancy_mode: none
     dockerfile: Dockerfile
     compose: docker-compose.prod.yml


### PR DESCRIPTION
Flat-View hatte bfagent bereits archiviert (raus aus Monitoring); der rich-Katalog (`registry/repos.yaml`) zog noch `deployed:true / lifecycle:production`. Jetzt angeglichen: `deployed:false`, `archived:true`, `lifecycle:archived`. `build`+`verify` grün, `validate_repos` exit 0. Diff nur bfagent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)