### PR TITLE
feat(registry): decks-hub (static Slidev site, deployed:false) — ADR-253 Schiene 1

### DIFF
--- a/registry/canonical.yaml
+++ b/registry/canonical.yaml
@@ -459,6 +459,26 @@ repos:
       lifecycle: production
       tenancy_mode: none
       coverage_threshold: 80
+  decks-hub:
+    in_flat: true
+    in_rich: true
+    flat:
+      type: static
+      prod_url: decks-hub.iil.pet
+      port: 8111
+      health: /healthz/
+    domain: Content & Publishing
+    rich:
+      name: decks-hub
+      repo: decks-hub
+      description: Web-Praesentationen (Vortraege/Lehr-Module/Webinare) mit Slidev - ADR-253 Schiene 1
+      github: achimdehnert/decks-hub
+      deployed: false
+      type: static
+      lifecycle: experimental
+      tenancy_mode: none
+      dockerfile: Dockerfile
+      notes: 'Statische Slidev-Site (kein Django/DB). Theme aus design-hub iil-extern. Deploy/DNS/Edge deferred bis Host (kann auf bestehendem Prod-Host ko-lokalisieren). ADR-253 Schiene 1.'
   pptx-hub:
     in_flat: true
     in_rich: true

--- a/registry/repos.yaml
+++ b/registry/repos.yaml
@@ -52,7 +52,6 @@
 #                       Default (wenn weggelassen): nur `/?demo=` an Root.
 #   Diese PR ergänzt **nur die Schema-Spezifikation** — per-Repo-Werte werden
 #   vom Owner pro Repo separat ratifiziert (kein Vorgriff durch den Agent).
-
 domains:
 - name: Developer Platform
   systems:
@@ -84,7 +83,7 @@ domains:
       django_settings_module: config.settings.production
       migrate_cmd: python manage.py migrate --noinput
       port: 19002
-      ingress: traefik   # ADR-212 Klausel-3 — central Traefik ingress (opt-in; default = nginx host-port)
+      ingress: traefik
       hostnames:
       - staging-devhub.iil.pet
     oidc:
@@ -104,7 +103,7 @@ domains:
   - name: nl2iot-hub
     repo: nl2iot-hub
     description: Natural-language-to-IoT — Developer Cockpit
-    github: iilgmbh/nl2iot-hub   # KONZ-002 S3 Welle 1 transferiert → C9-Lag 2026-06-06
+    github: iilgmbh/nl2iot-hub
     deployed: false
     type: python
     lifecycle: experimental
@@ -128,7 +127,7 @@ domains:
     description: Book Factory Agent — AI-assisted book creation
     github: achimdehnert/bfagent
     deployed: false
-    archived: true   # 2026-06-17 archiviert (Funktionsspeicher/import-only) — kein Live-Prod/Monitoring
+    archived: true
     url: https://bfagent.iil.pet
     type: django
     lifecycle: archived
@@ -144,6 +143,17 @@ domains:
       migrate_cmd: python manage.py migrate --noinput
       multi_tenant: false
       port: 8091
+  - name: decks-hub
+    repo: decks-hub
+    description: Web-Praesentationen (Vortraege/Lehr-Module/Webinare) mit Slidev - ADR-253 Schiene 1
+    github: achimdehnert/decks-hub
+    deployed: false
+    type: static
+    lifecycle: experimental
+    tenancy_mode: none
+    dockerfile: Dockerfile
+    notes: Statische Slidev-Site (kein Django/DB). Theme aus design-hub iil-extern. Deploy/DNS/Edge deferred
+      bis Host (kann auf bestehendem Prod-Host ko-lokalisieren). ADR-253 Schiene 1.
   - name: pptx-hub
     repo: pptx-hub
     description: Presentation Studio — PowerPoint generation (Prezimo)

--- a/scripts/repo-registry.yaml
+++ b/scripts/repo-registry.yaml
@@ -31,10 +31,7 @@ repos:
     pypi: authoringfw
   bfagent:
     type: agent
-    archived: true   # 2026-06-17 archiviert, nicht mehr aktiv — kein Live-Prod
-    # prod_url: bfagent.iil.pet   # archiviert (war :8091); aus Monitoring/Prod-Listen raus
-    # port: 8091
-    # health: /livez/
+    archived: true
   billing-hub:
     type: django
     prod_url: billing.iil.pet
@@ -134,6 +131,11 @@ repos:
   platform:
     type: infra
     note: ADRs, architecture docs, shared workflows, repo-registry
+  decks-hub:
+    type: static
+    prod_url: decks-hub.iil.pet
+    port: 8111
+    health: /healthz/
   pptx-hub:
     type: django
     prod_url: prezimo.com


### PR DESCRIPTION
Registriert **decks-hub** (achimdehnert/decks-hub) in der Plattform-Registry — **#2** des decks-hub-Onboardings (ADR-253 Schiene 1).

## Was
- `registry/canonical.yaml` (SSoT, ADR-234): neuer Eintrag `decks-hub`, `type: static`, `domain: Content & Publishing`, `deployed: false`, `tenancy_mode: none`, Port-Intent **8111**, Health `/healthz/`.
- `flip` → `registry/repos.yaml` + `scripts/repo-registry.yaml` regeneriert (`verify` clean, registry-consistency-Gate grün).

## Bewusst NICHT geändert
- `infra/ports.yaml` — bildet **realen Server-Zustand** ab; decks-hub ist noch nicht deployed.
- `github_repos.yaml` — `django_apps`-spezifisch (runner-health); decks-hub ist static + `deployed:false`.

## Kontext / Abgrenzung
- decks-hub ist eine **statische Slidev-Site** (kein Django/DB) — daher das Django-orientierte onboard-repo-Scaffold N/A.
- **Deploy/DNS/Edge deferred:** noch kein Host. Eine statische Site **braucht keinen eigenen Server** — kann als Container/vhost auf dem bestehenden Prod-Host ko-lokalisieren (Port 8111). Aktivierung später (eigener Go).
- Repo-Artefakte (Dockerfile node→nginx, CI, deploy.yml workflow_dispatch-only) liegen bereits in decks-hub und sind Docker-verifiziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)